### PR TITLE
Implement splitting of tasks

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,5 @@
+#[derive(Debug)]
+pub enum Error {
+    NoConfirmedDate(usize),
+    CannotSplit,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,10 @@ use wasm_bindgen::prelude::*;
 
 pub use goal::Goal;
 pub use input::Input;
-pub use output_formatter::{output_formatter, Error, Output};
+pub use output_formatter::{output_formatter, Output};
 pub use time_slice_iterator::Repetition;
 
+mod errors;
 /// API modules
 mod goal;
 pub mod input;
@@ -31,6 +32,7 @@ interface Input {
 // https://rustwasm.github.io/wasm-bindgen/reference/arbitrary-data-with-serde.html
 #[wasm_bindgen]
 pub fn schedule(input: &JsValue) -> Result<JsValue, JsError> {
+    use errors::Error;
     use output_formatter::*;
     use task_generator::task_generator;
     use task_placer::*;
@@ -45,6 +47,9 @@ pub fn schedule(input: &JsValue) -> Result<JsValue, JsError> {
         Err(Error::NoConfirmedDate(id)) => {
             panic!("Error with task:{id}. Tasks passed to output formatter should always have a confirmed_start/deadline.")
         }
+        Err(e) => {
+            panic!("Unexpected error: {:?}", e);
+        }
         Ok(output) => output,
     };
 
@@ -52,6 +57,7 @@ pub fn schedule(input: &JsValue) -> Result<JsValue, JsError> {
 }
 
 pub fn run_scheduler(input: Input) -> Vec<Output> {
+    use errors::Error;
     use output_formatter::*;
     use task_generator::task_generator;
     use task_placer::*;
@@ -61,7 +67,10 @@ pub fn run_scheduler(input: Input) -> Vec<Output> {
     let scheduled_tasks = task_placer(tasks, calendar_start, calendar_end);
     match output_formatter(scheduled_tasks) {
         Err(Error::NoConfirmedDate(id)) => {
-            panic!("Error with task:{id}. Tasks passed to output formatter should always have a confirmed_start/deadline.")
+            panic!("Error with task:{id}. Tasks passed to output formatter should always have a confirmed_start/deadline.");
+        }
+        Err(e) => {
+            panic!("Unexpected error: {:?}", e);
         }
         Ok(output) => output,
     }

--- a/src/output_formatter.rs
+++ b/src/output_formatter.rs
@@ -1,5 +1,6 @@
 //new module for outputting the result of task_placer in
 //whichever format required by front-end
+use crate::errors::Error;
 use crate::task::Task;
 use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
@@ -13,11 +14,6 @@ pub struct Output {
     duration: usize,
     start: NaiveDateTime,
     deadline: NaiveDateTime,
-}
-
-#[derive(Debug)]
-pub enum Error {
-    NoConfirmedDate(usize),
 }
 
 pub fn output_formatter(tasks: Vec<Task>) -> Result<Vec<Output>, Error> {

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,5 +1,6 @@
+use crate::errors::Error;
 use crate::goal::Goal;
-use chrono::NaiveDateTime;
+use chrono::{NaiveDateTime, Timelike};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 
@@ -80,6 +81,59 @@ impl Task {
             }
         }
         self.slots.remove(index);
+    }
+
+    pub fn split(
+        &mut self,
+        slot: &(NaiveDateTime, NaiveDateTime),
+        counter: &mut usize,
+    ) -> Result<(Task, Task), Error> {
+        if self.slots.len() == 2 {
+            return Err(Error::CannotSplit);
+        }
+        let mut task_a_slots: Vec<(NaiveDateTime, NaiveDateTime)> = Vec::new();
+        let mut task_b_slots: Vec<(NaiveDateTime, NaiveDateTime)> = Vec::new();
+        for i in 0..self.slots.len() {
+            if self.slots[i].0 < slot.0 {
+                task_a_slots.push(self.slots[i]);
+            } else if self.slots[i].0 > slot.0 {
+                task_b_slots.push(self.slots[i]);
+            }
+        }
+        let task_a = Task {
+            id: *counter,
+            goal_id: self.goal_id,
+            title: self.title.clone(),
+            duration: task_a_slots.len(),
+            status: TaskStatus::UNSCHEDULED,
+            flexibility: 1,
+            start: self.start,
+            deadline: self.deadline,
+            after_time: task_a_slots[0].0.hour() as usize,
+            before_time: task_a_slots[task_a_slots.len() - 1].1.hour() as usize,
+            slots: task_a_slots,
+            confirmed_start: None,
+            confirmed_deadline: None,
+        };
+        *counter += 1;
+        let task_b_duration = self.duration - task_a.duration;
+        let task_b = Task {
+            id: *counter,
+            goal_id: self.goal_id,
+            title: self.title.clone(),
+            duration: task_b_duration,
+            status: TaskStatus::UNSCHEDULED,
+            flexibility: task_b_slots.len() - task_b_duration + 1,
+            start: self.start,
+            deadline: self.deadline,
+            after_time: task_b_slots[0].0.hour() as usize,
+            before_time: task_b_slots[task_b_slots.len() - 1].1.hour() as usize,
+            slots: task_b_slots,
+            confirmed_start: None,
+            confirmed_deadline: None,
+        };
+        *counter += 1;
+        Ok((task_a, task_b))
     }
 }
 

--- a/src/task_placer.rs
+++ b/src/task_placer.rs
@@ -9,6 +9,18 @@ use crate::task::TaskStatus::{SCHEDULED, UNSCHEDULED};
 use crate::time_slice_iterator::{Repetition, TimeSliceIterator};
 use chrono::{NaiveDateTime, Timelike};
 
+pub trait Conflicts {
+    fn conflicts_with(&self, time1: NaiveDateTime, time2: NaiveDateTime) -> bool;
+}
+
+impl Conflicts for (NaiveDateTime, NaiveDateTime) {
+    fn conflicts_with(&self, after_time: NaiveDateTime, before_time: NaiveDateTime) -> bool {
+        //we can be either completely before or completely after. otherwise it's a conflict.
+        !((self.0 < after_time && self.1 <= before_time)
+            || (self.0 >= before_time && self.1 > before_time))
+    }
+}
+
 pub fn task_placer(
     mut tasks: Vec<Task>,
     calendar_start: NaiveDateTime,
@@ -26,31 +38,21 @@ pub fn task_placer(
     for task in &mut tasks {
         let mut i = 0;
         while i < time_slots.len() {
-            //check if the time_slot is:
-            //1) within the start and deadline dates of the task
-            if (time_slots[i].0 >= task.start) && (time_slots[i].1 < task.deadline) {
-                //2) after the after_time of the task
-                if time_slots[i].0.hour() >= task.after_time as u32 {
-                    for _ in 0..(get_num_slots(task)) as usize {
-                        if i < time_slots.len() {
-                            task.slots.push(time_slots[i]);
-                            i += 1;
-                        }
-                    }
-                    //skip to midnight so as not to add more slots on the same day
-                    while time_slots[i - 1].1.hour() != 0 {
-                        i += 1;
-                        if i == time_slots.len() {
-                            break;
-                        }
-                    }
-                    //if the remaining slots on calendar are less than this task's duration,
-                    //truncate the task's duration
-                    if task.slots.len() < task.duration {
-                        task.duration = task.slots.len();
-                    }
-                    continue;
-                }
+            //1) is the time_slot within the start and deadline dates of the task?
+            if !((time_slots[i].0 >= task.start) && (time_slots[i].1 < task.deadline)) {
+                i += 1;
+                continue;
+            }
+            //2) is the time_slot after the after_time of the task?
+            if !(time_slots[i].0.hour() >= task.after_time as u32) {
+                i += 1;
+                continue;
+            }
+            assign_slots(task, &time_slots, &mut i);
+            //if too few slots were assigned (the remaining slots on calendar were not enough),
+            //truncate the task's duration
+            if task.slots.len() < task.duration {
+                task.duration = task.slots.len();
             }
             i += 1;
         }
@@ -65,14 +67,13 @@ pub fn task_placer(
             tasks[index].set_confirmed_deadline(my_slots[my_slots.len() - 1].1);
             tasks[index].status = SCHEDULED;
             //slide 10 (remove the assigned slot from other tasks' slot lists)
-            remove_slots_from_tasks(&mut tasks, &my_slots[..]);
+            remove_slots_from_tasks(&mut tasks, my_slots[0].0, my_slots[my_slots.len() - 1].1);
         }
     }
 
     //slides 12-20 (attempt to schedule the other tasks without conflicting with other tasks'
     //slots)
     let mut counter = tasks[tasks.len() - 1].id + 1;
-
     loop {
         schedule_tasks(&mut tasks, &mut counter);
         if !tasks.iter().any(|t| t.status == UNSCHEDULED) {
@@ -83,11 +84,19 @@ pub fn task_placer(
     tasks
 }
 
-fn get_num_slots(task: &Task) -> usize {
-    if task.before_time > task.after_time {
-        task.before_time - task.after_time
-    } else {
-        task.before_time + (24 - task.after_time)
+fn assign_slots(task: &mut Task, time_slots: &Vec<(NaiveDateTime, NaiveDateTime)>, i: &mut usize) {
+    for _ in 0..(task.num_slots()) as usize {
+        if *i < time_slots.len() {
+            task.slots.push(time_slots[*i]);
+            *i += 1;
+        }
+    }
+    //skip to midnight so as not to add more slots on the same day
+    while time_slots[*i - 1].1.hour() != 0 {
+        *i += 1;
+        if *i == time_slots.len() {
+            break;
+        }
     }
 }
 
@@ -95,53 +104,36 @@ fn schedule_tasks(tasks: &mut Vec<Task>, counter: &mut usize) {
     tasks.sort();
     tasks.reverse();
 
-    let length = tasks.len();
-    'outer: for i in 0..length {
-        println!(
-            "Scheduling {} with slots {:?}",
-            tasks[i].title, tasks[i].slots
-        );
-        let my_slots = tasks[i].get_slots();
-        'inner: for (j, _) in my_slots.iter().enumerate() {
-            if j + tasks[i].duration - 1 >= my_slots.len() {
-                continue 'outer;
-            }
-            let desired_first_slot = my_slots.get(j).unwrap();
-            let desired_last_slot = my_slots.get(j + tasks[i].duration - 1).unwrap();
+    let tasks_length = tasks.len();
+    'task_loop: for i in 0..tasks_length {
+        while let Some((desired_start, desired_deadline)) =
+            tasks[i].next_start_deadline_combination()
+        {
             let mut is_conflicting = false;
-            for k in 0..length {
+            for k in 0..tasks_length {
                 if tasks[k].status == SCHEDULED || k == i {
                     continue;
                 }
-                if !((desired_first_slot < &tasks[k].slots[0]
-                    && desired_last_slot < &tasks[k].slots[0])
-                    || (desired_first_slot > &tasks[k].slots[tasks[k].slots.len() - 1]
-                        && desired_last_slot > &tasks[k].slots[tasks[k].slots.len() - 1]))
+                let other_task_after_time = tasks[k].slots[0].0;
+                let other_task_before_time = tasks[k].slots[tasks[k].slots.len() - 1].1;
+                if (desired_start, desired_deadline)
+                    .conflicts_with(other_task_after_time, other_task_before_time)
                 {
-                    println!("task {} conflicts with {}", tasks[k].title, tasks[i].title);
                     if k < i {
-                        println!("k {k} is less than i {i}");
-                        //can attempt to split since this is a failed-to-schedule task
-                        match tasks[k].split(&(desired_first_slot.0, desired_last_slot.1), counter)
-                        {
-                            Err(_) => {
+                        //this is a task that already tried to be scheduled but failed
+                        //so we can split it and take slots from it
+                        match tasks[k].split(&(desired_start, desired_deadline), counter) {
+                            Err(Error::CannotSplit) | Err(_) => {
                                 is_conflicting = true;
                                 break;
                             }
                             Ok((taska, taskb)) => {
-                                println!("Splitting.........");
                                 tasks.push(taska);
                                 tasks.push(taskb);
-                                tasks[i].set_confirmed_start(desired_first_slot.0);
-                                tasks[i].set_confirmed_deadline(desired_last_slot.1);
-                                remove_slots_from_tasks(
-                                    tasks,
-                                    &my_slots[j..j + tasks[i].duration - 1],
-                                );
-                                tasks[i].status = SCHEDULED;
+                                tasks[i].schedule(desired_start, desired_deadline);
+                                remove_slots_from_tasks(tasks, desired_start, desired_deadline);
                                 tasks.remove(k);
-
-                                continue 'outer;
+                                continue 'task_loop;
                             }
                         }
                     } else {
@@ -151,25 +143,21 @@ fn schedule_tasks(tasks: &mut Vec<Task>, counter: &mut usize) {
                 }
             }
             if is_conflicting {
-                continue 'inner;
+                continue;
             }
-            tasks[i].set_confirmed_start(desired_first_slot.0);
-            tasks[i].set_confirmed_deadline(desired_last_slot.1);
-            tasks[i].status = SCHEDULED;
-            remove_slots_from_tasks(tasks, &my_slots[j..j + tasks[i].duration - 1]);
-            println!("Task {} has been scheduled.", tasks[i].title);
-            continue 'outer;
+            tasks[i].schedule(desired_start, desired_deadline);
+            remove_slots_from_tasks(tasks, desired_start, desired_deadline);
+            continue 'task_loop;
         }
     }
-    //tasks
 }
 
-fn remove_slots_from_tasks(tasks: &mut Vec<Task>, my_slots: &[(NaiveDateTime, NaiveDateTime)]) {
+fn remove_slots_from_tasks(tasks: &mut Vec<Task>, start: NaiveDateTime, deadline: NaiveDateTime) {
     for task in tasks {
-        for slot in my_slots {
-            if task.slots.contains(slot) {
-                println!("Removing slot {:?} from task {}", slot, task.title);
-                task.remove_slot(slot);
+        let slots = task.get_slots();
+        for slot in slots {
+            if slot.0 >= start && slot.1 <= deadline {
+                task.remove_slot(&slot);
             }
         }
     }

--- a/src/unit_tests.rs
+++ b/src/unit_tests.rs
@@ -20,6 +20,7 @@ fn get_test_tasks() -> Vec<Task> {
             slots: Vec::new(),
             confirmed_start: None,
             confirmed_deadline: None,
+            internal_index: 0,
         },
         Task {
             id: 10,
@@ -35,6 +36,7 @@ fn get_test_tasks() -> Vec<Task> {
             slots: Vec::new(),
             confirmed_start: None,
             confirmed_deadline: None,
+            internal_index: 0,
         },
         Task {
             id: 30,
@@ -50,6 +52,7 @@ fn get_test_tasks() -> Vec<Task> {
             slots: Vec::new(),
             confirmed_start: None,
             confirmed_deadline: None,
+            internal_index: 0,
         },
     ]
 }
@@ -463,6 +466,7 @@ fn goal_generates_single_nonrepetitive_task() {
             slots: Vec::new(),
             confirmed_start: None,
             confirmed_deadline: None,
+            internal_index: 0,
         },]
     )
 }
@@ -700,6 +704,7 @@ fn task_splitting_works() {
         slots: original_slots,
         confirmed_start: None,
         confirmed_deadline: None,
+        internal_index: 0,
     };
 
     let task_a = Task {
@@ -716,6 +721,7 @@ fn task_splitting_works() {
         slots: task_a_slots,
         confirmed_start: None,
         confirmed_deadline: None,
+        internal_index: 0,
     };
 
     let task_b = Task {
@@ -732,6 +738,7 @@ fn task_splitting_works() {
         slots: task_b_slots,
         confirmed_start: None,
         confirmed_deadline: None,
+        internal_index: 0,
     };
 
     let split_slot = (

--- a/src/unit_tests.rs
+++ b/src/unit_tests.rs
@@ -469,7 +469,7 @@ fn goal_generates_single_nonrepetitive_task() {
 
 #[test]
 fn output_formatter_works() {
-    let desired_output = r#"[{"taskid":20,"goalid":2,"title":"dentist","duration":1,"start":"2022-01-01T10:00:00","deadline":"2022-01-01T11:00:00"},{"taskid":30,"goalid":3,"title":"exercise","duration":1,"start":"2022-01-01T13:00:00","deadline":"2022-01-01T14:00:00"},{"taskid":10,"goalid":1,"title":"shopping","duration":1,"start":"2022-01-01T11:00:00","deadline":"2022-01-01T12:00:00"}]"#;
+    let desired_output = r#"[{"taskid":30,"goalid":3,"title":"exercise","duration":1,"start":"2022-01-01T13:00:00","deadline":"2022-01-01T14:00:00"},{"taskid":10,"goalid":1,"title":"shopping","duration":1,"start":"2022-01-01T11:00:00","deadline":"2022-01-01T12:00:00"},{"taskid":20,"goalid":2,"title":"dentist","duration":1,"start":"2022-01-01T10:00:00","deadline":"2022-01-01T11:00:00"}]"#;
 
     let (calendar_start, calendar_end) = get_calendar_bounds();
     let scheduled_tasks = task_placer(get_test_tasks(), calendar_start, calendar_end);
@@ -548,28 +548,29 @@ fn task_placer_slots_tasks_correctly() {
     assert_eq!(scheduled_tasks[0].status, SCHEDULED);
     assert_eq!(scheduled_tasks[1].status, SCHEDULED);
     assert_eq!(scheduled_tasks[2].status, SCHEDULED);
+
     assert_eq!(
         scheduled_tasks[0].confirmed_start.unwrap(),
-        NaiveDate::from_ymd(2022, 1, 1).and_hms(10, 0, 0)
-    );
-    assert_eq!(
-        scheduled_tasks[0].confirmed_deadline.unwrap(),
-        NaiveDate::from_ymd(2022, 1, 1).and_hms(11, 0, 0)
-    );
-    assert_eq!(
-        scheduled_tasks[1].confirmed_start.unwrap(),
         NaiveDate::from_ymd(2022, 1, 1).and_hms(13, 0, 0)
     );
     assert_eq!(
-        scheduled_tasks[1].confirmed_deadline.unwrap(),
+        scheduled_tasks[0].confirmed_deadline.unwrap(),
         NaiveDate::from_ymd(2022, 1, 1).and_hms(14, 0, 0)
     );
     assert_eq!(
-        scheduled_tasks[2].confirmed_start.unwrap(),
+        scheduled_tasks[1].confirmed_start.unwrap(),
         NaiveDate::from_ymd(2022, 1, 1).and_hms(11, 0, 0)
     );
     assert_eq!(
-        scheduled_tasks[2].confirmed_deadline.unwrap(),
+        scheduled_tasks[1].confirmed_deadline.unwrap(),
         NaiveDate::from_ymd(2022, 1, 1).and_hms(12, 0, 0)
+    );
+    assert_eq!(
+        scheduled_tasks[2].confirmed_start.unwrap(),
+        NaiveDate::from_ymd(2022, 1, 1).and_hms(10, 0, 0)
+    );
+    assert_eq!(
+        scheduled_tasks[2].confirmed_deadline.unwrap(),
+        NaiveDate::from_ymd(2022, 1, 1).and_hms(11, 0, 0)
     );
 }

--- a/src/unit_tests.rs
+++ b/src/unit_tests.rs
@@ -574,3 +574,179 @@ fn task_placer_slots_tasks_correctly() {
         NaiveDate::from_ymd(2022, 1, 1).and_hms(11, 0, 0)
     );
 }
+
+#[test]
+fn task_splitting_works() {
+    let original_slots = vec![
+        (
+            NaiveDate::from_ymd(2022, 1, 1).and_hms(8, 0, 0),
+            NaiveDate::from_ymd(2022, 1, 1).and_hms(9, 0, 0),
+        ),
+        (
+            NaiveDate::from_ymd(2022, 1, 1).and_hms(9, 0, 0),
+            NaiveDate::from_ymd(2022, 1, 1).and_hms(10, 0, 0),
+        ),
+        (
+            NaiveDate::from_ymd(2022, 1, 1).and_hms(10, 0, 0),
+            NaiveDate::from_ymd(2022, 1, 1).and_hms(11, 0, 0),
+        ),
+        (
+            NaiveDate::from_ymd(2022, 1, 1).and_hms(11, 0, 0),
+            NaiveDate::from_ymd(2022, 1, 1).and_hms(12, 0, 0),
+        ),
+        (
+            NaiveDate::from_ymd(2022, 1, 1).and_hms(12, 0, 0),
+            NaiveDate::from_ymd(2022, 1, 1).and_hms(13, 0, 0),
+        ),
+        (
+            NaiveDate::from_ymd(2022, 1, 6).and_hms(13, 0, 0),
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(14, 0, 0),
+        ),
+        (
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(14, 0, 0),
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(15, 0, 0),
+        ),
+        (
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(15, 0, 0),
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(16, 0, 0),
+        ),
+        (
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(16, 0, 0),
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(17, 0, 0),
+        ),
+        (
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(17, 0, 0),
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(18, 0, 0),
+        ),
+        (
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(18, 0, 0),
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(19, 0, 0),
+        ),
+        (
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(19, 0, 0),
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(20, 0, 0),
+        ),
+        (
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(20, 0, 0),
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(21, 0, 0),
+        ),
+    ];
+
+    let task_a_slots = vec![
+        (
+            NaiveDate::from_ymd(2022, 1, 1).and_hms(8, 0, 0),
+            NaiveDate::from_ymd(2022, 1, 1).and_hms(9, 0, 0),
+        ),
+        (
+            NaiveDate::from_ymd(2022, 1, 1).and_hms(9, 0, 0),
+            NaiveDate::from_ymd(2022, 1, 1).and_hms(10, 0, 0),
+        ),
+        (
+            NaiveDate::from_ymd(2022, 1, 1).and_hms(10, 0, 0),
+            NaiveDate::from_ymd(2022, 1, 1).and_hms(11, 0, 0),
+        ),
+        (
+            NaiveDate::from_ymd(2022, 1, 1).and_hms(11, 0, 0),
+            NaiveDate::from_ymd(2022, 1, 1).and_hms(12, 0, 0),
+        ),
+    ];
+
+    let task_b_slots = vec![
+        (
+            NaiveDate::from_ymd(2022, 1, 6).and_hms(13, 0, 0),
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(14, 0, 0),
+        ),
+        (
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(14, 0, 0),
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(15, 0, 0),
+        ),
+        (
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(15, 0, 0),
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(16, 0, 0),
+        ),
+        (
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(16, 0, 0),
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(17, 0, 0),
+        ),
+        (
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(17, 0, 0),
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(18, 0, 0),
+        ),
+        (
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(18, 0, 0),
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(19, 0, 0),
+        ),
+        (
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(19, 0, 0),
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(20, 0, 0),
+        ),
+        (
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(20, 0, 0),
+            NaiveDate::from_ymd(2022, 1, 7).and_hms(21, 0, 0),
+        ),
+    ];
+
+    let mut task = Task {
+        id: 1,
+        goal_id: 1,
+        title: "Work".to_string(),
+        duration: 8,
+        status: UNSCHEDULED,
+        flexibility: 6,
+        start: NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0),
+        deadline: NaiveDate::from_ymd(2022, 1, 2).and_hms(0, 0, 0),
+        after_time: 8,
+        before_time: 21,
+        slots: original_slots,
+        confirmed_start: None,
+        confirmed_deadline: None,
+    };
+
+    let task_a = Task {
+        id: 2,
+        goal_id: 1,
+        title: "Work".to_string(),
+        duration: 4,
+        status: UNSCHEDULED,
+        flexibility: 1,
+        start: NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0),
+        deadline: NaiveDate::from_ymd(2022, 1, 2).and_hms(0, 0, 0),
+        after_time: 8,
+        before_time: 12,
+        slots: task_a_slots,
+        confirmed_start: None,
+        confirmed_deadline: None,
+    };
+
+    let task_b = Task {
+        id: 3,
+        goal_id: 1,
+        title: "Work".to_string(),
+        duration: 4,
+        status: UNSCHEDULED,
+        flexibility: 5,
+        start: NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0),
+        deadline: NaiveDate::from_ymd(2022, 1, 2).and_hms(0, 0, 0),
+        after_time: 13,
+        before_time: 21,
+        slots: task_b_slots,
+        confirmed_start: None,
+        confirmed_deadline: None,
+    };
+
+    let split_slot = (
+        NaiveDate::from_ymd(2022, 1, 1).and_hms(12, 0, 0),
+        NaiveDate::from_ymd(2022, 1, 1).and_hms(13, 0, 0),
+    );
+
+    let mut counter = 2;
+
+    assert_eq!(
+        task.split(&split_slot, &mut counter).unwrap(),
+        (task_a, task_b)
+    );
+}
+
+#[test]
+#[ignore]
+fn split_on_first_slot() {}

--- a/tests/jsons/basic-test/output.json
+++ b/tests/jsons/basic-test/output.json
@@ -1,13 +1,5 @@
 [
       {
-        "taskid": 1,
-        "goalid": 2,
-        "title": "dentist",
-        "duration": 1,
-        "start": "2022-01-01T10:00:00",
-        "deadline": "2022-01-01T11:00:00"
-      },
-      {
         "taskid": 2,
         "goalid": 3,
         "title": "exercise",
@@ -22,5 +14,13 @@
         "duration": 1,
         "start": "2022-01-01T11:00:00",
         "deadline": "2022-01-01T12:00:00"
+      },
+      {
+        "taskid": 1,
+        "goalid": 2,
+        "title": "dentist",
+        "duration": 1,
+        "start": "2022-01-01T10:00:00",
+        "deadline": "2022-01-01T11:00:00"
       }
 ]

--- a/tests/jsons/realistic-schedule/output.json
+++ b/tests/jsons/realistic-schedule/output.json
@@ -1,285 +1,5 @@
 [
       {
-        "taskid": 100,
-        "goalid": 6,
-        "title": "dentist",
-        "duration": 1,
-        "start": "2022-09-14T10:00:00",
-        "deadline": "2022-09-14T11:00:00"
-      },
-      {
-        "taskid": 93,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-30T05:00:00",
-        "deadline": "2022-09-30T07:00:00"
-      },
-      {
-        "taskid": 92,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-29T05:00:00",
-        "deadline": "2022-09-29T07:00:00"
-      },
-      {
-        "taskid": 91,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-28T05:00:00",
-        "deadline": "2022-09-28T07:00:00"
-      },
-      {
-        "taskid": 90,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-27T05:00:00",
-        "deadline": "2022-09-27T07:00:00"
-      },
-      {
-        "taskid": 89,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-26T05:00:00",
-        "deadline": "2022-09-26T07:00:00"
-      },
-      {
-        "taskid": 88,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-25T05:00:00",
-        "deadline": "2022-09-25T07:00:00"
-      },
-      {
-        "taskid": 87,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-24T05:00:00",
-        "deadline": "2022-09-24T07:00:00"
-      },
-      {
-        "taskid": 86,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-23T05:00:00",
-        "deadline": "2022-09-23T07:00:00"
-      },
-      {
-        "taskid": 85,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-22T05:00:00",
-        "deadline": "2022-09-22T07:00:00"
-      },
-      {
-        "taskid": 84,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-21T05:00:00",
-        "deadline": "2022-09-21T07:00:00"
-      },
-      {
-        "taskid": 83,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-20T05:00:00",
-        "deadline": "2022-09-20T07:00:00"
-      },
-      {
-        "taskid": 82,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-19T05:00:00",
-        "deadline": "2022-09-19T07:00:00"
-      },
-      {
-        "taskid": 81,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-18T05:00:00",
-        "deadline": "2022-09-18T07:00:00"
-      },
-      {
-        "taskid": 80,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-17T05:00:00",
-        "deadline": "2022-09-17T07:00:00"
-      },
-      {
-        "taskid": 79,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-16T05:00:00",
-        "deadline": "2022-09-16T07:00:00"
-      },
-      {
-        "taskid": 78,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-15T05:00:00",
-        "deadline": "2022-09-15T07:00:00"
-      },
-      {
-        "taskid": 77,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-14T05:00:00",
-        "deadline": "2022-09-14T07:00:00"
-      },
-      {
-        "taskid": 76,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-13T05:00:00",
-        "deadline": "2022-09-13T07:00:00"
-      },
-      {
-        "taskid": 75,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-12T05:00:00",
-        "deadline": "2022-09-12T07:00:00"
-      },
-      {
-        "taskid": 74,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-11T05:00:00",
-        "deadline": "2022-09-11T07:00:00"
-      },
-      {
-        "taskid": 73, 
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-10T05:00:00",
-        "deadline": "2022-09-10T07:00:00"
-      },
-      {
-        "taskid": 72,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-09T05:00:00",
-        "deadline": "2022-09-09T07:00:00"
-      },
-      {
-        "taskid": 71,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-08T05:00:00",
-        "deadline": "2022-09-08T07:00:00"
-      },
-      {
-        "taskid": 70,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-07T05:00:00",
-        "deadline": "2022-09-07T07:00:00"
-      },
-      {
-        "taskid": 69,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-06T05:00:00",
-        "deadline": "2022-09-06T07:00:00"
-      },
-      {
-        "taskid": 68,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-05T05:00:00",
-        "deadline": "2022-09-05T07:00:00"
-      },
-      {
-        "taskid": 67,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-04T05:00:00",
-        "deadline": "2022-09-04T07:00:00"
-      },
-      {
-        "taskid": 66,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-03T05:00:00",
-        "deadline": "2022-09-03T07:00:00"
-      },
-      {
-        "taskid": 65,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-02T05:00:00",
-        "deadline": "2022-09-02T07:00:00"
-      },
-      {
-        "taskid": 64,
-        "goalid": 4,
-        "title": "gym",
-        "duration": 2,
-        "start": "2022-09-01T05:00:00",
-        "deadline": "2022-09-01T07:00:00"
-      },
-      {
-        "taskid": 63,
-        "goalid": 3,
-        "title": "piano practice",
-        "duration": 2,
-        "start": "2022-09-28T12:00:00",
-        "deadline": "2022-09-28T14:00:00"
-      },
-      {
-        "taskid": 62,
-        "goalid": 3,
-        "title": "piano practice",
-        "duration": 2,
-        "start": "2022-09-21T12:00:00",
-        "deadline": "2022-09-21T14:00:00"
-      },
-      {
-        "taskid": 61,
-        "goalid": 3,
-        "title": "piano practice",
-        "duration": 2,
-        "start": "2022-09-14T12:00:00",
-        "deadline": "2022-09-14T14:00:00"
-      },
-      {
-        "taskid": 60,
-        "goalid": 3,
-        "title": "piano practice",
-        "duration": 2,
-        "start": "2022-09-07T12:00:00",
-        "deadline": "2022-09-07T14:00:00"
-      },
-      {
         "taskid": 102,
         "goalid": 8,
         "title": "repair sink",
@@ -822,5 +542,285 @@
         "duration": 1,
         "start": "2022-09-01T17:00:00",
         "deadline": "2022-09-01T18:00:00"
+      },
+      {
+        "taskid": 100,
+        "goalid": 6,
+        "title": "dentist",
+        "duration": 1,
+        "start": "2022-09-14T10:00:00",
+        "deadline": "2022-09-14T11:00:00"
+      },
+      {
+        "taskid": 93,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-30T05:00:00",
+        "deadline": "2022-09-30T07:00:00"
+      },
+      {
+        "taskid": 92,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-29T05:00:00",
+        "deadline": "2022-09-29T07:00:00"
+      },
+      {
+        "taskid": 91,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-28T05:00:00",
+        "deadline": "2022-09-28T07:00:00"
+      },
+      {
+        "taskid": 90,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-27T05:00:00",
+        "deadline": "2022-09-27T07:00:00"
+      },
+      {
+        "taskid": 89,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-26T05:00:00",
+        "deadline": "2022-09-26T07:00:00"
+      },
+      {
+        "taskid": 88,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-25T05:00:00",
+        "deadline": "2022-09-25T07:00:00"
+      },
+      {
+        "taskid": 87,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-24T05:00:00",
+        "deadline": "2022-09-24T07:00:00"
+      },
+      {
+        "taskid": 86,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-23T05:00:00",
+        "deadline": "2022-09-23T07:00:00"
+      },
+      {
+        "taskid": 85,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-22T05:00:00",
+        "deadline": "2022-09-22T07:00:00"
+      },
+      {
+        "taskid": 84,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-21T05:00:00",
+        "deadline": "2022-09-21T07:00:00"
+      },
+      {
+        "taskid": 83,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-20T05:00:00",
+        "deadline": "2022-09-20T07:00:00"
+      },
+      {
+        "taskid": 82,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-19T05:00:00",
+        "deadline": "2022-09-19T07:00:00"
+      },
+      {
+        "taskid": 81,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-18T05:00:00",
+        "deadline": "2022-09-18T07:00:00"
+      },
+      {
+        "taskid": 80,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-17T05:00:00",
+        "deadline": "2022-09-17T07:00:00"
+      },
+      {
+        "taskid": 79,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-16T05:00:00",
+        "deadline": "2022-09-16T07:00:00"
+      },
+      {
+        "taskid": 78,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-15T05:00:00",
+        "deadline": "2022-09-15T07:00:00"
+      },
+      {
+        "taskid": 77,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-14T05:00:00",
+        "deadline": "2022-09-14T07:00:00"
+      },
+      {
+        "taskid": 76,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-13T05:00:00",
+        "deadline": "2022-09-13T07:00:00"
+      },
+      {
+        "taskid": 75,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-12T05:00:00",
+        "deadline": "2022-09-12T07:00:00"
+      },
+      {
+        "taskid": 74,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-11T05:00:00",
+        "deadline": "2022-09-11T07:00:00"
+      },
+      {
+        "taskid": 73, 
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-10T05:00:00",
+        "deadline": "2022-09-10T07:00:00"
+      },
+      {
+        "taskid": 72,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-09T05:00:00",
+        "deadline": "2022-09-09T07:00:00"
+      },
+      {
+        "taskid": 71,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-08T05:00:00",
+        "deadline": "2022-09-08T07:00:00"
+      },
+      {
+        "taskid": 70,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-07T05:00:00",
+        "deadline": "2022-09-07T07:00:00"
+      },
+      {
+        "taskid": 69,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-06T05:00:00",
+        "deadline": "2022-09-06T07:00:00"
+      },
+      {
+        "taskid": 68,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-05T05:00:00",
+        "deadline": "2022-09-05T07:00:00"
+      },
+      {
+        "taskid": 67,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-04T05:00:00",
+        "deadline": "2022-09-04T07:00:00"
+      },
+      {
+        "taskid": 66,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-03T05:00:00",
+        "deadline": "2022-09-03T07:00:00"
+      },
+      {
+        "taskid": 65,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-02T05:00:00",
+        "deadline": "2022-09-02T07:00:00"
+      },
+      {
+        "taskid": 64,
+        "goalid": 4,
+        "title": "gym",
+        "duration": 2,
+        "start": "2022-09-01T05:00:00",
+        "deadline": "2022-09-01T07:00:00"
+      },
+      {
+        "taskid": 63,
+        "goalid": 3,
+        "title": "piano practice",
+        "duration": 2,
+        "start": "2022-09-28T12:00:00",
+        "deadline": "2022-09-28T14:00:00"
+      },
+      {
+        "taskid": 62,
+        "goalid": 3,
+        "title": "piano practice",
+        "duration": 2,
+        "start": "2022-09-21T12:00:00",
+        "deadline": "2022-09-21T14:00:00"
+      },
+      {
+        "taskid": 61,
+        "goalid": 3,
+        "title": "piano practice",
+        "duration": 2,
+        "start": "2022-09-14T12:00:00",
+        "deadline": "2022-09-14T14:00:00"
+      },
+      {
+        "taskid": 60,
+        "goalid": 3,
+        "title": "piano practice",
+        "duration": 2,
+        "start": "2022-09-07T12:00:00",
+        "deadline": "2022-09-07T14:00:00"
       }
 ]

--- a/tests/jsons/repetition-daily/output.json
+++ b/tests/jsons/repetition-daily/output.json
@@ -1,5 +1,5 @@
 [
-  {
+{
     "taskid": 2,
     "goalid": 1,
     "title": "walk",

--- a/tests/jsons/singleday-manygoals/output.json
+++ b/tests/jsons/singleday-manygoals/output.json
@@ -1,12 +1,5 @@
 [
-      {
-        "taskid": 1,
-        "goalid": 2,
-        "title": "dentist",
-        "duration": 1,
-        "start": "2022-01-01T10:00:00",
-        "deadline": "2022-01-01T11:00:00"
-      },
+      
       {
         "taskid": 7,
         "goalid": 8,
@@ -62,5 +55,13 @@
         "duration": 1,
         "start": "2022-01-01T05:00:00",
         "deadline": "2022-01-01T06:00:00"
+      },
+      {
+        "taskid": 1,
+        "goalid": 2,
+        "title": "dentist",
+        "duration": 1,
+        "start": "2022-01-01T10:00:00",
+        "deadline": "2022-01-01T11:00:00"
       }
 ]

--- a/tests/jsons/sleep/output.json
+++ b/tests/jsons/sleep/output.json
@@ -1,5 +1,5 @@
 [
-    {
+      {
         "taskid": 7,
         "goalid": 1,
         "title": "sleep",

--- a/tests/jsons/split-tasks-simple/input.json
+++ b/tests/jsons/split-tasks-simple/input.json
@@ -1,0 +1,24 @@
+{
+      "startDate": "2022-09-01T00:00:00",
+      "endDate": "2022-09-02T00:00:00",
+      "goals": [
+        {
+          "id": 1,
+          "title": "dentist",
+          "duration": 1,
+          "start": "2022-09-01T00:00:00",
+          "deadline": "2022-09-02T00:00:00",
+          "after_time": 12,
+          "before_time": 14 
+        },
+        {
+          "id": 2,
+          "title": "work",
+          "duration": 8,
+          "start": "2022-09-01T00:00:00",
+          "deadline": "2022-09-02T00:00:00",
+          "after_time": 8,
+          "before_time": 21 
+        }
+      ]
+}

--- a/tests/jsons/split-tasks-simple/output.json
+++ b/tests/jsons/split-tasks-simple/output.json
@@ -1,0 +1,26 @@
+[
+      {
+        "taskid": 3,
+        "goalid": 2,
+        "title": "work",
+        "duration": 4,
+        "start": "2022-09-01T13:00:00",
+        "deadline": "2022-09-01T17:00:00"
+      },
+      {
+        "taskid": 0,
+        "goalid": 1,
+        "title": "dentist",
+        "duration": 1,
+        "start": "2022-09-01T12:00:00",
+        "deadline": "2022-09-01T13:00:00"
+      },
+      {
+        "taskid": 2,
+        "goalid": 2,
+        "title": "work",
+        "duration": 4,
+        "start": "2022-09-01T08:00:00",
+        "deadline": "2022-09-01T12:00:00"
+      }
+]

--- a/tests/rust_tests.rs
+++ b/tests/rust_tests.rs
@@ -67,3 +67,9 @@ fn sleep() {
     let (actual_output, desired_output) = run_test("sleep");
     assert_eq!(actual_output, desired_output);
 }
+
+#[test]
+fn split_simple() {
+    let (actual_output, desired_output) = run_test("split-tasks-simple");
+    assert_eq!(actual_output, desired_output);
+}


### PR DESCRIPTION
```
{
        "taskid": 1,
        "goalid": 1,
        "title": "dentist",
        "duration": 1,
        "start": "2022-09-14T00:00:00",
        "deadline": "2022-09-15T00:00:00",
        "after_time": 12,
        "before_time": 14,
        "flexibility": 2,
}
{
        "taskid": 2,
        "goalid": 2,
        "title": "work",
        "duration": 8,
        "start": "2022-09-14T00:00:00",
        "deadline": "2022-09-15T00:00:00"
        "after_time": 8,
        "before_time": 21,
        "flexibility": 6
},
```

Suppose we have Task Dentist and Task Work and Task Work has a higher flexibility so is scheduled first. Prior to this PR, both would fail because while scheduling Work, it would conflict with Dentist's slots. And Dentist would fail because it conflicts with Work's slots.

This PR introduces a new step. Work will still fail initially. Then when attempting to schedule Dentist, it will find a conflict with Work. However the scheduler will now notice that Work is already a failed-to-schedule task, and allow Dentist to go ahead and schedule itself even though it's using slots within Work. It will then split Work into two tasks. One with slots before the dentist appointment, and one with slots after the dentist appointment. The durations of the new tasks will add up to the duration of the original task.

These two new tasks are then added to the list of tasks to schedule and the scheduler does another sweep to try and schedule all tasks. It will keep repeating this process until all tasks are scheduled (the assumption is we are working only with goals that can all be scheduled if split).

This is just for a very simple split test case. We need to test for many more scenarios and determine minimum size to allow splitting of a task (current is 3).

Closes #80.