### PR TITLE
feat: add cargo clippy to the workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,12 +25,14 @@ jobs:
       with:
           toolchain: nightly
           override: true
-          components: rustfmt clippy
+          components: rustfmt
     - name: Run rust fmt
       uses: actions-rs/cargo@v1
       with:
           command: fmt
           args: --all -- --check
+    - name: Install clippy component
+      run: rustup component add clippy
     - name: Run rust clippy
       uses: actions-rs/cargo@v1
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,9 +25,16 @@ jobs:
       with:
           toolchain: nightly
           override: true
-          components: rustfmt
+          components: rustfmt clippy
     - name: Run rust fmt
       uses: actions-rs/cargo@v1
       with:
           command: fmt
           args: --all -- --check
+    - name: Run rust clippy
+      uses: actions-rs/cargo@v1
+      with:
+          command: clippy
+          args: --release -- -D warnings
+
+

--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 use std::path::PathBuf;
 
 fn write_test(file: &mut std::fs::File, content: &mut str) -> Result<(), std::io::Error> {
-    write!(file, "{}\n", content)?;
+    writeln!(file, "{}", content)?;
     Ok(())
 }
 


### PR DESCRIPTION
Related to #229 

Feature to add checking code quality by running command `cargo clippy`.
