### PR TITLE
Clean/internal marker

### DIFF
--- a/src/slot.rs
+++ b/src/slot.rs
@@ -109,4 +109,9 @@ impl Slot {
     pub fn num_hours(&self) -> usize {
         (self.end - self.start).num_hours() as usize
     }
+
+    pub fn conflicts_with(&self, other_slot: &Slot) -> bool {
+        !((self.start < other_slot.start && self.end <= other_slot.start)
+            || (self.start >= other_slot.end && self.end > other_slot.end))
+    }
 }

--- a/src/slot_generator.rs
+++ b/src/slot_generator.rs
@@ -51,10 +51,10 @@ pub fn slot_generator(
 }
 
 fn assign_slots(num_of_slots: usize, hours: &Vec<Slot>, i: &mut usize) -> Slot {
-    let start = dbg!(hours[*i]);
+    let start = hours[*i];
     let mut end = hours[*i];
     for _ in 1..num_of_slots as usize {
-        if *i < dbg!(hours.len() - 1) {
+        if *i < hours.len() - 1 {
             *i += 1;
             end = hours[*i];
         }

--- a/src/task.rs
+++ b/src/task.rs
@@ -23,7 +23,7 @@ pub struct Task {
     pub slots: Vec<Slot>,
     pub confirmed_start: Option<NaiveDateTime>,
     pub confirmed_deadline: Option<NaiveDateTime>,
-    pub internal_marker: NaiveDateTime,
+    internal_marker: NaiveDateTime,
 }
 
 impl Ord for Task {
@@ -48,8 +48,7 @@ impl Task {
         goal: &Goal,
     ) -> Self {
         //set internal_marker to first possible hour for the task
-        let mut internal_marker = start;
-        internal_marker += Duration::hours(goal.after_time.unwrap_or(0) as i64);
+        let internal_marker = slots[0].start;
         Self {
             id,
             goal_id: goal.id,
@@ -99,11 +98,9 @@ impl Task {
             return Err(Error::CannotSplit);
         }
         let mut tasks = Vec::new();
-        for i in 0..self.duration {
+        for _ in 0..self.duration {
             //set internal_marker to first possible hour for the task
-            let mut internal_marker = self.start;
-            internal_marker += Duration::hours(self.after_time as i64);
-
+            let internal_marker = self.get_slots()[0].start;
             let task = Task {
                 id: *counter,
                 goal_id: self.goal_id,
@@ -151,6 +148,10 @@ impl Task {
             if index != self.slots.len() - 1 {
                 self.internal_marker = self.slots[index + 1].start;
             }
+        }
+        //reset the internal_marker and return none
+        if !self.slots.is_empty() {
+            self.internal_marker = self.slots[0].start;
         }
         return None;
     }
@@ -202,6 +203,9 @@ impl Task {
             new_slots.extend(*slot - s);
         }
         self.slots = new_slots;
+        if !self.slots.is_empty() {
+            self.internal_marker = self.slots[0].start;
+        }
     }
 }
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -23,7 +23,6 @@ pub struct Task {
     pub slots: Vec<Slot>,
     pub confirmed_start: Option<NaiveDateTime>,
     pub confirmed_deadline: Option<NaiveDateTime>,
-    internal_marker: NaiveDateTime,
 }
 
 impl Ord for Task {
@@ -38,6 +37,56 @@ impl PartialOrd for Task {
     }
 }
 
+//An iterator for start/deadline combinations for the task.
+//e.g. if a task has duration of 2, and one slot with start 10 and end 14,
+//then the following start/deadline combinations are possible:
+//10-12, 11-13, and 12-14.
+//It also needs to handle scenarios where the task has multiple slots.
+pub struct StartDeadlineIterator {
+    slots: Vec<Slot>,
+    duration: usize,
+    marker: NaiveDateTime,
+}
+
+impl StartDeadlineIterator {
+    fn new(slots: Vec<Slot>, duration: usize) -> StartDeadlineIterator {
+        let marker = slots[0].start;
+        StartDeadlineIterator {
+            slots,
+            duration,
+            marker,
+        }
+    }
+}
+
+impl Iterator for StartDeadlineIterator {
+    type Item = Slot;
+    fn next(&mut self) -> Option<Self::Item> {
+        for (index, slot) in self.slots.iter().enumerate() {
+            if !(self.marker >= slot.start && self.marker < slot.end) {
+                continue;
+            }
+            while (self.marker + Duration::hours(self.duration as i64)) <= slot.end {
+                let start = self.marker;
+                let end = self.marker + Duration::hours(self.duration as i64);
+                self.marker += Duration::hours(1);
+                if self.marker == slot.end {
+                    if index != self.slots.len() - 1 {
+                        self.marker = self.slots[index + 1].start;
+                    }
+                }
+                return Some(Slot { start, end });
+            }
+
+            if index != self.slots.len() - 1 {
+                self.marker = self.slots[index + 1].start;
+            }
+        }
+
+        return None;
+    }
+}
+
 impl Task {
     pub fn new(
         id: usize,
@@ -47,8 +96,6 @@ impl Task {
         flexibility: usize,
         goal: &Goal,
     ) -> Self {
-        //set internal_marker to first possible hour for the task
-        let internal_marker = slots[0].start;
         Self {
             id,
             goal_id: goal.id,
@@ -63,7 +110,6 @@ impl Task {
             slots,
             confirmed_start: None,
             confirmed_deadline: None,
-            internal_marker,
         }
     }
 
@@ -99,8 +145,6 @@ impl Task {
         }
         let mut tasks = Vec::new();
         for _ in 0..self.duration {
-            //set internal_marker to first possible hour for the task
-            let internal_marker = self.get_slots()[0].start;
             let task = Task {
                 id: *counter,
                 goal_id: self.goal_id,
@@ -115,7 +159,6 @@ impl Task {
                 slots: self.get_slots(),
                 confirmed_start: None,
                 confirmed_deadline: None,
-                internal_marker,
             };
             *counter += 1;
             tasks.push(task);
@@ -123,42 +166,13 @@ impl Task {
         Ok(tasks)
     }
 
-    pub fn next_start_deadline_combination(&mut self) -> Option<(NaiveDateTime, NaiveDateTime)> {
-        //uses the internal_marker belonging to this task to keep track of the last attempted start
-        //time, and increments before the next call.
-        //note that if the task has multiple slots (which will be separated by an hr or more),
-        //the marker will be moved to the start of the next slot when it reaches the end of a
-        //particular slot.
-        for (index, slot) in self.slots.iter().enumerate() {
-            if !(self.internal_marker >= slot.start && self.internal_marker < slot.end) {
-                continue;
-            }
-            while (self.internal_marker + Duration::hours(self.duration as i64)) <= slot.end {
-                let start = self.internal_marker;
-                let end = self.internal_marker + Duration::hours(self.duration as i64);
-                self.internal_marker += Duration::hours(1);
-                if self.internal_marker == slot.end {
-                    if index != self.slots.len() - 1 {
-                        self.internal_marker = self.slots[index + 1].start;
-                    }
-                }
-                return Some((start, end));
-            }
-
-            if index != self.slots.len() - 1 {
-                self.internal_marker = self.slots[index + 1].start;
-            }
-        }
-        //reset the internal_marker and return none
-        if !self.slots.is_empty() {
-            self.internal_marker = self.slots[0].start;
-        }
-        return None;
+    pub fn start_deadline_iterator(&mut self) -> StartDeadlineIterator {
+        StartDeadlineIterator::new(self.get_slots(), self.duration)
     }
 
-    pub fn schedule(&mut self, start: NaiveDateTime, deadline: NaiveDateTime) {
-        self.set_confirmed_start(start);
-        self.set_confirmed_deadline(deadline);
+    pub fn schedule(&mut self, slot: Slot) {
+        self.set_confirmed_start(slot.start);
+        self.set_confirmed_deadline(slot.end);
         self.status = TaskStatus::SCHEDULED;
     }
 
@@ -203,9 +217,6 @@ impl Task {
             new_slots.extend(*slot - s);
         }
         self.slots = new_slots;
-        if !self.slots.is_empty() {
-            self.internal_marker = self.slots[0].start;
-        }
     }
 }
 

--- a/src/task_placer.rs
+++ b/src/task_placer.rs
@@ -52,9 +52,6 @@ fn remove_slots_from_tasks(tasks: &mut Vec<Task>, start: NaiveDateTime, deadline
             end: deadline,
         };
         task.remove_slot(s);
-        if !task.slots.is_empty() {
-            task.internal_marker = task.slots[0].start;
-        }
     }
 }
 
@@ -83,8 +80,6 @@ fn schedule_tasks(tasks: &mut Vec<Task>) {
         if tasks[i].status == SCHEDULED {
             continue;
         }
-        //Place internal marker at first possible hour of task
-        tasks[i].internal_marker = tasks[i].slots[0].start;
         'slot_loop: while let Some((desired_start, desired_deadline)) =
             tasks[i].next_start_deadline_combination()
         {

--- a/src/unit_tests.rs
+++ b/src/unit_tests.rs
@@ -79,41 +79,6 @@ fn time_slot_iterator_returns_all_mondays() {
     )
 }
 
-#[test]
-fn goal_generates_single_nonrepetitive_task() {
-    let goal = Goal::new(1)
-        .duration(1)
-        .start(NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0))
-        .deadline(NaiveDate::from_ymd(2022, 1, 4).and_hms(0, 0, 0));
-    let mut counter = 0;
-    assert_eq!(
-        goal.generate_tasks(
-            NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0),
-            NaiveDate::from_ymd(2022, 1, 4).and_hms(0, 0, 0),
-            &mut counter
-        ),
-        vec![Task {
-            id: 0,
-            goal_id: 1,
-            title: "Test".to_string(),
-            duration: 1,
-            status: TaskStatus::UNSCHEDULED,
-            flexibility: 72,
-            start: NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0),
-            deadline: NaiveDate::from_ymd(2022, 1, 4).and_hms(0, 0, 0),
-            after_time: 0,
-            before_time: 24,
-            slots: vec!(Slot {
-                start: NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0),
-                end: NaiveDate::from_ymd(2022, 1, 4).and_hms(0, 0, 0)
-            }),
-            confirmed_start: None,
-            confirmed_deadline: None,
-            internal_marker: NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0),
-        },]
-    )
-}
-
 fn get_calendar_bounds() -> (NaiveDateTime, NaiveDateTime) {
     (
         (NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0)),


### PR DESCRIPTION
This is related to #158. It improves the code by not allowing the `internal_marker` to be modified externally.

I'd like to attempt an alternate approach that will allow us to avoid using the `internal_marker` altogether: implementing `Iterator` on `Task` for iterating over valid start/deadline combinations for the task. Might be more idiomatic this way.

Marking as draft while I attempt this and compare.