### PR TITLE
Fix error handling

### DIFF
--- a/src/output_formatter.rs
+++ b/src/output_formatter.rs
@@ -3,7 +3,7 @@
 use crate::task::Task;
 use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
-use serde_json::Result;
+//use serde_json::Result;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Output {
@@ -15,16 +15,29 @@ pub struct Output {
     deadline: NaiveDateTime,
 }
 
-pub fn output_formatter(tasks: Vec<Task>) -> Result<Vec<Output>> {
+#[derive(Debug)]
+pub enum Error {
+    NoConfirmedDate(usize),
+}
+
+pub fn output_formatter(tasks: Vec<Task>) -> Result<Vec<Output>, Error> {
     let mut outputs = Vec::new();
     for task in tasks {
+        if task.confirmed_start.is_none() || task.confirmed_deadline.is_none() {
+            return Err(Error::NoConfirmedDate(task.id));
+        }
+
         let output = Output {
             taskid: task.id,
             goalid: task.goal_id,
             title: task.title,
             duration: task.duration,
-            start: task.confirmed_start.unwrap(),
-            deadline: task.confirmed_deadline.unwrap(),
+            start: task
+                .confirmed_start
+                .expect("Checked for None done above so should always be Some."),
+            deadline: task
+                .confirmed_deadline
+                .expect("Checked for None done above so should always be Some."),
         };
         outputs.push(output);
     }


### PR DESCRIPTION
Closes #61 .
Removed the `unwrap()` statements. Created an Error type that we'll use going forward to handle various error conditions.