### PR TITLE
Clean code: slot assigner

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ interface Input {
 pub fn schedule(input: &JsValue) -> Result<JsValue, JsError> {
     use errors::Error;
     use output_formatter::*;
+    use slot_assigner::slot_assigner;
     use task_generator::task_generator;
     use task_placer::*;
     // JsError implements From<Error>, so we can just use `?` on any Error
@@ -44,7 +45,8 @@ pub fn schedule(input: &JsValue) -> Result<JsValue, JsError> {
 
     let calendar_start = input.calendar_start;
     let calendar_end = input.calendar_end;
-    let tasks = task_generator(input);
+    let mut tasks = task_generator(input);
+    tasks = slot_assigner(tasks, calendar_start, calendar_end);
     let scheduled_tasks = task_placer(tasks);
     let output = match output_formatter(scheduled_tasks) {
         Err(Error::NoConfirmedDate(title, id)) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ mod goal;
 pub mod input;
 pub mod output_formatter;
 mod slot;
+mod slot_assigner;
 mod task;
 mod task_generator;
 mod task_placer;
@@ -44,7 +45,7 @@ pub fn schedule(input: &JsValue) -> Result<JsValue, JsError> {
     let calendar_start = input.calendar_start;
     let calendar_end = input.calendar_end;
     let tasks = task_generator(input);
-    let scheduled_tasks = task_placer(tasks, calendar_start, calendar_end);
+    let scheduled_tasks = task_placer(tasks);
     let output = match output_formatter(scheduled_tasks) {
         Err(Error::NoConfirmedDate(title, id)) => {
             panic!("Error with task {title}:{id}. Tasks passed to output formatter should always have a confirmed_start/deadline.")
@@ -61,12 +62,14 @@ pub fn schedule(input: &JsValue) -> Result<JsValue, JsError> {
 pub fn run_scheduler(input: Input) -> Vec<Output> {
     use errors::Error;
     use output_formatter::*;
+    use slot_assigner::slot_assigner;
     use task_generator::task_generator;
     use task_placer::*;
     let calendar_start = input.calendar_start;
     let calendar_end = input.calendar_end;
-    let tasks = task_generator(input);
-    let scheduled_tasks = task_placer(tasks, calendar_start, calendar_end);
+    let mut tasks = task_generator(input);
+    tasks = slot_assigner(tasks, calendar_start, calendar_end);
+    let scheduled_tasks = task_placer(tasks);
     match output_formatter(scheduled_tasks) {
         Err(Error::NoConfirmedDate(title, id)) => {
             panic!("Error with task {title}:{id}. Tasks passed to output formatter should always have a confirmed_start/deadline.");

--- a/src/slot_assigner.rs
+++ b/src/slot_assigner.rs
@@ -1,0 +1,82 @@
+//! The Task Placer receives a list of tasks from the Task Generator and attempts to assign each
+//! task a confirmed start and deadline.
+//! The scheduler optimizes for the minimum amount of IMPOSSIBLE tasks.
+//For a visual step-by-step breakdown of the scheduler algorithm see https://docs.google.com/presentation/d/1Tj0Bg6v_NVkS8mpa-aRtbDQXM-WFkb3MloWuouhTnAM/edit?usp=sharing
+
+use crate::slot::Slot;
+use crate::task::Task;
+use crate::time_slot_iterator::{Repetition, TimeSlotIterator};
+use chrono::{NaiveDateTime, Timelike};
+
+pub fn slot_assigner(
+    mut tasks: Vec<Task>,
+    calendar_start: NaiveDateTime,
+    calendar_end: NaiveDateTime,
+) -> Vec<Task> {
+    //slide 1 (generate all time slots based on calendar dates)
+    let time_slot_iterator = TimeSlotIterator {
+        start: calendar_start,
+        end: calendar_end,
+        repetition: Repetition::HOURLY,
+    };
+    let time_slots: Vec<Slot> = time_slot_iterator.collect();
+
+    //slides 2 - 7 (assign slots to tasks)
+    for task in &mut tasks {
+        let mut i = 0;
+        while i < time_slots.len() {
+            //1) is the time_slot within the start and deadline dates of the task?
+            if !((time_slots[i].start >= task.start) && (time_slots[i].end < task.deadline)) {
+                i += 1;
+                continue;
+            }
+            //2) is the time_slot after the after_time of the task?
+            if !(time_slots[i].start.hour() >= task.after_time as u32) {
+                i += 1;
+                continue;
+            }
+            assign_slots(task, &time_slots, &mut i);
+
+            i += 1;
+        }
+        //if too few slots were assigned for the task (the remaining slots on calendar were not enough),
+        //truncate the task's duration.
+        //TODO: Need to confirm if this is the expected behaviour in all cases.
+        let mut total_slot_hours = 0;
+        for slot in &task.slots {
+            total_slot_hours += slot.num_hours();
+        }
+        if total_slot_hours < task.duration {
+            task.duration = total_slot_hours;
+        }
+        task.calculate_flexibility();
+    }
+
+    tasks
+}
+
+//assigns slots to a task based on its after_time and before_time.
+//"i" is an index referring to a position in the time_slots vector.
+fn assign_slots(task: &mut Task, time_slots: &Vec<Slot>, i: &mut usize) {
+    let start = time_slots[*i];
+    let mut end = time_slots[*i];
+    for _ in 1..(task.size_of_slots_to_be_assigned()) as usize {
+        if *i < time_slots.len() - 1 {
+            *i += 1;
+            end = time_slots[*i];
+        }
+    }
+    let slot = Slot {
+        start: start.start,
+        end: end.end,
+    };
+
+    task.slots.push(slot);
+    //move the time_slots index to midnight so as not to add more slots on the same day
+    while time_slots[*i - 1].end.hour() != 0 {
+        *i += 1;
+        if *i == time_slots.len() {
+            break;
+        }
+    }
+}

--- a/src/task_placer.rs
+++ b/src/task_placer.rs
@@ -7,53 +7,9 @@ use crate::errors::Error;
 use crate::slot::Slot;
 use crate::task::Task;
 use crate::task::TaskStatus::{SCHEDULED, UNSCHEDULED};
-use crate::time_slot_iterator::{Repetition, TimeSlotIterator};
-use chrono::{NaiveDateTime, Timelike};
+use chrono::NaiveDateTime;
 
-pub fn task_placer(
-    mut tasks: Vec<Task>,
-    calendar_start: NaiveDateTime,
-    calendar_end: NaiveDateTime,
-) -> Vec<Task> {
-    //slide 1 (generate all time slots based on calendar dates)
-    let time_slot_iterator = TimeSlotIterator {
-        start: calendar_start,
-        end: calendar_end,
-        repetition: Repetition::HOURLY,
-    };
-    let time_slots: Vec<Slot> = time_slot_iterator.collect();
-
-    //slides 2 - 7 (assign slots to tasks)
-    for task in &mut tasks {
-        let mut i = 0;
-        while i < time_slots.len() {
-            //1) is the time_slot within the start and deadline dates of the task?
-            if !((time_slots[i].start >= task.start) && (time_slots[i].end < task.deadline)) {
-                i += 1;
-                continue;
-            }
-            //2) is the time_slot after the after_time of the task?
-            if !(time_slots[i].start.hour() >= task.after_time as u32) {
-                i += 1;
-                continue;
-            }
-            assign_slots(task, &time_slots, &mut i);
-
-            i += 1;
-        }
-        //if too few slots were assigned for the task (the remaining slots on calendar were not enough),
-        //truncate the task's duration.
-        //TODO: Need to confirm if this is the expected behaviour in all cases.
-        let mut total_slot_hours = 0;
-        for slot in &task.slots {
-            total_slot_hours += slot.num_hours();
-        }
-        if total_slot_hours < task.duration {
-            task.duration = total_slot_hours;
-        }
-        task.calculate_flexibility();
-    }
-
+pub fn task_placer(mut tasks: Vec<Task>) -> Vec<Task> {
     //slide 9 (schedule task(s) with flexibilityof 1)
     //TODO: currently we're assuming tasks with flex 1 are not conflicting.
     for index in 0..tasks.len() {
@@ -86,32 +42,6 @@ pub fn task_placer(
         }
     }
     tasks
-}
-
-//assigns slots to a task based on its after_time and before_time.
-//"i" is an index referring to a position in the time_slots vector.
-fn assign_slots(task: &mut Task, time_slots: &Vec<Slot>, i: &mut usize) {
-    let start = time_slots[*i];
-    let mut end = time_slots[*i];
-    for _ in 1..(task.size_of_slots_to_be_assigned()) as usize {
-        if *i < time_slots.len() - 1 {
-            *i += 1;
-            end = time_slots[*i];
-        }
-    }
-    let slot = Slot {
-        start: start.start,
-        end: end.end,
-    };
-
-    task.slots.push(slot);
-    //move the time_slots index to midnight so as not to add more slots on the same day
-    while time_slots[*i - 1].end.hour() != 0 {
-        *i += 1;
-        if *i == time_slots.len() {
-            break;
-        }
-    }
 }
 
 //when a task is scheduled, remove the time it occupies from other tasks' slots

--- a/src/unit_tests.rs
+++ b/src/unit_tests.rs
@@ -1,7 +1,7 @@
 use self::serde::*;
 use crate::{
-    goal::*, input::*, output_formatter::*, slot::*, task::TaskStatus::*, task::*,
-    task_generator::*, task_placer::*, time_slot_iterator::*,
+    goal::*, input::*, output_formatter::*, slot::*, slot_assigner::*, task::TaskStatus::*,
+    task::*, task_generator::*, task_placer::*, time_slot_iterator::*,
 };
 use chrono::*;
 
@@ -176,16 +176,17 @@ fn output_formatter_works() {
     let desired_output = r#"[{"taskid":0,"goalid":2,"title":"dentist","duration":1,"start":"2022-01-01T10:00:00","deadline":"2022-01-01T11:00:00"},{"taskid":1,"goalid":1,"title":"shopping","duration":1,"start":"2022-01-01T11:00:00","deadline":"2022-01-01T12:00:00"},{"taskid":2,"goalid":3,"title":"exercise","duration":1,"start":"2022-01-01T13:00:00","deadline":"2022-01-01T14:00:00"}]"#;
 
     let (calendar_start, calendar_end) = get_calendar_bounds();
-    let scheduled_tasks = task_placer(get_test_tasks(), calendar_start, calendar_end);
+    let assigned_tasks = slot_assigner(get_test_tasks(), calendar_start, calendar_end);
+    let scheduled_tasks = task_placer(assigned_tasks);
     let output = output_formatter(scheduled_tasks).unwrap();
     assert_eq!(desired_output, serde_json::to_string(&output).unwrap());
 }
 
 #[test]
 fn task_placer_slots_tasks_correctly() {
-    let tasks = get_test_tasks();
     let (calendar_start, calendar_end) = get_calendar_bounds();
-    let scheduled_tasks = task_placer(tasks, calendar_start, calendar_end);
+    let assigned_tasks = slot_assigner(get_test_tasks(), calendar_start, calendar_end);
+    let scheduled_tasks = task_placer(assigned_tasks);
     assert_eq!(scheduled_tasks[0].status, SCHEDULED);
     assert_eq!(scheduled_tasks[1].status, SCHEDULED);
     assert_eq!(scheduled_tasks[2].status, SCHEDULED);
@@ -462,9 +463,9 @@ fn get_calendar_bounds_2() -> (NaiveDateTime, NaiveDateTime) {
 
 #[test]
 fn task_placer_assigns_contiguous_slots() {
-    let tasks = get_test_tasks_2();
     let (calendar_start, calendar_end) = get_calendar_bounds_2();
-    let scheduled_tasks = task_placer(tasks, calendar_start, calendar_end);
+    let assigned_tasks = slot_assigner(get_test_tasks_2(), calendar_start, calendar_end);
+    let scheduled_tasks = task_placer(assigned_tasks);
     assert_eq!(scheduled_tasks[0].status, SCHEDULED);
     assert_eq!(scheduled_tasks[1].status, SCHEDULED);
     assert_eq!(scheduled_tasks[2].status, SCHEDULED);


### PR DESCRIPTION
This decouples the functionality of assigning slots to tasks from the task_placer and into its own separate module. Closes #157. Some of the other improvements mentioned in that issue's comments to be handled in separate pr.