### PR TITLE
Refactor scheduler implementation.

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -7,9 +7,9 @@ use crate::goal::Goal;
 /// Just a deserialization target
 pub struct Input {
 	#[serde(rename = "startDate")]
-	pub start: NaiveDate,
+	pub calendar_start: NaiveDateTime,
 	#[serde(rename = "endDate")]
-	pub end: NaiveDate,
+	pub calendar_end: NaiveDateTime,
 	pub goals: Vec<Goal>,
 }
 
@@ -17,7 +17,11 @@ pub struct Input {
 impl Input {
 	/// Create a new Input. Only useful for tests, otherwise input is
 	/// deserialized as the input function.
-	pub fn new(start: NaiveDate, end: NaiveDate, goals: Vec<Goal>) -> Self {
-		Self { start, end, goals }
+	pub fn new(start: NaiveDateTime, end: NaiveDateTime, goals: Vec<Goal>) -> Self {
+		Self {
+			calendar_start: start,
+			calendar_end: end,
+			goals,
+		}
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod input;
 mod task;
 mod task_generator;
 mod task_placer;
+mod output_formatter;
 mod util;
 
 // Tests
@@ -28,10 +29,12 @@ interface Input {
 #[wasm_bindgen]
 pub fn schedule(input: JsValue) -> Result<JsValue, JsError> {
 	use task_generator::task_generator;
-
+    use task_placer::*;
+    use output_formatter::*;
 	// JsError implements From<Error>, so we can just use `?` on any Error
-	let input = input.into_serde()?;
+	let input:Input = input.into_serde()?;
 
+/*
 	// Generates a task and slots list from the provided parameters
 	let placer = task_generator(input);
 	let result = match placer.task_placer() {
@@ -41,4 +44,12 @@ pub fn schedule(input: JsValue) -> Result<JsValue, JsError> {
 	};
 
 	Ok(JsValue::from_serde(&result)?)
+*/
+    let calendar_start = input.calendar_start;
+    let calendar_end = input.calendar_end;
+    let mut tasks = task_generator(input);
+    task_placer(&mut tasks,calendar_start,calendar_end);
+    let output = output_formatter(tasks).unwrap();
+    Ok(JsValue::from_serde(&output)?)
+
 }

--- a/src/output_formatter.rs
+++ b/src/output_formatter.rs
@@ -1,0 +1,33 @@
+//new module for outputting the result of task_placer in
+//whichever format required by front-end
+use chrono::NaiveDateTime;
+use crate::task::Task;
+use serde::{Deserialize, Serialize};
+use serde_json::Result;
+
+#[derive(Serialize, Deserialize)]
+pub struct Output {
+    taskid: usize,
+    goalid: usize,
+    title: String,
+    duration: usize,
+    start: NaiveDateTime,
+    deadline: NaiveDateTime,
+}
+
+pub fn output_formatter(tasks: Vec<Task>) -> Result<Vec<Output>> {
+    let mut outputs = Vec::new();
+    for task in tasks {
+        
+        let output = Output {
+            taskid: task.id,
+            goalid: task.goal_id,
+            title: task.title,
+            duration: task.duration,
+            start: task.slots[0].0,
+            deadline: task.slots[task.slots.len()-1].1,
+        };
+        outputs.push(output);
+    }
+    Ok(outputs)
+}

--- a/src/task_generator.rs
+++ b/src/task_generator.rs
@@ -1,28 +1,30 @@
 use chrono::prelude::*;
 use chrono::Duration;
-
 use crate::input::Input;
-use crate::task::{Slot, Task};
-use crate::task_placer::TaskPlacer;
+use crate::task::Task;
 use crate::util::MyDurationRound;
 
 /// A range of datetimes with an interval.
 pub(crate) struct DateRange {
 	pub(crate) start: NaiveDateTime,
 	pub(crate) end: NaiveDateTime,
-	pub(crate) interval: Duration,
+	pub(crate) interval: Option<Duration>,
 }
 
 impl Iterator for DateRange {
 	type Item = (NaiveDateTime, NaiveDateTime);
 	fn next(&mut self) -> Option<Self::Item> {
+        if self.interval.is_none() {
+            return Some((self.start,self.end));
+        }
 		if self.start < self.end {
 			let start = self.start;
-			let mut end = self.start + self.interval;
+			let mut end = self.start + self.interval.unwrap();//It's okay to unwrap coz we've
+                                                              //handled case where is_none() above
 			if end > self.end {
 				end = self.end;
 			} else {
-				end = end.duration_round(self.interval).ok()?;
+				end = end.duration_round(self.interval.unwrap()).ok()?;
 			}
 			self.start = end;
 			Some((start, end))
@@ -32,46 +34,10 @@ impl Iterator for DateRange {
 	}
 }
 
-pub fn task_generator(Input { start, end, goals }: Input) -> TaskPlacer {
+pub fn task_generator(Input { calendar_start, calendar_end, goals }: Input) -> Vec<Task> {
 	let mut tasks = vec![];
-	let mut slots = vec![];
-
-	let mut id = 0;
-	for goal in goals.into_iter() {
-		// Default dates for goals if start/deadline is not set
-		let start = start.and_time(NaiveTime::from_hms(0, 0, 0));
-		let end = end.and_time(NaiveTime::from_hms(0, 0, 0));
-		let goal_start = goal.start.unwrap_or(start);
-		let goal_end = goal.deadline.unwrap_or(end);
-
-		// If there's repetition, create multiple tasks
-		if let Some(repetition) = goal.repetition {
-			let range = DateRange {
-				start: goal_start,
-				end: goal_end,
-				interval: repetition.into(),
-			};
-
-			for (task_start, task_end) in range {
-				tasks.push(Task::new(id, goal.id, goal.duration));
-				slots.push(Slot::new(
-					id,
-					(task_start - start).num_hours() as usize,
-					(task_end - start).num_hours() as usize,
-				));
-				id += 1;
-			}
-			continue;
-		}
-
-		tasks.push(Task::new(id, goal.id, goal.duration));
-		slots.push(Slot::new(
-			id,
-			(goal_start - start).num_hours() as usize,
-			(goal_end - start).num_hours() as usize,
-		));
-		id += 1;
-	}
-
-	TaskPlacer::new(tasks, slots)
+	for goal in goals {
+        tasks.extend(goal.generate_tasks(calendar_start,calendar_end)); 
+    }
+	tasks
 }

--- a/src/task_placer.rs
+++ b/src/task_placer.rs
@@ -5,184 +5,32 @@
 //! The scheduler optimizes for the minimum amount of IMPOSSIBLE tasks.
 //! https://github.com/tijlleenders/ZinZen-scheduler/wiki/Core
 
-use std::mem::swap;
-
-use serde::Serialize;
-
 use crate::task::TaskStatus::{IMPOSSIBLE, SCHEDULED};
-use crate::task::{Slot, Task, TaskResult};
+use crate::task::Task;
+use crate::task_generator::DateRange;
+use chrono::{Duration, NaiveDateTime};
 
-#[derive(Debug)]
-pub struct TaskPlacer {
-	pub tasks: Vec<Task>,
-	pub slots: Vec<Slot>,
-	/// Tasks that have been processed. Initially empty
-	processed_tasks: Vec<Task>,
-}
+pub fn task_placer<'a>(tasks: &'a mut Vec<Task>, calendar_start: NaiveDateTime, calendar_end: NaiveDateTime) {
+	let date_range = DateRange {
+		start: calendar_start,
+		end: calendar_end,
+		interval: Some(Duration::hours(1)),
+	};
 
-#[derive(Serialize, Debug)]
-pub struct Output {
-	pub tasks: Vec<TaskResult>,
-	pub slots: Vec<Slot>,
-}
+	let mut time_slots: Vec<(NaiveDateTime, NaiveDateTime)> = date_range.collect();
 
-// Internal for collecting
-struct SlotOverlap {
-	overlap: usize,
-	slot: (usize, usize),
-}
+	tasks.sort();
 
-impl TaskPlacer {
-	pub fn new(tasks: Vec<Task>, slots: Vec<Slot>) -> Self {
-		Self {
-			tasks,
-			slots,
-			processed_tasks: vec![],
-		}
-	}
-
-	fn calculate_flexibility(&mut self) {
-		for task in &mut self.tasks {
-			let id = task.id();
-			for slot in self.slots.iter_mut().filter(|slot| slot.task_id == id) {
-				task.flexibility += slot.end - slot.start;
+	for task in tasks {
+		'inner: for i in 0..time_slots.len() {
+			if time_slots[i].0 >= task.start {
+				for _ in 0..task.duration {
+					println!("Pushing slot in Task {:?}: {:?}", task.id, time_slots[i]);
+					task.slots.push(time_slots.remove(i));
+				}
+                task.status = SCHEDULED;
+				break 'inner;
 			}
 		}
-	}
-
-	fn find_overlap_number_for(&self, begin: usize, end: usize) -> usize {
-		let mut result: usize = 0;
-		for slot in &self.slots {
-			if slot.start < end && slot.end > begin {
-				result += 1;
-			}
-		}
-		result
-	}
-
-	fn find_least_requested_slot_for_task(&self, task: &Task) -> Result<(usize, usize), anyhow::Error> {
-		let res = self
-			.slots
-			.iter()
-			.filter(|slot| slot.task_id == task.id())
-			.map(|slot| {
-				// No need for checked sub, if it fails. The program will panic, and cause an exception.
-				// https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Control_flow/unreachable
-				let num_windows_in_slot = (slot.end - slot.start + 1) - task.duration_to_schedule;
-
-				(0..num_windows_in_slot)
-					.map(|slot_offset| {
-						let overlap = self.find_overlap_number_for(
-							slot.start + slot_offset,
-							slot.start + slot_offset + task.duration_to_schedule,
-						);
-
-						SlotOverlap {
-							overlap,
-							slot: (
-								slot.start + slot_offset,
-								slot.start + slot_offset + task.duration_to_schedule,
-							),
-						}
-					})
-					.min_by_key(|x| x.overlap)
-					.ok_or(anyhow::anyhow!("No slot found for task {}", task.id()))
-			})
-			// You can turn a Iter<Result<T, E>> into Result<Vec<T>, E>
-			// If any Err(---) is encountered, the collection is disposed and the error is yielded
-			// https://doc.rust-lang.org/rust-by-example/error/iter_result.html#fail-the-entire-operation-with-collect
-			.collect::<Result<Vec<SlotOverlap>, anyhow::Error>>()?;
-
-		// Destructure
-		let SlotOverlap { slot, .. } = res
-			.into_iter()
-			.min_by_key(|x| x.overlap)
-			.ok_or(anyhow::anyhow!("No slot found for task {}", task.id()))?;
-
-		Ok(slot)
-	}
-
-	/// Schedule the given task to this slot,
-	/// updating the other tasks and their slots as needed.
-	fn do_schedule(&mut self, mut task: Task, scheduled_slot: Slot) {
-		task.status = SCHEDULED;
-		swap(&mut task.duration_scheduled, &mut task.duration_to_schedule);
-		let task_id = task.id();
-
-		self.processed_tasks.push(task);
-		self.slots.retain(|slot| slot.task_id != task_id);
-
-		// Remove the parts of slots from other tasks that overlap with scheduled slot
-		let (cut_start, cut_end) = (scheduled_slot.start, scheduled_slot.end);
-
-		self.slots = self.slots.iter().fold(vec![], |mut acc, slot| {
-			if slot.start >= cut_start && slot.start < cut_end {
-				// start
-				acc.push(Slot::new(slot.task_id, cut_end, slot.end));
-			} else if scheduled_slot.start < cut_start && scheduled_slot.end > cut_end {
-				// middle
-				acc.push(Slot::new(slot.task_id, slot.start, cut_start));
-				acc.push(Slot::new(slot.task_id, cut_end, slot.end));
-			} else if scheduled_slot.start < cut_start && scheduled_slot.end > cut_start {
-				// end
-				acc.push(Slot::new(slot.task_id, slot.start, cut_end));
-			} else {
-				// no cutoff, keep same slot
-				// XXX cannot move so cloning
-				acc.push(slot.clone());
-			}
-			acc
-		});
-
-		// Add the newly scheduled slot
-		self.slots.push(scheduled_slot);
-	}
-
-	/// Place all the tasks.
-	pub fn task_placer(mut self) -> Result<Output, anyhow::Error> {
-		while !self.tasks.is_empty() {
-			self.calculate_flexibility();
-			// Tasks with flex 0 are unscheduled
-			if let Some(i) = self.tasks.iter().position(|task| task.flexibility == 0) {
-				let mut task = self.tasks.remove(i);
-				task.status = IMPOSSIBLE;
-				self.processed_tasks.push(task);
-				continue;
-			}
-
-			// Tasks with min flex should be scheduled now
-			if let Some(i) = self.tasks.iter().position(|task| task.flexibility == 1) {
-				let task = self.tasks.remove(i);
-				let slot_index = self
-					.slots
-					.iter_mut()
-					.position(|slot| slot.task_id == task.id())
-					.expect(&*format!(
-						"Expected 1 slot available for flex 1 task {:?}, none found, scheduler={:?}",
-						task, self
-					));
-				let slot = self.slots.remove(slot_index);
-
-				self.do_schedule(task, slot);
-				continue;
-			}
-
-			// Get the max flex task
-			self.tasks.sort_by_key(|x| x.flexibility);
-			let task = self.tasks.pop().ok_or(anyhow::anyhow!("No tasks found"))?;
-
-			// Find slot with least overlap
-			let (start, end) = self.find_least_requested_slot_for_task(&task)?;
-			let task_id = task.id();
-			self.do_schedule(task, Slot::new(task_id, start, end));
-		}
-
-		self.processed_tasks.sort_by_key(|x| x.id());
-		self.slots.sort_by_key(|x| x.task_id);
-
-		Ok(Output {
-			tasks: self.processed_tasks.into_iter().map(|t| t.into_task_result()).collect(),
-			slots: self.slots,
-		})
 	}
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,13 +1,386 @@
-use crate::{goal::*, input::*, task::*, task_generator::*};
+use crate::{goal::*, input::*, output_formatter::*, task::*, task_generator::*, task_placer::*};
 use chrono::*;
 
 #[test]
-fn basic_test() {
+fn date_range_iter_simple() {
+	let r = DateRange {
+		start: NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0),
+		end: NaiveDate::from_ymd(2022, 1, 2).and_hms(0, 0, 0),
+		interval: Some(Duration::hours(8)),
+	};
+
+	assert_eq!(
+		r.into_iter().collect::<Vec<_>>(),
+		vec![
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(8, 0, 0)
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(8, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(16, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(16, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 2).and_hms(0, 0, 0),
+			),
+		]
+	)
+}
+
+#[test]
+fn date_range_single() {
+	let r = DateRange {
+		start: NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0),
+		end: NaiveDate::from_ymd(2022, 1, 1).and_hms(8, 0, 0),
+		interval: Some(Duration::hours(8)),
+	};
+
+	assert_eq!(
+		r.into_iter().collect::<Vec<_>>(),
+		vec![(
+			NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0),
+			NaiveDate::from_ymd(2022, 1, 1).and_hms(8, 0, 0)
+		),]
+	)
+}
+
+#[test]
+fn date_range_single_not_round() {
+	let r = DateRange {
+		start: NaiveDate::from_ymd(2022, 1, 1).and_hms(1, 0, 0),
+		end: NaiveDate::from_ymd(2022, 1, 1).and_hms(7, 0, 0),
+		interval: Some(Duration::hours(8)),
+	};
+
+	assert_eq!(
+		r.into_iter().collect::<Vec<_>>(),
+		vec![(
+			NaiveDate::from_ymd(2022, 1, 1).and_hms(1, 0, 0),
+			NaiveDate::from_ymd(2022, 1, 1).and_hms(7, 0, 0)
+		),]
+	)
+}
+
+#[test]
+fn date_range_iter_not_round_end() {
+	let r = DateRange {
+		start: NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0),
+		end: NaiveDate::from_ymd(2022, 1, 1).and_hms(23, 0, 1),
+		interval: Some(Duration::hours(8)),
+	};
+
+	assert_eq!(
+		r.into_iter().collect::<Vec<_>>(),
+		vec![
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(8, 0, 0)
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(8, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(16, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(16, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(23, 0, 1),
+			),
+		]
+	)
+}
+
+#[test]
+fn date_range_iter_not_round_start() {
+	let r = DateRange {
+		start: NaiveDate::from_ymd(2022, 1, 1).and_hms(1, 0, 1),
+		end: NaiveDate::from_ymd(2022, 1, 2).and_hms(0, 0, 0),
+		interval: Some(Duration::hours(8)),
+	};
+
+	assert_eq!(
+		r.into_iter().collect::<Vec<_>>(),
+		vec![
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(1, 0, 1),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(8, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(8, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(16, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(16, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 2).and_hms(0, 0, 0),
+			),
+		]
+	)
+}
+
+#[test]
+fn date_range_iter_not_round_start_end() {
+	let r = DateRange {
+		start: NaiveDate::from_ymd(2022, 1, 1).and_hms(1, 0, 1),
+		end: NaiveDate::from_ymd(2022, 1, 1).and_hms(23, 0, 1),
+		interval: Some(Duration::hours(8)),
+	};
+
+	assert_eq!(
+		r.into_iter().collect::<Vec<_>>(),
+		vec![
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(1, 0, 1),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(8, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(8, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(16, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(16, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(23, 0, 1),
+			),
+		]
+	)
+}
+
+#[test]
+fn date_range_splits_into_single_days() {
+	let r = DateRange {
+		start: NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0),
+		end: NaiveDate::from_ymd(2022, 1, 7).and_hms(23, 59, 59),
+		interval: Some(Duration::days(1)),
+	};
+
+	assert_eq!(
+		r.into_iter().collect::<Vec<_>>(),
+		vec![
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 2).and_hms(0, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 2).and_hms(0, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 3).and_hms(0, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 3).and_hms(0, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 4).and_hms(0, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 4).and_hms(0, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 5).and_hms(0, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 5).and_hms(0, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 6).and_hms(0, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 6).and_hms(0, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 7).and_hms(0, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 7).and_hms(0, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 7).and_hms(23, 59, 59),
+			),
+		]
+	)
+}
+
+#[test]
+fn date_range_splits_day_into_24_hrs() {
+	let r = DateRange {
+		start: NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0),
+		end: NaiveDate::from_ymd(2022, 1, 2).and_hms(0, 0, 0),
+		interval: Some(Duration::hours(1)),
+	};
+
+	assert_eq!(
+		r.into_iter().collect::<Vec<_>>(),
+		vec![
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(1, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(1, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(2, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(2, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(3, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(3, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(4, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(4, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(5, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(5, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(6, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(6, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(7, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(7, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(8, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(8, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(9, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(9, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(10, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(10, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(11, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(11, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(12, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(12, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(13, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(13, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(14, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(14, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(15, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(15, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(16, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(16, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(17, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(17, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(18, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(18, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(19, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(19, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(20, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(20, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(21, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(21, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(22, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(22, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(23, 0, 0),
+			),
+			(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(23, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 2).and_hms(0, 0, 0),
+			),
+		]
+	)
+}
+
+#[test]
+fn goal_generates_daily_tasks() {
+	let goal = Goal::new(1)
+		.duration(1)
+		.repetition(Repetition::DAILY)
+		.start(NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0))
+		.deadline(NaiveDate::from_ymd(2022, 1, 4).and_hms(0, 0, 0));
+
+	assert_eq!(
+		goal.generate_tasks(
+			NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0),
+			NaiveDate::from_ymd(2022, 1, 4).and_hms(0, 0, 0)
+		),
+		vec![
+			Task {
+				id: 10,
+				goal_id: 1,
+				title: "Test".to_string(),
+				duration: 1,
+				status: TaskStatus::UNSCHEDULED,
+				flexibility: 24,
+				start: NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0),
+				end: NaiveDate::from_ymd(2022, 1, 2).and_hms(0, 0, 0),
+				slots: Vec::new(),
+			},
+			Task {
+				id: 11,
+				goal_id: 1,
+				title: "Test".to_string(),
+				duration: 1,
+				status: TaskStatus::UNSCHEDULED,
+				flexibility: 24,
+				start: NaiveDate::from_ymd(2022, 1, 2).and_hms(0, 0, 0),
+				end: NaiveDate::from_ymd(2022, 1, 3).and_hms(0, 0, 0),
+				slots: Vec::new(),
+			},
+			Task {
+				id: 12,
+				goal_id: 1,
+				title: "Test".to_string(),
+				duration: 1,
+				status: TaskStatus::UNSCHEDULED,
+				flexibility: 24,
+				start: NaiveDate::from_ymd(2022, 1, 3).and_hms(0, 0, 0),
+				end: NaiveDate::from_ymd(2022, 1, 4).and_hms(0, 0, 0),
+				slots: Vec::new(),
+			},
+		]
+	)
+}
+
+#[test]
+fn goal_generates_single_nonrepetitive_task() {
+	let goal = Goal::new(1)
+		.duration(1)
+		.start(NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0))
+		.deadline(NaiveDate::from_ymd(2022, 1, 4).and_hms(0, 0, 0));
+
+	assert_eq!(
+		goal.generate_tasks(
+			NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0),
+			NaiveDate::from_ymd(2022, 1, 4).and_hms(0, 0, 0)
+		),
+		vec![Task {
+			id: 10,
+			goal_id: 1,
+			title: "Test".to_string(),
+			duration: 1,
+			status: TaskStatus::UNSCHEDULED,
+			flexibility: 72,
+			start: NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0),
+			end: NaiveDate::from_ymd(2022, 1, 4).and_hms(0, 0, 0),
+			slots: Vec::new(),
+		},]
+	)
+}
+
+#[test]
+fn task_placer_works_simple() {
 	let input: Input = serde_json::from_str(
 		r#"
 {
-    "startDate": "2022-01-01",
-    "endDate": "2022-01-02",
+    "startDate": "2022-01-01T00:00:00",
+    "endDate": "2022-01-02T00:00:00",
     "goals": [
         {
           "id": 1,
@@ -35,283 +408,339 @@ fn basic_test() {
         "#,
 	)
 	.unwrap();
-
-	let scheduler = task_generator(input);
-	let result = scheduler.task_placer().unwrap();
-	let result_json = serde_json::to_string_pretty(&result).unwrap();
-
-	//println!("{}", result_json);
-	assert_eq!(
-		result_json,
-		r#"{
-  "tasks": [
-    {
-      "id": 0,
-      "goal_id": 1,
-      "duration_to_schedule": 0,
-      "duration_scheduled": 1,
-      "status": "SCHEDULED"
-    },
-    {
-      "id": 1,
-      "goal_id": 2,
-      "duration_to_schedule": 0,
-      "duration_scheduled": 1,
-      "status": "SCHEDULED"
-    },
-    {
-      "id": 2,
-      "goal_id": 3,
-      "duration_to_schedule": 0,
-      "duration_scheduled": 1,
-      "status": "SCHEDULED"
-    }
-  ],
-  "slots": [
-    {
-      "task_id": 0,
-      "start": 11,
-      "end": 12
-    },
-    {
-      "task_id": 1,
-      "start": 10,
-      "end": 11
-    },
-    {
-      "task_id": 2,
-      "start": 13,
-      "end": 14
-    }
-  ]
-}"#
-	);
-}
-
-#[test]
-fn date_range_iter_simple() {
-	let r = DateRange {
-		start: NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0),
-		end: NaiveDate::from_ymd(2022, 1, 2).and_hms(0, 0, 0),
-		interval: Duration::hours(8),
-	};
+	let calendar_start = input.calendar_start;
+	let calendar_end = input.calendar_end;
+	let mut tasks = task_generator(input);
+	task_placer(&mut tasks, calendar_start, calendar_end);
 
 	assert_eq!(
-		r.into_iter().collect::<Vec<_>>(),
+		tasks,
 		vec![
-			(
-				NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0),
-				NaiveDate::from_ymd(2022, 1, 1).and_hms(8, 0, 0)
-			),
-			(
-				NaiveDate::from_ymd(2022, 1, 1).and_hms(8, 0, 0),
-				NaiveDate::from_ymd(2022, 1, 1).and_hms(16, 0, 0),
-			),
-			(
-				NaiveDate::from_ymd(2022, 1, 1).and_hms(16, 0, 0),
-				NaiveDate::from_ymd(2022, 1, 2).and_hms(0, 0, 0),
-			),
+			Task {
+				id: 20,
+				goal_id: 2,
+				title: "dentist".to_string(),
+				duration: 1,
+				status: TaskStatus::SCHEDULED,
+				flexibility: 1,
+				start: NaiveDate::from_ymd(2022, 1, 1).and_hms(10, 0, 0),
+				end: NaiveDate::from_ymd(2022, 1, 1).and_hms(11, 0, 0),
+				slots: vec![(
+					NaiveDate::from_ymd(2022, 1, 1).and_hms(10, 0, 0),
+					NaiveDate::from_ymd(2022, 1, 1).and_hms(11, 0, 0)
+				)],
+			},
+			Task {
+				id: 10,
+				goal_id: 1,
+				title: "shopping".to_string(),
+				duration: 1,
+				status: TaskStatus::SCHEDULED,
+				flexibility: 3,
+				start: NaiveDate::from_ymd(2022, 1, 1).and_hms(10, 0, 0),
+				end: NaiveDate::from_ymd(2022, 1, 1).and_hms(13, 0, 0),
+				slots: vec![(
+					NaiveDate::from_ymd(2022, 1, 1).and_hms(11, 0, 0),
+					NaiveDate::from_ymd(2022, 1, 1).and_hms(12, 0, 0)
+				)],
+			},
+			Task {
+				id: 30,
+				goal_id: 3,
+				title: "exercise".to_string(),
+				duration: 1,
+				status: TaskStatus::SCHEDULED,
+				flexibility: 8,
+				start: NaiveDate::from_ymd(2022, 1, 1).and_hms(10, 0, 0),
+				end: NaiveDate::from_ymd(2022, 1, 1).and_hms(18, 0, 0),
+				slots: vec![(
+					NaiveDate::from_ymd(2022, 1, 1).and_hms(12, 0, 0),
+					NaiveDate::from_ymd(2022, 1, 1).and_hms(13, 0, 0)
+				)],
+			}
 		]
 	)
 }
 
 #[test]
-fn date_range_single() {
-	let r = DateRange {
-		start: NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0),
-		end: NaiveDate::from_ymd(2022, 1, 1).and_hms(8, 0, 0),
-		interval: Duration::hours(8),
-	};
-
-	assert_eq!(
-		r.into_iter().collect::<Vec<_>>(),
-		vec![(
-			NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0),
-			NaiveDate::from_ymd(2022, 1, 1).and_hms(8, 0, 0)
-		),]
-	)
+fn task_placer_works_multiple_days() {
+	let input: Input = serde_json::from_str(
+		r#"
+{
+    "startDate": "2022-01-01T00:00:00",
+    "endDate": "2022-01-04T00:00:00",
+    "goals": [
+        {
+          "id": 1,
+          "title" : "shopping",
+          "duration": 1,
+          "start": "2022-01-01T10:00:00",
+          "deadline": "2022-01-01T13:00:00"
+        },
+        {
+          "id": 2,
+          "title": "dentist",
+          "duration": 1,
+          "start": "2022-01-02T10:00:00",
+          "deadline": "2022-01-02T11:00:00"
+        },
+        {
+          "id": 3,
+          "title" : "exercise",
+          "duration": 1,
+          "start": "2022-01-03T10:00:00",
+          "deadline": "2022-01-03T18:00:00"
+        }
+    ]
 }
-
-#[test]
-fn date_range_single_not_round() {
-	let r = DateRange {
-		start: NaiveDate::from_ymd(2022, 1, 1).and_hms(1, 0, 0),
-		end: NaiveDate::from_ymd(2022, 1, 1).and_hms(7, 0, 0),
-		interval: Duration::hours(8),
-	};
-
-	assert_eq!(
-		r.into_iter().collect::<Vec<_>>(),
-		vec![(
-			NaiveDate::from_ymd(2022, 1, 1).and_hms(1, 0, 0),
-			NaiveDate::from_ymd(2022, 1, 1).and_hms(7, 0, 0)
-		),]
+        "#,
 	)
-}
-
-#[test]
-fn date_range_iter_not_round_end() {
-	let r = DateRange {
-		start: NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0),
-		end: NaiveDate::from_ymd(2022, 1, 1).and_hms(23, 0, 1),
-		interval: Duration::hours(8),
-	};
+	.unwrap();
+	let calendar_start = input.calendar_start;
+	let calendar_end = input.calendar_end;
+	let mut tasks = task_generator(input);
+	task_placer(&mut tasks, calendar_start, calendar_end);
 
 	assert_eq!(
-		r.into_iter().collect::<Vec<_>>(),
+		tasks,
 		vec![
-			(
-				NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0),
-				NaiveDate::from_ymd(2022, 1, 1).and_hms(8, 0, 0)
-			),
-			(
-				NaiveDate::from_ymd(2022, 1, 1).and_hms(8, 0, 0),
-				NaiveDate::from_ymd(2022, 1, 1).and_hms(16, 0, 0),
-			),
-			(
-				NaiveDate::from_ymd(2022, 1, 1).and_hms(16, 0, 0),
-				NaiveDate::from_ymd(2022, 1, 1).and_hms(23, 0, 1),
-			),
+			Task {
+				id: 20,
+				goal_id: 2,
+				title: "dentist".to_string(),
+				duration: 1,
+				status: TaskStatus::SCHEDULED,
+				flexibility: 1,
+				start: NaiveDate::from_ymd(2022, 1, 2).and_hms(10, 0, 0),
+				end: NaiveDate::from_ymd(2022, 1, 2).and_hms(11, 0, 0),
+				slots: vec![(
+					NaiveDate::from_ymd(2022, 1, 2).and_hms(10, 0, 0),
+					NaiveDate::from_ymd(2022, 1, 2).and_hms(11, 0, 0)
+				)],
+			},
+			Task {
+				id: 10,
+				goal_id: 1,
+				title: "shopping".to_string(),
+				duration: 1,
+				status: TaskStatus::SCHEDULED,
+				flexibility: 3,
+				start: NaiveDate::from_ymd(2022, 1, 1).and_hms(10, 0, 0),
+				end: NaiveDate::from_ymd(2022, 1, 1).and_hms(13, 0, 0),
+				slots: vec![(
+					NaiveDate::from_ymd(2022, 1, 1).and_hms(10, 0, 0),
+					NaiveDate::from_ymd(2022, 1, 1).and_hms(11, 0, 0)
+				)],
+			},
+			Task {
+				id: 30,
+				goal_id: 3,
+				title: "exercise".to_string(),
+				duration: 1,
+				status: TaskStatus::SCHEDULED,
+				flexibility: 8,
+				start: NaiveDate::from_ymd(2022, 1, 3).and_hms(10, 0, 0),
+				end: NaiveDate::from_ymd(2022, 1, 3).and_hms(18, 0, 0),
+				slots: vec![(
+					NaiveDate::from_ymd(2022, 1, 3).and_hms(10, 0, 0),
+					NaiveDate::from_ymd(2022, 1, 3).and_hms(11, 0, 0)
+				)],
+			}
 		]
 	)
 }
 
 #[test]
-fn date_range_iter_not_round_start() {
-	let r = DateRange {
-		start: NaiveDate::from_ymd(2022, 1, 1).and_hms(1, 0, 1),
-		end: NaiveDate::from_ymd(2022, 1, 2).and_hms(0, 0, 0),
-		interval: Duration::hours(8),
-	};
+fn task_placer_works_long_duration_multiple_days() {
+	let input: Input = serde_json::from_str(
+		r#"
+{
+    "startDate": "2022-01-01T00:00:00",
+    "endDate": "2022-01-04T00:00:00",
+    "goals": [
+        {
+          "id": 1,
+          "title" : "shopping",
+          "duration": 2,
+          "start": "2022-01-01T10:00:00",
+          "deadline": "2022-01-01T13:00:00"
+        },
+        {
+          "id": 2,
+          "title": "dentist",
+          "duration": 1,
+          "start": "2022-01-01T10:00:00",
+          "deadline": "2022-01-01T11:00:00"
+        },
+        {
+          "id": 3,
+          "title" : "exercise",
+          "duration": 4,
+          "start": "2022-01-03T10:00:00",
+          "deadline": "2022-01-03T18:00:00"
+        }
+    ]
+}
+        "#,
+	)
+	.unwrap();
+	let calendar_start = input.calendar_start;
+	let calendar_end = input.calendar_end;
+	let mut tasks = task_generator(input);
+	task_placer(&mut tasks, calendar_start, calendar_end);
 
 	assert_eq!(
-		r.into_iter().collect::<Vec<_>>(),
+		tasks,
 		vec![
-			(
-				NaiveDate::from_ymd(2022, 1, 1).and_hms(1, 0, 1),
-				NaiveDate::from_ymd(2022, 1, 1).and_hms(8, 0, 0),
-			),
-			(
-				NaiveDate::from_ymd(2022, 1, 1).and_hms(8, 0, 0),
-				NaiveDate::from_ymd(2022, 1, 1).and_hms(16, 0, 0),
-			),
-			(
-				NaiveDate::from_ymd(2022, 1, 1).and_hms(16, 0, 0),
-				NaiveDate::from_ymd(2022, 1, 2).and_hms(0, 0, 0),
-			),
+			Task {
+				id: 20,
+				goal_id: 2,
+				title: "dentist".to_string(),
+				duration: 1,
+				status: TaskStatus::SCHEDULED,
+				flexibility: 1,
+				start: NaiveDate::from_ymd(2022, 1, 1).and_hms(10, 0, 0),
+				end: NaiveDate::from_ymd(2022, 1, 1).and_hms(11, 0, 0),
+				slots: vec![(
+					NaiveDate::from_ymd(2022, 1, 1).and_hms(10, 0, 0),
+					NaiveDate::from_ymd(2022, 1, 1).and_hms(11, 0, 0)
+				)],
+			},
+			Task {
+				id: 10,
+				goal_id: 1,
+				title: "shopping".to_string(),
+				duration: 2,
+				status: TaskStatus::SCHEDULED,
+				flexibility: 3,
+				start: NaiveDate::from_ymd(2022, 1, 1).and_hms(10, 0, 0),
+				end: NaiveDate::from_ymd(2022, 1, 1).and_hms(13, 0, 0),
+				slots: vec![
+					(
+						NaiveDate::from_ymd(2022, 1, 1).and_hms(11, 0, 0),
+						NaiveDate::from_ymd(2022, 1, 1).and_hms(12, 0, 0)
+					),
+					(
+						NaiveDate::from_ymd(2022, 1, 1).and_hms(12, 0, 0),
+						NaiveDate::from_ymd(2022, 1, 1).and_hms(13, 0, 0)
+					)
+				],
+			},
+			Task {
+				id: 30,
+				goal_id: 3,
+				title: "exercise".to_string(),
+				duration: 4,
+				status: TaskStatus::SCHEDULED,
+				flexibility: 8,
+				start: NaiveDate::from_ymd(2022, 1, 3).and_hms(10, 0, 0),
+				end: NaiveDate::from_ymd(2022, 1, 3).and_hms(18, 0, 0),
+				slots: vec![
+					(
+						NaiveDate::from_ymd(2022, 1, 3).and_hms(10, 0, 0),
+						NaiveDate::from_ymd(2022, 1, 3).and_hms(11, 0, 0)
+					),
+					(
+						NaiveDate::from_ymd(2022, 1, 3).and_hms(11, 0, 0),
+						NaiveDate::from_ymd(2022, 1, 3).and_hms(12, 0, 0)
+					),
+					(
+						NaiveDate::from_ymd(2022, 1, 3).and_hms(12, 0, 0),
+						NaiveDate::from_ymd(2022, 1, 3).and_hms(13, 0, 0)
+					),
+					(
+						NaiveDate::from_ymd(2022, 1, 3).and_hms(13, 0, 0),
+						NaiveDate::from_ymd(2022, 1, 3).and_hms(14, 0, 0)
+					)
+				],
+			}
 		]
 	)
 }
 
 #[test]
-fn date_range_iter_not_round_start_end() {
-	let r = DateRange {
-		start: NaiveDate::from_ymd(2022, 1, 1).and_hms(1, 0, 1),
-		end: NaiveDate::from_ymd(2022, 1, 1).and_hms(23, 0, 1),
-		interval: Duration::hours(8),
-	};
+fn output_formatter_works() {
+	/*
+	Below is a pretty-printed version of the test output for easier reference.
+	The one used in the actual test doesn't have line breaks and spaces and
+	is therefore hard to read.
 
-	assert_eq!(
-		r.into_iter().collect::<Vec<_>>(),
-		vec![
-			(
-				NaiveDate::from_ymd(2022, 1, 1).and_hms(1, 0, 1),
-				NaiveDate::from_ymd(2022, 1, 1).and_hms(8, 0, 0),
-			),
-			(
-				NaiveDate::from_ymd(2022, 1, 1).and_hms(8, 0, 0),
-				NaiveDate::from_ymd(2022, 1, 1).and_hms(16, 0, 0),
-			),
-			(
-				NaiveDate::from_ymd(2022, 1, 1).and_hms(16, 0, 0),
-				NaiveDate::from_ymd(2022, 1, 1).and_hms(23, 0, 1),
-			),
-		]
-	)
-}
+	let desired_output = r#"
+	[
+	  {
+		"taskid": 20,
+		"goalid": 2,
+		"title": "dentist",
+		"duration": 1,
+		"start": "2022-01-01T10:00:00"
+		"deadline": "2022-01-01T11:00:00"
+	  },
+	  {
+		"taskid": 10,
+		"goalid": 1,
+		"title": "shopping",
+		"duration": 1,
+		"start": "2022-01-01T11:00:00"
+		"deadline": "2022-01-01T12:00:00"
+	  },
+	  {
+		"taskid": 30,
+		"goalid": 3,
+		"title": "exercise",
+		"duration": 1,
+		"start": "2022-01-01T12:00:00"
+		"deadline": "2022-01-01T13:00:00"
+	  }
+	]
+			"#;*/
 
-#[test]
-fn repeat() {
-	let input = Input::new(
-		NaiveDate::from_ymd(2022, 1, 1),
-		NaiveDate::from_ymd(2022, 1, 4),
-		vec![Goal::new(1).duration(1).repetition(Repetition::DAILY)],
-	);
+	let desired_output = r#"[{"taskid":20,"goalid":2,"title":"dentist","duration":1,"start":"2022-01-01T10:00:00","deadline":"2022-01-01T11:00:00"},{"taskid":10,"goalid":1,"title":"shopping","duration":1,"start":"2022-01-01T11:00:00","deadline":"2022-01-01T12:00:00"},{"taskid":30,"goalid":3,"title":"exercise","duration":1,"start":"2022-01-01T12:00:00","deadline":"2022-01-01T13:00:00"}]"#;
 
-	let scheduler = task_generator(input);
-	assert_eq!(
-		scheduler.tasks,
-		vec![Task::new(0, 1, 1), Task::new(1, 1, 1), Task::new(2, 1, 1)]
-	);
-	assert_eq!(
-		scheduler.slots,
-		vec![Slot::new(0, 0, 24), Slot::new(1, 24, 48), Slot::new(2, 48, 72)]
-	)
-}
+	let tasks = vec![
+		Task {
+			id: 20,
+			goal_id: 2,
+			title: "dentist".to_string(),
+			duration: 1,
+			status: TaskStatus::SCHEDULED,
+			flexibility: 1,
+			start: NaiveDate::from_ymd(2022, 1, 1).and_hms(10, 0, 0),
+			end: NaiveDate::from_ymd(2022, 1, 1).and_hms(11, 0, 0),
+			slots: vec![(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(10, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(11, 0, 0),
+			)],
+		},
+		Task {
+			id: 10,
+			goal_id: 1,
+			title: "shopping".to_string(),
+			duration: 1,
+			status: TaskStatus::SCHEDULED,
+			flexibility: 3,
+			start: NaiveDate::from_ymd(2022, 1, 1).and_hms(10, 0, 0),
+			end: NaiveDate::from_ymd(2022, 1, 1).and_hms(13, 0, 0),
+			slots: vec![(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(11, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(12, 0, 0),
+			)],
+		},
+		Task {
+			id: 30,
+			goal_id: 3,
+			title: "exercise".to_string(),
+			duration: 1,
+			status: TaskStatus::SCHEDULED,
+			flexibility: 8,
+			start: NaiveDate::from_ymd(2022, 1, 1).and_hms(10, 0, 0),
+			end: NaiveDate::from_ymd(2022, 1, 1).and_hms(18, 0, 0),
+			slots: vec![(
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(12, 0, 0),
+				NaiveDate::from_ymd(2022, 1, 1).and_hms(13, 0, 0),
+			)],
+		},
+	];
 
-#[test]
-fn repeat_with_goal_start_not_midnight() {
-	let input = Input::new(
-		NaiveDate::from_ymd(2022, 1, 1),
-		NaiveDate::from_ymd(2022, 1, 4),
-		vec![Goal::new(1)
-			.duration(1)
-			.repetition(Repetition::DAILY)
-			.start(NaiveDate::from_ymd(2022, 1, 1).and_hms(10, 0, 0))],
-	);
-
-	let scheduler = task_generator(input);
-	assert_eq!(
-		scheduler.tasks,
-		vec![Task::new(0, 1, 1), Task::new(1, 1, 1), Task::new(2, 1, 1)]
-	);
-	assert_eq!(
-		scheduler.slots,
-		vec![Slot::new(0, 10, 24), Slot::new(1, 24, 48), Slot::new(2, 48, 72)]
-	)
-}
-
-#[test]
-fn repeat_with_goal_end_not_midnight() {
-	let input = Input::new(
-		NaiveDate::from_ymd(2022, 1, 1),
-		NaiveDate::from_ymd(2022, 1, 4),
-		vec![Goal::new(1)
-			.duration(1)
-			.repetition(Repetition::DAILY)
-			.deadline(NaiveDate::from_ymd(2022, 1, 3).and_hms(14, 0, 0))],
-	);
-
-	let scheduler = task_generator(input);
-	assert_eq!(
-		scheduler.tasks,
-		vec![Task::new(0, 1, 1), Task::new(1, 1, 1), Task::new(2, 1, 1)]
-	);
-	assert_eq!(
-		scheduler.slots,
-		vec![Slot::new(0, 0, 24), Slot::new(1, 24, 48), Slot::new(2, 48, 62)]
-	)
-}
-
-#[test]
-fn repeat_with_goal_start_and_end_not_midnight() {
-	let input = Input::new(
-		NaiveDate::from_ymd(2022, 1, 1),
-		NaiveDate::from_ymd(2022, 1, 4),
-		vec![Goal::new(1)
-			.duration(1)
-			.repetition(Repetition::DAILY)
-			.start(NaiveDate::from_ymd(2022, 1, 1).and_hms(10, 0, 0))
-			.deadline(NaiveDate::from_ymd(2022, 1, 3).and_hms(14, 0, 0))],
-	);
-
-	let scheduler = task_generator(input);
-	assert_eq!(
-		scheduler.tasks,
-		vec![Task::new(0, 1, 1), Task::new(1, 1, 1), Task::new(2, 1, 1)]
-	);
-	assert_eq!(
-		scheduler.slots,
-		vec![Slot::new(0, 10, 24), Slot::new(1, 24, 48), Slot::new(2, 48, 62)]
-	)
+	let output = output_formatter(tasks).unwrap();
+	assert_eq!(desired_output, serde_json::to_string(&output).unwrap());
 }


### PR DESCRIPTION
### Overview
In this commit I'm suggesting a few adjustments to the scheduler code that I
think will make it more readable, easier to maintain and easier to add new
features. I've tried as much as possible to stick to the original scheduler algorithm and the provided input/output schemas.

### Abstract formatting of ouput
I've created a sepearate `output_formatter` module that handles the
formatting of the output from the `task_placer` for presentation to the
front-end. I think this will allow for more flexibility as we won't need to touch the core
logic of the scheduler when the requirements from the front-end change
(unless it's a major change). This is in keeping with
[Model-View-Controller architecture](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller).

### Goal struct
I've moved the logic of converting a goal into tasks to the goal struct itself.
Now the `task_generator`'s job has been greatly simplified; it's responsible for getting all the tasks
when given a number of goals. We still end up with a flat list of
tasks, not a hierarchy.

### Algorithm
The algorithm is the same at it's core i.e. the concept of splitting the
available time into "slots" and giving tasks specific slots. However
I've tweaked the data structures involved a little bit, mainly to make it easier to
implement. Please check the following Google slides where I've tried to
explain how it works:

- [Simple Case](https://docs.google.com/presentation/d/1cfMOgFIVaYj-jKrUIuFADjmuomJhmSb-6SBYxoeptc8/edit?usp=sharing)
- [Multiple Days](https://docs.google.com/presentation/d/161PI1EnTg3yQf39PZBC2DX7alBdvzvesnghnJSx6SCM/edit?usp=sharing)
- [Long Duration](https://docs.google.com/presentation/d/1-9mjsbW2BsA1RjzJW4NelOEPMui3KWMV0MZBX3_l-Ys/edit?usp=sharing)

It should now be quite easy to adjust granularity as we desire. We can
generate slots of minutes as easily as we can slots of hours.

Currently, it's simply going from least flexible task to 2nd least flexible task
etc, but it's easy to adjust this in the `task_placer` to do least
flexible then the most flexible etc. Please note the tweaked algorithm does result in a
slightly different placement of the tasks for the basic test in issue #3 (see the above slides for a walk-through and the tests in `tests.rs`).

### Task_placer simplified
Although it's not yet handling things like
overlapping and failed placements of tasks, the `task_placer` has been greatly simplified.

One difference from before is that after being processed by the `task_placer`, each task holds a list of slots, plus other relevant information about the task. The `output_formatter` then handles the formatting of output data.

### Tests
I've added some tests in `tests.rs` to test the new functions etc.

### Please note
I haven't implemented a number of important things e.g.:
- Rewriting tests and adding more tests
- Error handling
- Handling failed placements of tasks
- Many other things

The changes in this commit are just suggestions! I've probably
overlooked some things and it may not be the way to go. I'll gladly
revert to the previous code if it is so desired.