### PR TITLE
Uncomment realistic-schedule test.

### DIFF
--- a/tests/rust_tests.rs
+++ b/tests/rust_tests.rs
@@ -57,7 +57,6 @@ fn every_wednesday_works() {
 }
 
 #[test]
-#[ignore]
 fn realistic_schedule_works() {
     let (actual_output, desired_output) = run_test("realistic-schedule");
     assert_eq!(actual_output, desired_output);


### PR DESCRIPTION
This test had been commented out while #83 was being worked on. Now can be uncommented.