### PR TITLE
add a deno benchmark basic schedule

### DIFF
--- a/deno_bench.sh
+++ b/deno_bench.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+deno bench --unstable --allow-read

--- a/deno_bench.ts
+++ b/deno_bench.ts
@@ -1,0 +1,31 @@
+import { schedule } from "./js-api/scheduler.js";
+
+Deno.bench("basic bench for issue #3 (https://github.com/tijlleenders/ZinZen-scheduler/issues/3)", () => {
+    schedule({
+        "startDate": "2022-01-01",
+        "endDate": "2022-01-02",
+        "goals": [
+          {
+            "id": 1,
+            "title": "shopping",
+            "duration": 1,
+            "start": "2022-01-01T10:00:00",
+            "deadline": "2022-01-01T13:00:00",
+          },
+          {
+            "id": 2,
+            "title": "dentist",
+            "duration": 1,
+            "start": "2022-01-01T10:00:00",
+            "deadline": "2022-01-01T11:00:00",
+          },
+          {
+            "id": 3,
+            "title": "exercise",
+            "duration": 1,
+            "start": "2022-01-01T10:00:00",
+            "deadline": "2022-01-01T18:00:00",
+          },
+        ],
+      })
+  });


### PR DESCRIPTION
Deno benchmark test. Run with ```./deno_bench.ts```
Still would like to benchmarkt the wasm code separately - but this tests includes the deserialization of the input so also nice to compare later so we can maybe improve the interface.