### PR TITLE
put target back in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Cargo.lock
 .vscode
 .cargo
 outputformat.txt
+target/


### PR DESCRIPTION
target was not ignored ... probably done when trying to create a link to the build?

Can we put it back so I don't get 600+ commits when running cargo test?