### PR TITLE
fix: filter timing issue consider extra hours out of deadline

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,4 +142,8 @@ IDEA: This is to uniform location for notes related to similar bugs/concepts/iss
     - Task::remove_taken_slots(&mut self, s: Slot)
     - Timeline::remove_slots(&mut self, slots_to_remove: Vec<Slot>)
 
+# 2023-06-07
+- For filter_timing, "sleep" task in bug_215, on the last slot it consider few hours
+more out of deadline than it should.
+
 */

--- a/src/mocking/mod.rs
+++ b/src/mocking/mod.rs
@@ -132,6 +132,45 @@ impl Task {
             goal_id: "1".to_string(),
         }
     }
+
+    /// Mock a Scheduled Task
+    /// ```
+    /// Task {
+    ///     id: id,
+    ///     goal_id: goal_id,
+    ///     title: title,
+    ///     duration: duration,
+    ///     status: TaskStatus::Scheduled,
+    ///     flexibility: flexibility,
+    ///     start: task_timing.start,
+    ///     deadline: task_timing.end,
+    ///     slots: vec![],
+    ///     tags: vec![],
+    ///     after_goals: None
+    ///}
+    /// ```
+    pub fn mock_scheduled(
+        id: usize,
+        goal_id: &str,
+        title: &str,
+        duration: usize,
+        flexibility: usize,
+        task_timing: Slot,
+    ) -> Task {
+        Task {
+            id: id,
+            goal_id: goal_id.to_string(),
+            title: title.to_string(),
+            duration,
+            status: TaskStatus::Scheduled,
+            flexibility,
+            start: Some(task_timing.start),
+            deadline: Some(task_timing.end),
+            slots: vec![],
+            tags: vec![],
+            after_goals: None,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -165,6 +204,38 @@ mod tests {
 
             let result = Task::mock("test", 1, 168, TaskStatus::ReadyToSchedule, slots);
 
+            assert_eq!(expected, result);
+        }
+
+        #[test]
+        fn test_mock_scheduled() {
+            let expected_task_timing = Slot::mock(Duration::days(1), 2023, 5, 1, 0, 0);
+
+            let expected = Task {
+                id: 1,
+                goal_id: "1".to_string(),
+                title: "Sheduled Task".to_string(),
+                duration: 1,
+                status: TaskStatus::Scheduled,
+                flexibility: 168,
+                start: Some(expected_task_timing.start),
+                deadline: Some(expected_task_timing.end),
+                slots: vec![],
+                tags: vec![],
+                after_goals: None,
+            };
+
+            let result = Task::mock_scheduled(
+                1,
+                "1",
+                "Sheduled Task",
+                1,
+                168,
+                Slot::mock(Duration::days(1), 2023, 5, 1, 0, 0),
+            );
+
+            dbg!(&result, &expected);
+            assert_eq!(expected.status, result.status);
             assert_eq!(expected, result);
         }
     }

--- a/src/models/task/impls.rs
+++ b/src/models/task/impls.rs
@@ -151,6 +151,9 @@ impl Task {
     }
 
     pub fn remove_slot(&mut self, s: Slot) {
+        // Todo 2023-06-08: develop a rule when chosen_slot > task.slot,
+        //which will not removed from task.slot
+
         //Todo: duplicate of remove_taken_slots?
         if self.status == TaskStatus::Scheduled {
             return;

--- a/src/services/flexibility.rs
+++ b/src/services/flexibility.rs
@@ -4,6 +4,7 @@ use crate::models::{
 };
 
 impl TasksToPlace {
+    /// Calculate flexibility for each task in tasks then sort them
     pub fn sort_on_flexibility(&mut self) {
         self.calculate_flexibilities();
         self.tasks.sort();
@@ -20,10 +21,11 @@ impl Task {
     /// Calculate flexibility of a task slots
     pub fn calculate_flexibility(&mut self) {
         if self.status == TaskStatus::Scheduled || self.status == TaskStatus::Impossible {
-            dbg!(
+            let message = format!(
                 "TaskStatus must be ReadyToSchedule, but it is now TaskStatus::{:?}",
                 self.status.clone()
             );
+            dbg!(message);
             return;
         }
 

--- a/src/services/placer/find_best_slots.rs
+++ b/src/services/placer/find_best_slots.rs
@@ -85,7 +85,7 @@ impl Slot {
         }
     }
 
-    /// Generate list of schedulable slots which can be scheduled in give
+    /// Generate list of schedulable slots which can be scheduled in a given
     /// slot based on given slot's duration and given slot
     /// - Example:
     ///     ```

--- a/src/services/placer/mod.rs
+++ b/src/services/placer/mod.rs
@@ -197,7 +197,7 @@ mod tests {
 
     /// Simulating test case bug_215 when coming to the function `task_placer`
     #[test]
-    #[ignore]
+    // #[ignore]
     fn test_task_placer_to_simulate_bug_215() {
         /*
         TODO 2023-06-05  | Debug notes
@@ -205,7 +205,9 @@ mod tests {
         - For task: "water the plants indoors", correct flexiblity is 14 but it is calculated as 34.
             - FIXME 2023-06-06 | For task: "water the plants indoors", it added slots out of budget. It is noticed inside funciton `schedule`, after function `tasks_to_place.sort_on_flexibility()` and before calling function `find_best_slots`
         - For task: "sleep", correct flexibility is 19 but it is calculated as 22.
-        - Task::mock function should support customize fields "start" and "deadline".
+
+        # 2023-06-08
+        - Tasks after function `task_placer` have inaccurate fields "id" and "goal_id"
         */
 
         let calendar_timing = Slot::mock(Duration::days(7), 2023, 01, 03, 0, 0);
@@ -321,7 +323,7 @@ mod tests {
                     Slot::mock(Duration::hours(10), 2023, 01, 06, 22, 0),
                     Slot::mock(Duration::hours(10), 2023, 01, 07, 22, 0),
                     Slot::mock(Duration::hours(10), 2023, 01, 08, 22, 0),
-                    Slot::mock(Duration::hours(10), 2023, 01, 09, 22, 0),
+                    Slot::mock(Duration::hours(2), 2023, 01, 09, 22, 0),
                 ],
             ),
         ];
@@ -343,61 +345,69 @@ mod tests {
         dbg!(&tasks_to_place);
 
         let expected_tasks: Vec<Task> = vec![
-            Task::mock(
+            Task::mock_scheduled(
+                9,
+                "1",
                 "me time",
                 1,
                 168,
-                TaskStatus::ReadyToSchedule,
-                vec![Slot::mock(chrono::Duration::hours(1), 2023, 1, 3, 09, 0)],
+                Slot::mock(chrono::Duration::hours(1), 2023, 1, 3, 09, 0),
             ),
-            Task::mock(
+            Task::mock_scheduled(
+                9,
+                "1",
                 "walk",
                 1,
                 42,
-                TaskStatus::ReadyToSchedule,
-                vec![Slot::mock(chrono::Duration::hours(1), 2023, 1, 3, 14, 0)],
+                Slot::mock(chrono::Duration::hours(1), 2023, 1, 3, 14, 0),
             ),
-            Task::mock(
+            Task::mock_scheduled(
+                9,
+                "1",
                 "dinner",
                 1,
                 21,
-                TaskStatus::ReadyToSchedule,
-                vec![Slot::mock(chrono::Duration::hours(1), 2023, 1, 3, 18, 0)],
+                Slot::mock(chrono::Duration::hours(1), 2023, 1, 3, 18, 0),
             ),
-            Task::mock(
+            Task::mock_scheduled(
+                9,
+                "1",
                 "breakfast",
                 1,
                 21,
-                TaskStatus::ReadyToSchedule,
-                vec![Slot::mock(chrono::Duration::hours(1), 2023, 1, 3, 08, 0)],
+                Slot::mock(chrono::Duration::hours(1), 2023, 1, 3, 08, 0),
             ),
-            Task::mock(
+            Task::mock_scheduled(
+                9,
+                "1",
                 "sleep",
                 8,
                 19,
-                TaskStatus::ReadyToSchedule,
-                vec![Slot::mock(Duration::hours(8), 2023, 01, 03, 0, 0)],
+                Slot::mock(Duration::hours(8), 2023, 01, 03, 0, 0),
             ),
-            Task::mock(
+            Task::mock_scheduled(
+                9,
+                "1",
                 "water the plants indoors",
                 1,
                 14,
-                TaskStatus::ReadyToSchedule,
-                vec![Slot::mock(chrono::Duration::hours(1), 2023, 1, 4, 1, 0)],
+                Slot::mock(chrono::Duration::hours(1), 2023, 1, 4, 1, 0),
             ),
-            Task::mock(
+            Task::mock_scheduled(
+                9,
+                "1",
                 "lunch",
                 1,
                 14,
-                TaskStatus::ReadyToSchedule,
-                vec![Slot::mock(chrono::Duration::hours(1), 2023, 1, 3, 12, 0)],
+                Slot::mock(chrono::Duration::hours(1), 2023, 1, 3, 12, 0),
             ),
-            Task::mock(
+            Task::mock_scheduled(
+                9,
+                "1",
                 "hurdle",
                 2,
                 7,
-                TaskStatus::ReadyToSchedule,
-                vec![Slot::mock(chrono::Duration::hours(2), 2023, 1, 5, 1, 0)],
+                Slot::mock(chrono::Duration::hours(2), 2023, 1, 5, 1, 0),
             ),
         ];
 

--- a/src/services/placer/mod.rs
+++ b/src/services/placer/mod.rs
@@ -197,7 +197,7 @@ mod tests {
 
     /// Simulating test case bug_215 when coming to the function `task_placer`
     #[test]
-    // #[ignore]
+    #[ignore]
     fn test_task_placer_to_simulate_bug_215() {
         /*
         TODO 2023-06-05  | Debug notes

--- a/tests/jsons/basic-2/actual_output.json
+++ b/tests/jsons/basic-2/actual_output.json
@@ -7,28 +7,20 @@
           "taskid": 0,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 10,
           "start": "2022-01-01T00:00:00",
-          "deadline": "2022-01-01T08:00:00"
+          "deadline": "2022-01-01T10:00:00"
         },
         {
           "taskid": 1,
           "goalid": "2",
           "title": "presentation",
           "duration": 1,
-          "start": "2022-01-01T08:00:00",
-          "deadline": "2022-01-01T09:00:00"
-        },
-        {
-          "taskid": 2,
-          "goalid": "free",
-          "title": "free",
-          "duration": 2,
-          "start": "2022-01-01T09:00:00",
+          "start": "2022-01-01T10:00:00",
           "deadline": "2022-01-01T11:00:00"
         },
         {
-          "taskid": 3,
+          "taskid": 2,
           "goalid": "3",
           "title": "swimming_class",
           "duration": 2,
@@ -36,7 +28,7 @@
           "deadline": "2022-01-01T13:00:00"
         },
         {
-          "taskid": 4,
+          "taskid": 3,
           "goalid": "1",
           "title": "group_discussion",
           "duration": 3,
@@ -44,7 +36,7 @@
           "deadline": "2022-01-01T16:00:00"
         },
         {
-          "taskid": 5,
+          "taskid": 4,
           "goalid": "free",
           "title": "free",
           "duration": 8,

--- a/tests/jsons/budget-with-no-children/actual_output.json
+++ b/tests/jsons/budget-with-no-children/actual_output.json
@@ -21,8 +21,8 @@
         },
         {
           "taskid": 2,
-          "goalid": "6d71c60f-b9f2-4ad8-b80e-87c38dfb7ec3",
-          "title": "Work",
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2018-01-01T07:00:00",
           "deadline": "2018-01-01T09:00:00"
@@ -37,8 +37,8 @@
         },
         {
           "taskid": 4,
-          "goalid": "6d71c60f-b9f2-4ad8-b80e-87c38dfb7ec3",
-          "title": "Work",
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2018-01-01T10:00:00",
           "deadline": "2018-01-01T12:00:00"
@@ -53,8 +53,8 @@
         },
         {
           "taskid": 6,
-          "goalid": "6d71c60f-b9f2-4ad8-b80e-87c38dfb7ec3",
-          "title": "Work",
+          "goalid": "free",
+          "title": "free",
           "duration": 1,
           "start": "2018-01-01T13:00:00",
           "deadline": "2018-01-01T14:00:00"
@@ -69,8 +69,8 @@
         },
         {
           "taskid": 8,
-          "goalid": "6d71c60f-b9f2-4ad8-b80e-87c38dfb7ec3",
-          "title": "Work",
+          "goalid": "free",
+          "title": "free",
           "duration": 3,
           "start": "2018-01-01T15:00:00",
           "deadline": "2018-01-01T18:00:00"
@@ -85,8 +85,8 @@
         },
         {
           "taskid": 10,
-          "goalid": "6d71c60f-b9f2-4ad8-b80e-87c38dfb7ec3",
-          "title": "Work",
+          "goalid": "free",
+          "title": "free",
           "duration": 5,
           "start": "2018-01-01T19:00:00",
           "deadline": "2018-01-02T00:00:00"
@@ -114,8 +114,8 @@
         },
         {
           "taskid": 13,
-          "goalid": "6d71c60f-b9f2-4ad8-b80e-87c38dfb7ec3",
-          "title": "Work",
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2018-01-02T07:00:00",
           "deadline": "2018-01-02T09:00:00"
@@ -130,8 +130,8 @@
         },
         {
           "taskid": 15,
-          "goalid": "6d71c60f-b9f2-4ad8-b80e-87c38dfb7ec3",
-          "title": "Work",
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2018-01-02T10:00:00",
           "deadline": "2018-01-02T12:00:00"
@@ -146,8 +146,8 @@
         },
         {
           "taskid": 17,
-          "goalid": "6d71c60f-b9f2-4ad8-b80e-87c38dfb7ec3",
-          "title": "Work",
+          "goalid": "free",
+          "title": "free",
           "duration": 1,
           "start": "2018-01-02T13:00:00",
           "deadline": "2018-01-02T14:00:00"
@@ -162,8 +162,8 @@
         },
         {
           "taskid": 19,
-          "goalid": "6d71c60f-b9f2-4ad8-b80e-87c38dfb7ec3",
-          "title": "Work",
+          "goalid": "free",
+          "title": "free",
           "duration": 3,
           "start": "2018-01-02T15:00:00",
           "deadline": "2018-01-02T18:00:00"
@@ -178,8 +178,8 @@
         },
         {
           "taskid": 21,
-          "goalid": "6d71c60f-b9f2-4ad8-b80e-87c38dfb7ec3",
-          "title": "Work",
+          "goalid": "free",
+          "title": "free",
           "duration": 5,
           "start": "2018-01-02T19:00:00",
           "deadline": "2018-01-03T00:00:00"
@@ -207,8 +207,8 @@
         },
         {
           "taskid": 24,
-          "goalid": "6d71c60f-b9f2-4ad8-b80e-87c38dfb7ec3",
-          "title": "Work",
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2018-01-03T07:00:00",
           "deadline": "2018-01-03T09:00:00"
@@ -223,8 +223,8 @@
         },
         {
           "taskid": 26,
-          "goalid": "6d71c60f-b9f2-4ad8-b80e-87c38dfb7ec3",
-          "title": "Work",
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2018-01-03T10:00:00",
           "deadline": "2018-01-03T12:00:00"
@@ -239,8 +239,8 @@
         },
         {
           "taskid": 28,
-          "goalid": "6d71c60f-b9f2-4ad8-b80e-87c38dfb7ec3",
-          "title": "Work",
+          "goalid": "free",
+          "title": "free",
           "duration": 1,
           "start": "2018-01-03T13:00:00",
           "deadline": "2018-01-03T14:00:00"
@@ -255,8 +255,8 @@
         },
         {
           "taskid": 30,
-          "goalid": "6d71c60f-b9f2-4ad8-b80e-87c38dfb7ec3",
-          "title": "Work",
+          "goalid": "free",
+          "title": "free",
           "duration": 3,
           "start": "2018-01-03T15:00:00",
           "deadline": "2018-01-03T18:00:00"
@@ -271,8 +271,8 @@
         },
         {
           "taskid": 32,
-          "goalid": "6d71c60f-b9f2-4ad8-b80e-87c38dfb7ec3",
-          "title": "Work",
+          "goalid": "free",
+          "title": "free",
           "duration": 5,
           "start": "2018-01-03T19:00:00",
           "deadline": "2018-01-04T00:00:00"
@@ -300,22 +300,14 @@
         },
         {
           "taskid": 35,
-          "goalid": "6d71c60f-b9f2-4ad8-b80e-87c38dfb7ec3",
-          "title": "Work",
-          "duration": 1,
-          "start": "2018-01-04T07:00:00",
-          "deadline": "2018-01-04T08:00:00"
-        },
-        {
-          "taskid": 36,
           "goalid": "free",
           "title": "free",
-          "duration": 1,
-          "start": "2018-01-04T08:00:00",
+          "duration": 2,
+          "start": "2018-01-04T07:00:00",
           "deadline": "2018-01-04T09:00:00"
         },
         {
-          "taskid": 37,
+          "taskid": 36,
           "goalid": "05a6b43c-3c50-48e1-9c6a-3a01cdcd102f",
           "title": "Me time 🧘🏽😌",
           "duration": 1,
@@ -323,7 +315,7 @@
           "deadline": "2018-01-04T10:00:00"
         },
         {
-          "taskid": 38,
+          "taskid": 37,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -331,7 +323,7 @@
           "deadline": "2018-01-04T12:00:00"
         },
         {
-          "taskid": 39,
+          "taskid": 38,
           "goalid": "6ce569f4-b8e1-4df9-8d2a-b55ea7ffcff8",
           "title": "Lunch 🥪",
           "duration": 1,
@@ -339,7 +331,7 @@
           "deadline": "2018-01-04T13:00:00"
         },
         {
-          "taskid": 40,
+          "taskid": 39,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -347,7 +339,7 @@
           "deadline": "2018-01-04T14:00:00"
         },
         {
-          "taskid": 41,
+          "taskid": 40,
           "goalid": "0c37df98-dbd4-4226-bc74-47d7dc317bbf",
           "title": "Walk 🚶🏽",
           "duration": 1,
@@ -355,7 +347,7 @@
           "deadline": "2018-01-04T15:00:00"
         },
         {
-          "taskid": 42,
+          "taskid": 41,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -363,7 +355,7 @@
           "deadline": "2018-01-04T18:00:00"
         },
         {
-          "taskid": 43,
+          "taskid": 42,
           "goalid": "d7b56844-87eb-43b3-b0db-807128133e5d",
           "title": "Dinner 🍽️",
           "duration": 1,
@@ -371,7 +363,7 @@
           "deadline": "2018-01-04T19:00:00"
         },
         {
-          "taskid": 44,
+          "taskid": 43,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -384,7 +376,7 @@
       "day": "2018-01-05",
       "outputs": [
         {
-          "taskid": 45,
+          "taskid": 44,
           "goalid": "749b306c-a025-4b1b-b945-71939189868d",
           "title": "Sleep 😴🌙",
           "duration": 6,
@@ -392,7 +384,7 @@
           "deadline": "2018-01-05T06:00:00"
         },
         {
-          "taskid": 46,
+          "taskid": 45,
           "goalid": "84bd2e15-9771-42b2-81f7-c83e6f25801b",
           "title": "Breakfast 🥐🥣",
           "duration": 1,
@@ -400,7 +392,7 @@
           "deadline": "2018-01-05T07:00:00"
         },
         {
-          "taskid": 47,
+          "taskid": 46,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -408,7 +400,7 @@
           "deadline": "2018-01-05T09:00:00"
         },
         {
-          "taskid": 48,
+          "taskid": 47,
           "goalid": "05a6b43c-3c50-48e1-9c6a-3a01cdcd102f",
           "title": "Me time 🧘🏽😌",
           "duration": 1,
@@ -416,7 +408,7 @@
           "deadline": "2018-01-05T10:00:00"
         },
         {
-          "taskid": 49,
+          "taskid": 48,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -424,7 +416,7 @@
           "deadline": "2018-01-05T12:00:00"
         },
         {
-          "taskid": 50,
+          "taskid": 49,
           "goalid": "6ce569f4-b8e1-4df9-8d2a-b55ea7ffcff8",
           "title": "Lunch 🥪",
           "duration": 1,
@@ -432,7 +424,7 @@
           "deadline": "2018-01-05T13:00:00"
         },
         {
-          "taskid": 51,
+          "taskid": 50,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -440,7 +432,7 @@
           "deadline": "2018-01-05T14:00:00"
         },
         {
-          "taskid": 52,
+          "taskid": 51,
           "goalid": "0c37df98-dbd4-4226-bc74-47d7dc317bbf",
           "title": "Walk 🚶🏽",
           "duration": 1,
@@ -448,7 +440,7 @@
           "deadline": "2018-01-05T15:00:00"
         },
         {
-          "taskid": 53,
+          "taskid": 52,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -456,7 +448,7 @@
           "deadline": "2018-01-05T18:00:00"
         },
         {
-          "taskid": 54,
+          "taskid": 53,
           "goalid": "d7b56844-87eb-43b3-b0db-807128133e5d",
           "title": "Dinner 🍽️",
           "duration": 1,
@@ -464,7 +456,7 @@
           "deadline": "2018-01-05T19:00:00"
         },
         {
-          "taskid": 55,
+          "taskid": 54,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -477,7 +469,7 @@
       "day": "2018-01-06",
       "outputs": [
         {
-          "taskid": 56,
+          "taskid": 55,
           "goalid": "749b306c-a025-4b1b-b945-71939189868d",
           "title": "Sleep 😴🌙",
           "duration": 6,
@@ -485,7 +477,7 @@
           "deadline": "2018-01-06T06:00:00"
         },
         {
-          "taskid": 57,
+          "taskid": 56,
           "goalid": "84bd2e15-9771-42b2-81f7-c83e6f25801b",
           "title": "Breakfast 🥐🥣",
           "duration": 1,
@@ -493,7 +485,7 @@
           "deadline": "2018-01-06T07:00:00"
         },
         {
-          "taskid": 58,
+          "taskid": 57,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -501,7 +493,7 @@
           "deadline": "2018-01-06T09:00:00"
         },
         {
-          "taskid": 59,
+          "taskid": 58,
           "goalid": "05a6b43c-3c50-48e1-9c6a-3a01cdcd102f",
           "title": "Me time 🧘🏽😌",
           "duration": 1,
@@ -509,7 +501,7 @@
           "deadline": "2018-01-06T10:00:00"
         },
         {
-          "taskid": 60,
+          "taskid": 59,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -517,7 +509,7 @@
           "deadline": "2018-01-06T12:00:00"
         },
         {
-          "taskid": 61,
+          "taskid": 60,
           "goalid": "6ce569f4-b8e1-4df9-8d2a-b55ea7ffcff8",
           "title": "Lunch 🥪",
           "duration": 1,
@@ -525,7 +517,7 @@
           "deadline": "2018-01-06T13:00:00"
         },
         {
-          "taskid": 62,
+          "taskid": 61,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -533,7 +525,7 @@
           "deadline": "2018-01-06T14:00:00"
         },
         {
-          "taskid": 63,
+          "taskid": 62,
           "goalid": "0c37df98-dbd4-4226-bc74-47d7dc317bbf",
           "title": "Walk 🚶🏽",
           "duration": 1,
@@ -541,7 +533,7 @@
           "deadline": "2018-01-06T15:00:00"
         },
         {
-          "taskid": 64,
+          "taskid": 63,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -549,7 +541,7 @@
           "deadline": "2018-01-06T18:00:00"
         },
         {
-          "taskid": 65,
+          "taskid": 64,
           "goalid": "d7b56844-87eb-43b3-b0db-807128133e5d",
           "title": "Dinner 🍽️",
           "duration": 1,
@@ -557,7 +549,7 @@
           "deadline": "2018-01-06T19:00:00"
         },
         {
-          "taskid": 66,
+          "taskid": 65,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -570,7 +562,7 @@
       "day": "2018-01-07",
       "outputs": [
         {
-          "taskid": 67,
+          "taskid": 66,
           "goalid": "749b306c-a025-4b1b-b945-71939189868d",
           "title": "Sleep 😴🌙",
           "duration": 6,
@@ -578,7 +570,7 @@
           "deadline": "2018-01-07T06:00:00"
         },
         {
-          "taskid": 68,
+          "taskid": 67,
           "goalid": "84bd2e15-9771-42b2-81f7-c83e6f25801b",
           "title": "Breakfast 🥐🥣",
           "duration": 1,
@@ -586,7 +578,7 @@
           "deadline": "2018-01-07T07:00:00"
         },
         {
-          "taskid": 69,
+          "taskid": 68,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -594,7 +586,7 @@
           "deadline": "2018-01-07T09:00:00"
         },
         {
-          "taskid": 70,
+          "taskid": 69,
           "goalid": "05a6b43c-3c50-48e1-9c6a-3a01cdcd102f",
           "title": "Me time 🧘🏽😌",
           "duration": 1,
@@ -602,7 +594,7 @@
           "deadline": "2018-01-07T10:00:00"
         },
         {
-          "taskid": 71,
+          "taskid": 70,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -610,7 +602,7 @@
           "deadline": "2018-01-07T12:00:00"
         },
         {
-          "taskid": 72,
+          "taskid": 71,
           "goalid": "6ce569f4-b8e1-4df9-8d2a-b55ea7ffcff8",
           "title": "Lunch 🥪",
           "duration": 1,
@@ -618,7 +610,7 @@
           "deadline": "2018-01-07T13:00:00"
         },
         {
-          "taskid": 73,
+          "taskid": 72,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -626,7 +618,7 @@
           "deadline": "2018-01-07T14:00:00"
         },
         {
-          "taskid": 74,
+          "taskid": 73,
           "goalid": "0c37df98-dbd4-4226-bc74-47d7dc317bbf",
           "title": "Walk 🚶🏽",
           "duration": 1,
@@ -634,7 +626,7 @@
           "deadline": "2018-01-07T15:00:00"
         },
         {
-          "taskid": 75,
+          "taskid": 74,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -642,7 +634,7 @@
           "deadline": "2018-01-07T18:00:00"
         },
         {
-          "taskid": 76,
+          "taskid": 75,
           "goalid": "d7b56844-87eb-43b3-b0db-807128133e5d",
           "title": "Dinner 🍽️",
           "duration": 1,
@@ -650,7 +642,7 @@
           "deadline": "2018-01-07T19:00:00"
         },
         {
-          "taskid": 77,
+          "taskid": 76,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -663,7 +655,16 @@
   "impossible": [
     {
       "day": "2018-01-01",
-      "outputs": []
+      "outputs": [
+        {
+          "taskid": 77,
+          "goalid": "6d71c60f-b9f2-4ad8-b80e-87c38dfb7ec3",
+          "title": "Work",
+          "duration": 40,
+          "start": "2018-01-01T00:00:00",
+          "deadline": "2018-01-08T00:00:00"
+        }
+      ]
     },
     {
       "day": "2018-01-02",

--- a/tests/jsons/bug-215/actual_output.json
+++ b/tests/jsons/bug-215/actual_output.json
@@ -5,46 +5,38 @@
       "outputs": [
         {
           "taskid": 0,
-          "goalid": "free",
-          "title": "free",
+          "goalid": "8",
+          "title": "water the plants indoors",
           "duration": 1,
           "start": "2023-01-03T00:00:00",
           "deadline": "2023-01-03T01:00:00"
         },
         {
           "taskid": 1,
-          "goalid": "8",
-          "title": "water the plants indoors",
-          "duration": 1,
-          "start": "2023-01-03T01:00:00",
-          "deadline": "2023-01-03T02:00:00"
+          "goalid": "1",
+          "title": "sleep",
+          "duration": 8,
+          "start": "2023-01-03T00:00:00",
+          "deadline": "2023-01-03T08:00:00"
         },
         {
           "taskid": 2,
-          "goalid": "free",
-          "title": "free",
-          "duration": 4,
-          "start": "2023-01-03T02:00:00",
-          "deadline": "2023-01-03T06:00:00"
+          "goalid": "2",
+          "title": "hurdle",
+          "duration": 2,
+          "start": "2023-01-03T03:00:00",
+          "deadline": "2023-01-03T05:00:00"
         },
         {
           "taskid": 3,
           "goalid": "5",
           "title": "breakfast",
           "duration": 1,
-          "start": "2023-01-03T06:00:00",
-          "deadline": "2023-01-03T07:00:00"
-        },
-        {
-          "taskid": 4,
-          "goalid": "free",
-          "title": "free",
-          "duration": 2,
-          "start": "2023-01-03T07:00:00",
+          "start": "2023-01-03T08:00:00",
           "deadline": "2023-01-03T09:00:00"
         },
         {
-          "taskid": 5,
+          "taskid": 4,
           "goalid": "4",
           "title": "me time",
           "duration": 1,
@@ -52,7 +44,7 @@
           "deadline": "2023-01-03T10:00:00"
         },
         {
-          "taskid": 6,
+          "taskid": 5,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -60,7 +52,7 @@
           "deadline": "2023-01-03T12:00:00"
         },
         {
-          "taskid": 7,
+          "taskid": 6,
           "goalid": "3",
           "title": "lunch",
           "duration": 1,
@@ -68,7 +60,7 @@
           "deadline": "2023-01-03T13:00:00"
         },
         {
-          "taskid": 8,
+          "taskid": 7,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -76,7 +68,7 @@
           "deadline": "2023-01-03T14:00:00"
         },
         {
-          "taskid": 9,
+          "taskid": 8,
           "goalid": "6",
           "title": "walk",
           "duration": 1,
@@ -84,7 +76,7 @@
           "deadline": "2023-01-03T15:00:00"
         },
         {
-          "taskid": 10,
+          "taskid": 9,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -92,7 +84,7 @@
           "deadline": "2023-01-03T18:00:00"
         },
         {
-          "taskid": 11,
+          "taskid": 10,
           "goalid": "7",
           "title": "dinner",
           "duration": 1,
@@ -100,19 +92,11 @@
           "deadline": "2023-01-03T19:00:00"
         },
         {
-          "taskid": 12,
+          "taskid": 11,
           "goalid": "free",
           "title": "free",
-          "duration": 3,
+          "duration": 5,
           "start": "2023-01-03T19:00:00",
-          "deadline": "2023-01-03T22:00:00"
-        },
-        {
-          "taskid": 13,
-          "goalid": "2",
-          "title": "hurdle",
-          "duration": 2,
-          "start": "2023-01-03T22:00:00",
           "deadline": "2023-01-04T00:00:00"
         }
       ]
@@ -121,7 +105,7 @@
       "day": "2023-01-04",
       "outputs": [
         {
-          "taskid": 14,
+          "taskid": 12,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -134,7 +118,7 @@
       "day": "2023-01-05",
       "outputs": [
         {
-          "taskid": 15,
+          "taskid": 13,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -147,7 +131,7 @@
       "day": "2023-01-06",
       "outputs": [
         {
-          "taskid": 16,
+          "taskid": 14,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -160,7 +144,7 @@
       "day": "2023-01-07",
       "outputs": [
         {
-          "taskid": 17,
+          "taskid": 15,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -173,7 +157,7 @@
       "day": "2023-01-08",
       "outputs": [
         {
-          "taskid": 18,
+          "taskid": 16,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -186,19 +170,11 @@
       "day": "2023-01-09",
       "outputs": [
         {
-          "taskid": 19,
+          "taskid": 17,
           "goalid": "free",
           "title": "free",
-          "duration": 22,
+          "duration": 24,
           "start": "2023-01-09T00:00:00",
-          "deadline": "2023-01-09T22:00:00"
-        },
-        {
-          "taskid": 20,
-          "goalid": "1",
-          "title": "sleep",
-          "duration": 2,
-          "start": "2023-01-09T22:00:00",
           "deadline": "2023-01-10T00:00:00"
         }
       ]

--- a/tests/jsons/bug-215/actual_output.json
+++ b/tests/jsons/bug-215/actual_output.json
@@ -5,8 +5,8 @@
       "outputs": [
         {
           "taskid": 0,
-          "goalid": "1",
-          "title": "sleep",
+          "goalid": "free",
+          "title": "free",
           "duration": 1,
           "start": "2023-01-03T00:00:00",
           "deadline": "2023-01-03T01:00:00"
@@ -21,22 +21,14 @@
         },
         {
           "taskid": 2,
-          "goalid": "2",
-          "title": "hurdle",
-          "duration": 1,
+          "goalid": "free",
+          "title": "free",
+          "duration": 4,
           "start": "2023-01-03T02:00:00",
-          "deadline": "2023-01-03T03:00:00"
-        },
-        {
-          "taskid": 3,
-          "goalid": "1",
-          "title": "sleep",
-          "duration": 3,
-          "start": "2023-01-03T03:00:00",
           "deadline": "2023-01-03T06:00:00"
         },
         {
-          "taskid": 4,
+          "taskid": 3,
           "goalid": "5",
           "title": "breakfast",
           "duration": 1,
@@ -44,7 +36,7 @@
           "deadline": "2023-01-03T07:00:00"
         },
         {
-          "taskid": 5,
+          "taskid": 4,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -52,7 +44,7 @@
           "deadline": "2023-01-03T09:00:00"
         },
         {
-          "taskid": 6,
+          "taskid": 5,
           "goalid": "4",
           "title": "me time",
           "duration": 1,
@@ -60,7 +52,7 @@
           "deadline": "2023-01-03T10:00:00"
         },
         {
-          "taskid": 7,
+          "taskid": 6,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -68,7 +60,7 @@
           "deadline": "2023-01-03T12:00:00"
         },
         {
-          "taskid": 8,
+          "taskid": 7,
           "goalid": "3",
           "title": "lunch",
           "duration": 1,
@@ -76,7 +68,7 @@
           "deadline": "2023-01-03T13:00:00"
         },
         {
-          "taskid": 9,
+          "taskid": 8,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -84,7 +76,7 @@
           "deadline": "2023-01-03T14:00:00"
         },
         {
-          "taskid": 10,
+          "taskid": 9,
           "goalid": "6",
           "title": "walk",
           "duration": 1,
@@ -92,7 +84,7 @@
           "deadline": "2023-01-03T15:00:00"
         },
         {
-          "taskid": 11,
+          "taskid": 10,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -100,7 +92,7 @@
           "deadline": "2023-01-03T18:00:00"
         },
         {
-          "taskid": 12,
+          "taskid": 11,
           "goalid": "7",
           "title": "dinner",
           "duration": 1,
@@ -108,7 +100,7 @@
           "deadline": "2023-01-03T19:00:00"
         },
         {
-          "taskid": 13,
+          "taskid": 12,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -116,9 +108,9 @@
           "deadline": "2023-01-03T22:00:00"
         },
         {
-          "taskid": 14,
-          "goalid": "1",
-          "title": "sleep",
+          "taskid": 13,
+          "goalid": "2",
+          "title": "hurdle",
           "duration": 2,
           "start": "2023-01-03T22:00:00",
           "deadline": "2023-01-04T00:00:00"
@@ -129,43 +121,11 @@
       "day": "2023-01-04",
       "outputs": [
         {
-          "taskid": 15,
-          "goalid": "1",
-          "title": "sleep",
-          "duration": 1,
+          "taskid": 14,
+          "goalid": "free",
+          "title": "free",
+          "duration": 24,
           "start": "2023-01-04T00:00:00",
-          "deadline": "2023-01-04T01:00:00"
-        },
-        {
-          "taskid": 16,
-          "goalid": "2",
-          "title": "hurdle",
-          "duration": 1,
-          "start": "2023-01-04T01:00:00",
-          "deadline": "2023-01-04T02:00:00"
-        },
-        {
-          "taskid": 17,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2023-01-04T02:00:00",
-          "deadline": "2023-01-04T03:00:00"
-        },
-        {
-          "taskid": 18,
-          "goalid": "1",
-          "title": "sleep",
-          "duration": 1,
-          "start": "2023-01-04T03:00:00",
-          "deadline": "2023-01-04T04:00:00"
-        },
-        {
-          "taskid": 19,
-          "goalid": "free",
-          "title": "free",
-          "duration": 20,
-          "start": "2023-01-04T04:00:00",
           "deadline": "2023-01-05T00:00:00"
         }
       ]
@@ -174,7 +134,7 @@
       "day": "2023-01-05",
       "outputs": [
         {
-          "taskid": 20,
+          "taskid": 15,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -187,7 +147,7 @@
       "day": "2023-01-06",
       "outputs": [
         {
-          "taskid": 21,
+          "taskid": 16,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -200,7 +160,7 @@
       "day": "2023-01-07",
       "outputs": [
         {
-          "taskid": 22,
+          "taskid": 17,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -213,7 +173,7 @@
       "day": "2023-01-08",
       "outputs": [
         {
-          "taskid": 23,
+          "taskid": 18,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -226,11 +186,19 @@
       "day": "2023-01-09",
       "outputs": [
         {
-          "taskid": 24,
+          "taskid": 19,
           "goalid": "free",
           "title": "free",
-          "duration": 24,
+          "duration": 22,
           "start": "2023-01-09T00:00:00",
+          "deadline": "2023-01-09T22:00:00"
+        },
+        {
+          "taskid": 20,
+          "goalid": "1",
+          "title": "sleep",
+          "duration": 2,
+          "start": "2023-01-09T22:00:00",
           "deadline": "2023-01-10T00:00:00"
         }
       ]

--- a/tests/jsons/bug-236/actual_output.json
+++ b/tests/jsons/bug-236/actual_output.json
@@ -7,24 +7,8 @@
           "taskid": 0,
           "goalid": "free",
           "title": "free",
-          "duration": 6,
+          "duration": 24,
           "start": "2022-01-31T00:00:00",
-          "deadline": "2022-01-31T06:00:00"
-        },
-        {
-          "taskid": 1,
-          "goalid": "1",
-          "title": "work",
-          "duration": 4,
-          "start": "2022-01-31T06:00:00",
-          "deadline": "2022-01-31T10:00:00"
-        },
-        {
-          "taskid": 2,
-          "goalid": "free",
-          "title": "free",
-          "duration": 14,
-          "start": "2022-01-31T10:00:00",
           "deadline": "2022-02-01T00:00:00"
         }
       ]
@@ -33,27 +17,11 @@
       "day": "2022-02-01",
       "outputs": [
         {
-          "taskid": 3,
+          "taskid": 1,
           "goalid": "free",
           "title": "free",
-          "duration": 6,
+          "duration": 24,
           "start": "2022-02-01T00:00:00",
-          "deadline": "2022-02-01T06:00:00"
-        },
-        {
-          "taskid": 4,
-          "goalid": "1",
-          "title": "work",
-          "duration": 4,
-          "start": "2022-02-01T06:00:00",
-          "deadline": "2022-02-01T10:00:00"
-        },
-        {
-          "taskid": 5,
-          "goalid": "free",
-          "title": "free",
-          "duration": 14,
-          "start": "2022-02-01T10:00:00",
           "deadline": "2022-02-02T00:00:00"
         }
       ]
@@ -62,27 +30,11 @@
       "day": "2022-02-02",
       "outputs": [
         {
-          "taskid": 6,
+          "taskid": 2,
           "goalid": "free",
           "title": "free",
-          "duration": 6,
+          "duration": 24,
           "start": "2022-02-02T00:00:00",
-          "deadline": "2022-02-02T06:00:00"
-        },
-        {
-          "taskid": 7,
-          "goalid": "1",
-          "title": "work",
-          "duration": 4,
-          "start": "2022-02-02T06:00:00",
-          "deadline": "2022-02-02T10:00:00"
-        },
-        {
-          "taskid": 8,
-          "goalid": "free",
-          "title": "free",
-          "duration": 14,
-          "start": "2022-02-02T10:00:00",
           "deadline": "2022-02-03T00:00:00"
         }
       ]
@@ -91,7 +43,7 @@
       "day": "2022-02-03",
       "outputs": [
         {
-          "taskid": 9,
+          "taskid": 3,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -104,7 +56,7 @@
       "day": "2022-02-04",
       "outputs": [
         {
-          "taskid": 10,
+          "taskid": 4,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -117,7 +69,7 @@
       "day": "2022-02-05",
       "outputs": [
         {
-          "taskid": 11,
+          "taskid": 5,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -130,7 +82,7 @@
       "day": "2022-02-06",
       "outputs": [
         {
-          "taskid": 12,
+          "taskid": 6,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -143,7 +95,16 @@
   "impossible": [
     {
       "day": "2022-01-31",
-      "outputs": []
+      "outputs": [
+        {
+          "taskid": 7,
+          "goalid": "1",
+          "title": "work",
+          "duration": 12,
+          "start": "2022-01-31T00:00:00",
+          "deadline": "2022-02-07T00:00:00"
+        }
+      ]
     },
     {
       "day": "2022-02-01",

--- a/tests/jsons/children-with-over-duration/actual_output.json
+++ b/tests/jsons/children-with-over-duration/actual_output.json
@@ -13,18 +13,26 @@
         },
         {
           "taskid": 1,
-          "goalid": "2",
-          "title": "Project A",
-          "duration": 8,
+          "goalid": "5",
+          "title": "Write report",
+          "duration": 1,
           "start": "2018-03-05T08:00:00",
-          "deadline": "2018-03-05T16:00:00"
+          "deadline": "2018-03-05T09:00:00"
         },
         {
           "taskid": 2,
+          "goalid": "4",
+          "title": "Research",
+          "duration": 3,
+          "start": "2018-03-05T09:00:00",
+          "deadline": "2018-03-05T12:00:00"
+        },
+        {
+          "taskid": 3,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
-          "start": "2018-03-05T16:00:00",
+          "duration": 12,
+          "start": "2018-03-05T12:00:00",
           "deadline": "2018-03-06T00:00:00"
         }
       ]
@@ -33,27 +41,11 @@
       "day": "2018-03-06",
       "outputs": [
         {
-          "taskid": 3,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2018-03-06T00:00:00",
-          "deadline": "2018-03-06T08:00:00"
-        },
-        {
           "taskid": 4,
-          "goalid": "2",
-          "title": "Project A",
-          "duration": 8,
-          "start": "2018-03-06T08:00:00",
-          "deadline": "2018-03-06T16:00:00"
-        },
-        {
-          "taskid": 5,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
-          "start": "2018-03-06T16:00:00",
+          "duration": 24,
+          "start": "2018-03-06T00:00:00",
           "deadline": "2018-03-07T00:00:00"
         }
       ]
@@ -62,27 +54,11 @@
       "day": "2018-03-07",
       "outputs": [
         {
-          "taskid": 6,
+          "taskid": 5,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2018-03-07T00:00:00",
-          "deadline": "2018-03-07T08:00:00"
-        },
-        {
-          "taskid": 7,
-          "goalid": "2",
-          "title": "Project A",
-          "duration": 8,
-          "start": "2018-03-07T08:00:00",
-          "deadline": "2018-03-07T16:00:00"
-        },
-        {
-          "taskid": 8,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2018-03-07T16:00:00",
           "deadline": "2018-03-08T00:00:00"
         }
       ]
@@ -91,27 +67,11 @@
       "day": "2018-03-08",
       "outputs": [
         {
-          "taskid": 9,
+          "taskid": 6,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2018-03-08T00:00:00",
-          "deadline": "2018-03-08T08:00:00"
-        },
-        {
-          "taskid": 10,
-          "goalid": "2",
-          "title": "Project A",
-          "duration": 8,
-          "start": "2018-03-08T08:00:00",
-          "deadline": "2018-03-08T16:00:00"
-        },
-        {
-          "taskid": 11,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2018-03-08T16:00:00",
           "deadline": "2018-03-09T00:00:00"
         }
       ]
@@ -120,51 +80,11 @@
       "day": "2018-03-09",
       "outputs": [
         {
-          "taskid": 12,
+          "taskid": 7,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2018-03-09T00:00:00",
-          "deadline": "2018-03-09T08:00:00"
-        },
-        {
-          "taskid": 13,
-          "goalid": "2",
-          "title": "Project A",
-          "duration": 3,
-          "start": "2018-03-09T08:00:00",
-          "deadline": "2018-03-09T11:00:00"
-        },
-        {
-          "taskid": 14,
-          "goalid": "5",
-          "title": "Write report",
-          "duration": 1,
-          "start": "2018-03-09T11:00:00",
-          "deadline": "2018-03-09T12:00:00"
-        },
-        {
-          "taskid": 15,
-          "goalid": "4",
-          "title": "Research",
-          "duration": 3,
-          "start": "2018-03-09T12:00:00",
-          "deadline": "2018-03-09T15:00:00"
-        },
-        {
-          "taskid": 16,
-          "goalid": "3",
-          "title": "Project B filler",
-          "duration": 1,
-          "start": "2018-03-09T15:00:00",
-          "deadline": "2018-03-09T16:00:00"
-        },
-        {
-          "taskid": 17,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2018-03-09T16:00:00",
           "deadline": "2018-03-10T00:00:00"
         }
       ]
@@ -173,27 +93,11 @@
       "day": "2018-03-10",
       "outputs": [
         {
-          "taskid": 18,
+          "taskid": 8,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2018-03-10T00:00:00",
-          "deadline": "2018-03-10T08:00:00"
-        },
-        {
-          "taskid": 19,
-          "goalid": "3",
-          "title": "Project B filler",
-          "duration": 5,
-          "start": "2018-03-10T08:00:00",
-          "deadline": "2018-03-10T13:00:00"
-        },
-        {
-          "taskid": 20,
-          "goalid": "free",
-          "title": "free",
-          "duration": 11,
-          "start": "2018-03-10T13:00:00",
           "deadline": "2018-03-11T00:00:00"
         }
       ]
@@ -202,7 +106,7 @@
       "day": "2018-03-11",
       "outputs": [
         {
-          "taskid": 21,
+          "taskid": 9,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -215,27 +119,11 @@
       "day": "2018-03-12",
       "outputs": [
         {
-          "taskid": 22,
+          "taskid": 10,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2018-03-12T00:00:00",
-          "deadline": "2018-03-12T08:00:00"
-        },
-        {
-          "taskid": 23,
-          "goalid": "1",
-          "title": "work",
-          "duration": 8,
-          "start": "2018-03-12T08:00:00",
-          "deadline": "2018-03-12T16:00:00"
-        },
-        {
-          "taskid": 24,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2018-03-12T16:00:00",
           "deadline": "2018-03-13T00:00:00"
         }
       ]
@@ -244,27 +132,11 @@
       "day": "2018-03-13",
       "outputs": [
         {
-          "taskid": 25,
+          "taskid": 11,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2018-03-13T00:00:00",
-          "deadline": "2018-03-13T08:00:00"
-        },
-        {
-          "taskid": 26,
-          "goalid": "1",
-          "title": "work",
-          "duration": 8,
-          "start": "2018-03-13T08:00:00",
-          "deadline": "2018-03-13T16:00:00"
-        },
-        {
-          "taskid": 27,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2018-03-13T16:00:00",
           "deadline": "2018-03-14T00:00:00"
         }
       ]
@@ -273,27 +145,11 @@
       "day": "2018-03-14",
       "outputs": [
         {
-          "taskid": 28,
+          "taskid": 12,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2018-03-14T00:00:00",
-          "deadline": "2018-03-14T08:00:00"
-        },
-        {
-          "taskid": 29,
-          "goalid": "1",
-          "title": "work",
-          "duration": 8,
-          "start": "2018-03-14T08:00:00",
-          "deadline": "2018-03-14T16:00:00"
-        },
-        {
-          "taskid": 30,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2018-03-14T16:00:00",
           "deadline": "2018-03-15T00:00:00"
         }
       ]
@@ -302,27 +158,11 @@
       "day": "2018-03-15",
       "outputs": [
         {
-          "taskid": 31,
+          "taskid": 13,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2018-03-15T00:00:00",
-          "deadline": "2018-03-15T08:00:00"
-        },
-        {
-          "taskid": 32,
-          "goalid": "1",
-          "title": "work",
-          "duration": 8,
-          "start": "2018-03-15T08:00:00",
-          "deadline": "2018-03-15T16:00:00"
-        },
-        {
-          "taskid": 33,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2018-03-15T16:00:00",
           "deadline": "2018-03-16T00:00:00"
         }
       ]
@@ -331,27 +171,11 @@
       "day": "2018-03-16",
       "outputs": [
         {
-          "taskid": 34,
+          "taskid": 14,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2018-03-16T00:00:00",
-          "deadline": "2018-03-16T08:00:00"
-        },
-        {
-          "taskid": 35,
-          "goalid": "1",
-          "title": "work",
-          "duration": 6,
-          "start": "2018-03-16T08:00:00",
-          "deadline": "2018-03-16T14:00:00"
-        },
-        {
-          "taskid": 36,
-          "goalid": "free",
-          "title": "free",
-          "duration": 10,
-          "start": "2018-03-16T14:00:00",
           "deadline": "2018-03-17T00:00:00"
         }
       ]
@@ -360,7 +184,7 @@
       "day": "2018-03-17",
       "outputs": [
         {
-          "taskid": 37,
+          "taskid": 15,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -373,7 +197,7 @@
       "day": "2018-03-18",
       "outputs": [
         {
-          "taskid": 38,
+          "taskid": 16,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -386,27 +210,11 @@
       "day": "2018-03-19",
       "outputs": [
         {
-          "taskid": 39,
+          "taskid": 17,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2018-03-19T00:00:00",
-          "deadline": "2018-03-19T08:00:00"
-        },
-        {
-          "taskid": 40,
-          "goalid": "1",
-          "title": "work",
-          "duration": 8,
-          "start": "2018-03-19T08:00:00",
-          "deadline": "2018-03-19T16:00:00"
-        },
-        {
-          "taskid": 41,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2018-03-19T16:00:00",
           "deadline": "2018-03-20T00:00:00"
         }
       ]
@@ -415,27 +223,11 @@
       "day": "2018-03-20",
       "outputs": [
         {
-          "taskid": 42,
+          "taskid": 18,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2018-03-20T00:00:00",
-          "deadline": "2018-03-20T08:00:00"
-        },
-        {
-          "taskid": 43,
-          "goalid": "1",
-          "title": "work",
-          "duration": 8,
-          "start": "2018-03-20T08:00:00",
-          "deadline": "2018-03-20T16:00:00"
-        },
-        {
-          "taskid": 44,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2018-03-20T16:00:00",
           "deadline": "2018-03-21T00:00:00"
         }
       ]
@@ -444,27 +236,11 @@
       "day": "2018-03-21",
       "outputs": [
         {
-          "taskid": 45,
+          "taskid": 19,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2018-03-21T00:00:00",
-          "deadline": "2018-03-21T08:00:00"
-        },
-        {
-          "taskid": 46,
-          "goalid": "1",
-          "title": "work",
-          "duration": 8,
-          "start": "2018-03-21T08:00:00",
-          "deadline": "2018-03-21T16:00:00"
-        },
-        {
-          "taskid": 47,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2018-03-21T16:00:00",
           "deadline": "2018-03-22T00:00:00"
         }
       ]
@@ -473,27 +249,11 @@
       "day": "2018-03-22",
       "outputs": [
         {
-          "taskid": 48,
+          "taskid": 20,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2018-03-22T00:00:00",
-          "deadline": "2018-03-22T08:00:00"
-        },
-        {
-          "taskid": 49,
-          "goalid": "1",
-          "title": "work",
-          "duration": 8,
-          "start": "2018-03-22T08:00:00",
-          "deadline": "2018-03-22T16:00:00"
-        },
-        {
-          "taskid": 50,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2018-03-22T16:00:00",
           "deadline": "2018-03-23T00:00:00"
         }
       ]
@@ -502,27 +262,11 @@
       "day": "2018-03-23",
       "outputs": [
         {
-          "taskid": 51,
+          "taskid": 21,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2018-03-23T00:00:00",
-          "deadline": "2018-03-23T08:00:00"
-        },
-        {
-          "taskid": 52,
-          "goalid": "1",
-          "title": "work",
-          "duration": 6,
-          "start": "2018-03-23T08:00:00",
-          "deadline": "2018-03-23T14:00:00"
-        },
-        {
-          "taskid": 53,
-          "goalid": "free",
-          "title": "free",
-          "duration": 10,
-          "start": "2018-03-23T14:00:00",
           "deadline": "2018-03-24T00:00:00"
         }
       ]
@@ -531,7 +275,7 @@
       "day": "2018-03-24",
       "outputs": [
         {
-          "taskid": 54,
+          "taskid": 22,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -544,7 +288,7 @@
       "day": "2018-03-25",
       "outputs": [
         {
-          "taskid": 55,
+          "taskid": 23,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -559,10 +303,42 @@
       "day": "2018-03-05",
       "outputs": [
         {
-          "taskid": 56,
+          "taskid": 24,
+          "goalid": "2",
+          "title": "Project A",
+          "duration": 35,
+          "start": "2018-03-05T00:00:00",
+          "deadline": "2018-03-26T00:00:00"
+        },
+        {
+          "taskid": 25,
+          "goalid": "1",
+          "title": "work",
+          "duration": 38,
+          "start": "2018-03-05T00:00:00",
+          "deadline": "2018-03-26T00:00:00"
+        },
+        {
+          "taskid": 26,
+          "goalid": "1",
+          "title": "work",
+          "duration": 38,
+          "start": "2018-03-05T00:00:00",
+          "deadline": "2018-03-26T00:00:00"
+        },
+        {
+          "taskid": 27,
+          "goalid": "1",
+          "title": "work",
+          "duration": 34,
+          "start": "2018-03-05T00:00:00",
+          "deadline": "2018-03-26T00:00:00"
+        },
+        {
+          "taskid": 28,
           "goalid": "3",
           "title": "Project B filler",
-          "duration": 5,
+          "duration": 11,
           "start": "2018-03-05T00:00:00",
           "deadline": "2018-03-26T00:00:00"
         }

--- a/tests/jsons/demo-1-old/actual_output.json
+++ b/tests/jsons/demo-1-old/actual_output.json
@@ -13,18 +13,26 @@
         },
         {
           "taskid": 1,
-          "goalid": "2",
-          "title": "Project A",
-          "duration": 10,
+          "goalid": "5",
+          "title": "Write report",
+          "duration": 1,
           "start": "2018-01-01T06:00:00",
-          "deadline": "2018-01-01T16:00:00"
+          "deadline": "2018-01-01T07:00:00"
         },
         {
           "taskid": 2,
+          "goalid": "4",
+          "title": "Research",
+          "duration": 3,
+          "start": "2018-01-01T07:00:00",
+          "deadline": "2018-01-01T10:00:00"
+        },
+        {
+          "taskid": 3,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
-          "start": "2018-01-01T16:00:00",
+          "duration": 14,
+          "start": "2018-01-01T10:00:00",
           "deadline": "2018-01-02T00:00:00"
         }
       ]
@@ -33,27 +41,11 @@
       "day": "2018-01-02",
       "outputs": [
         {
-          "taskid": 3,
-          "goalid": "free",
-          "title": "free",
-          "duration": 6,
-          "start": "2018-01-02T00:00:00",
-          "deadline": "2018-01-02T06:00:00"
-        },
-        {
           "taskid": 4,
-          "goalid": "2",
-          "title": "Project A",
-          "duration": 10,
-          "start": "2018-01-02T06:00:00",
-          "deadline": "2018-01-02T16:00:00"
-        },
-        {
-          "taskid": 5,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
-          "start": "2018-01-02T16:00:00",
+          "duration": 24,
+          "start": "2018-01-02T00:00:00",
           "deadline": "2018-01-03T00:00:00"
         }
       ]
@@ -62,43 +54,11 @@
       "day": "2018-01-03",
       "outputs": [
         {
-          "taskid": 6,
+          "taskid": 5,
           "goalid": "free",
           "title": "free",
-          "duration": 6,
+          "duration": 24,
           "start": "2018-01-03T00:00:00",
-          "deadline": "2018-01-03T06:00:00"
-        },
-        {
-          "taskid": 7,
-          "goalid": "5",
-          "title": "Write report",
-          "duration": 1,
-          "start": "2018-01-03T06:00:00",
-          "deadline": "2018-01-03T07:00:00"
-        },
-        {
-          "taskid": 8,
-          "goalid": "4",
-          "title": "Research",
-          "duration": 3,
-          "start": "2018-01-03T07:00:00",
-          "deadline": "2018-01-03T10:00:00"
-        },
-        {
-          "taskid": 9,
-          "goalid": "3",
-          "title": "Project B filler",
-          "duration": 6,
-          "start": "2018-01-03T10:00:00",
-          "deadline": "2018-01-03T16:00:00"
-        },
-        {
-          "taskid": 10,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2018-01-03T16:00:00",
           "deadline": "2018-01-04T00:00:00"
         }
       ]
@@ -107,35 +67,11 @@
       "day": "2018-01-04",
       "outputs": [
         {
-          "taskid": 11,
+          "taskid": 6,
           "goalid": "free",
           "title": "free",
-          "duration": 6,
+          "duration": 24,
           "start": "2018-01-04T00:00:00",
-          "deadline": "2018-01-04T06:00:00"
-        },
-        {
-          "taskid": 12,
-          "goalid": "3",
-          "title": "Project B filler",
-          "duration": 5,
-          "start": "2018-01-04T06:00:00",
-          "deadline": "2018-01-04T11:00:00"
-        },
-        {
-          "taskid": 13,
-          "goalid": "1",
-          "title": "work",
-          "duration": 3,
-          "start": "2018-01-04T11:00:00",
-          "deadline": "2018-01-04T14:00:00"
-        },
-        {
-          "taskid": 14,
-          "goalid": "free",
-          "title": "free",
-          "duration": 10,
-          "start": "2018-01-04T14:00:00",
           "deadline": "2018-01-05T00:00:00"
         }
       ]
@@ -144,7 +80,7 @@
       "day": "2018-01-05",
       "outputs": [
         {
-          "taskid": 15,
+          "taskid": 7,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -157,7 +93,32 @@
   "impossible": [
     {
       "day": "2018-01-01",
-      "outputs": []
+      "outputs": [
+        {
+          "taskid": 8,
+          "goalid": "2",
+          "title": "Project A",
+          "duration": 20,
+          "start": "2018-01-01T00:00:00",
+          "deadline": "2018-01-06T00:00:00"
+        },
+        {
+          "taskid": 9,
+          "goalid": "1",
+          "title": "work",
+          "duration": 34,
+          "start": "2018-01-01T00:00:00",
+          "deadline": "2018-01-06T00:00:00"
+        },
+        {
+          "taskid": 10,
+          "goalid": "3",
+          "title": "Project B filler",
+          "duration": 11,
+          "start": "2018-01-01T00:00:00",
+          "deadline": "2018-01-06T00:00:00"
+        }
+      ]
     },
     {
       "day": "2018-01-02",

--- a/tests/jsons/demo-2-with-filler-with-budget/actual_output.json
+++ b/tests/jsons/demo-2-with-filler-with-budget/actual_output.json
@@ -13,18 +13,26 @@
         },
         {
           "taskid": 1,
-          "goalid": "2",
-          "title": "Project A",
-          "duration": 8,
+          "goalid": "5",
+          "title": "Write report",
+          "duration": 1,
           "start": "2018-03-09T08:00:00",
-          "deadline": "2018-03-09T16:00:00"
+          "deadline": "2018-03-09T09:00:00"
         },
         {
           "taskid": 2,
+          "goalid": "4",
+          "title": "Research",
+          "duration": 3,
+          "start": "2018-03-09T09:00:00",
+          "deadline": "2018-03-09T12:00:00"
+        },
+        {
+          "taskid": 3,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
-          "start": "2018-03-09T16:00:00",
+          "duration": 12,
+          "start": "2018-03-09T12:00:00",
           "deadline": "2018-03-10T00:00:00"
         }
       ]
@@ -33,27 +41,11 @@
       "day": "2018-03-10",
       "outputs": [
         {
-          "taskid": 3,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2018-03-10T00:00:00",
-          "deadline": "2018-03-10T08:00:00"
-        },
-        {
           "taskid": 4,
-          "goalid": "2",
-          "title": "Project A",
-          "duration": 8,
-          "start": "2018-03-10T08:00:00",
-          "deadline": "2018-03-10T16:00:00"
-        },
-        {
-          "taskid": 5,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
-          "start": "2018-03-10T16:00:00",
+          "duration": 24,
+          "start": "2018-03-10T00:00:00",
           "deadline": "2018-03-11T00:00:00"
         }
       ]
@@ -62,43 +54,11 @@
       "day": "2018-03-11",
       "outputs": [
         {
-          "taskid": 6,
+          "taskid": 5,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2018-03-11T00:00:00",
-          "deadline": "2018-03-11T08:00:00"
-        },
-        {
-          "taskid": 7,
-          "goalid": "2",
-          "title": "Project A",
-          "duration": 4,
-          "start": "2018-03-11T08:00:00",
-          "deadline": "2018-03-11T12:00:00"
-        },
-        {
-          "taskid": 8,
-          "goalid": "5",
-          "title": "Write report",
-          "duration": 1,
-          "start": "2018-03-11T12:00:00",
-          "deadline": "2018-03-11T13:00:00"
-        },
-        {
-          "taskid": 9,
-          "goalid": "4",
-          "title": "Research",
-          "duration": 3,
-          "start": "2018-03-11T13:00:00",
-          "deadline": "2018-03-11T16:00:00"
-        },
-        {
-          "taskid": 10,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2018-03-11T16:00:00",
           "deadline": "2018-03-12T00:00:00"
         }
       ]
@@ -107,27 +67,11 @@
       "day": "2018-03-12",
       "outputs": [
         {
-          "taskid": 11,
+          "taskid": 6,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2018-03-12T00:00:00",
-          "deadline": "2018-03-12T08:00:00"
-        },
-        {
-          "taskid": 12,
-          "goalid": "3",
-          "title": "Project B filler",
-          "duration": 8,
-          "start": "2018-03-12T08:00:00",
-          "deadline": "2018-03-12T16:00:00"
-        },
-        {
-          "taskid": 13,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2018-03-12T16:00:00",
           "deadline": "2018-03-13T00:00:00"
         }
       ]
@@ -136,27 +80,11 @@
       "day": "2018-03-13",
       "outputs": [
         {
-          "taskid": 14,
+          "taskid": 7,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2018-03-13T00:00:00",
-          "deadline": "2018-03-13T08:00:00"
-        },
-        {
-          "taskid": 15,
-          "goalid": "3",
-          "title": "Project B filler",
-          "duration": 3,
-          "start": "2018-03-13T08:00:00",
-          "deadline": "2018-03-13T11:00:00"
-        },
-        {
-          "taskid": 16,
-          "goalid": "free",
-          "title": "free",
-          "duration": 13,
-          "start": "2018-03-13T11:00:00",
           "deadline": "2018-03-14T00:00:00"
         }
       ]
@@ -165,7 +93,7 @@
       "day": "2018-03-14",
       "outputs": [
         {
-          "taskid": 17,
+          "taskid": 8,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -178,7 +106,7 @@
       "day": "2018-03-15",
       "outputs": [
         {
-          "taskid": 18,
+          "taskid": 9,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -191,7 +119,32 @@
   "impossible": [
     {
       "day": "2018-03-09",
-      "outputs": []
+      "outputs": [
+        {
+          "taskid": 10,
+          "goalid": "2",
+          "title": "Project A",
+          "duration": 20,
+          "start": "2018-03-09T00:00:00",
+          "deadline": "2018-03-16T00:00:00"
+        },
+        {
+          "taskid": 11,
+          "goalid": "1",
+          "title": "work",
+          "duration": 31,
+          "start": "2018-03-09T00:00:00",
+          "deadline": "2018-03-16T00:00:00"
+        },
+        {
+          "taskid": 12,
+          "goalid": "3",
+          "title": "Project B filler",
+          "duration": 11,
+          "start": "2018-03-09T00:00:00",
+          "deadline": "2018-03-16T00:00:00"
+        }
+      ]
     },
     {
       "day": "2018-03-10",

--- a/tests/jsons/different-repetition-goals/actual_output.json
+++ b/tests/jsons/different-repetition-goals/actual_output.json
@@ -122,8 +122,8 @@
         },
         {
           "taskid": 14,
-          "goalid": "04069248-0a5e-46e2-99bb-5886eb905cf0",
-          "title": "work",
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2023-03-02T10:00:00",
           "deadline": "2023-03-02T12:00:00"
@@ -138,8 +138,8 @@
         },
         {
           "taskid": 16,
-          "goalid": "04069248-0a5e-46e2-99bb-5886eb905cf0",
-          "title": "work",
+          "goalid": "free",
+          "title": "free",
           "duration": 1,
           "start": "2023-03-02T13:00:00",
           "deadline": "2023-03-02T14:00:00"
@@ -154,8 +154,8 @@
         },
         {
           "taskid": 18,
-          "goalid": "free",
-          "title": "free",
+          "goalid": "04069248-0a5e-46e2-99bb-5886eb905cf0",
+          "title": "work",
           "duration": 3,
           "start": "2023-03-02T15:00:00",
           "deadline": "2023-03-02T18:00:00"

--- a/tests/jsons/every-6-hours-2/actual_output.json
+++ b/tests/jsons/every-6-hours-2/actual_output.json
@@ -23,16 +23,8 @@
           "taskid": 2,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
+          "duration": 5,
           "start": "2022-11-19T19:00:00",
-          "deadline": "2022-11-19T21:00:00"
-        },
-        {
-          "taskid": 3,
-          "goalid": "1",
-          "title": "backup data",
-          "duration": 3,
-          "start": "2022-11-19T21:00:00",
           "deadline": "2022-11-20T00:00:00"
         }
       ]
@@ -43,10 +35,10 @@
       "day": "2022-11-19",
       "outputs": [
         {
-          "taskid": 4,
+          "taskid": 3,
           "goalid": "1",
           "title": "backup data",
-          "duration": 1,
+          "duration": 4,
           "start": "2022-11-19T00:00:00",
           "deadline": "2022-11-20T00:00:00"
         }

--- a/tests/jsons/every-6-hours/actual_output.json
+++ b/tests/jsons/every-6-hours/actual_output.json
@@ -23,16 +23,8 @@
           "taskid": 2,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
+          "duration": 5,
           "start": "2022-11-19T19:00:00",
-          "deadline": "2022-11-19T21:00:00"
-        },
-        {
-          "taskid": 3,
-          "goalid": "1",
-          "title": "backup data",
-          "duration": 3,
-          "start": "2022-11-19T21:00:00",
           "deadline": "2022-11-20T00:00:00"
         }
       ]
@@ -43,10 +35,10 @@
       "day": "2022-11-19",
       "outputs": [
         {
-          "taskid": 4,
+          "taskid": 3,
           "goalid": "1",
           "title": "backup data",
-          "duration": 1,
+          "duration": 4,
           "start": "2022-11-19T00:00:00",
           "deadline": "2022-11-20T00:00:00"
         }

--- a/tests/jsons/flex-duration-2/actual_output.json
+++ b/tests/jsons/flex-duration-2/actual_output.json
@@ -5,30 +5,14 @@
       "outputs": [
         {
           "taskid": 0,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 6,
-          "start": "2022-10-01T00:00:00",
-          "deadline": "2022-10-01T06:00:00"
-        },
-        {
-          "taskid": 1,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
-          "start": "2022-10-01T06:00:00",
-          "deadline": "2022-10-01T08:00:00"
-        },
-        {
-          "taskid": 2,
-          "goalid": "1",
-          "title": "work",
-          "duration": 3,
-          "start": "2022-10-01T08:00:00",
+          "duration": 11,
+          "start": "2022-10-01T00:00:00",
           "deadline": "2022-10-01T11:00:00"
         },
         {
-          "taskid": 3,
+          "taskid": 1,
           "goalid": "2",
           "title": "exercise",
           "duration": 5,
@@ -36,27 +20,11 @@
           "deadline": "2022-10-01T16:00:00"
         },
         {
-          "taskid": 4,
-          "goalid": "1",
-          "title": "work",
-          "duration": 2,
-          "start": "2022-10-01T16:00:00",
-          "deadline": "2022-10-01T18:00:00"
-        },
-        {
-          "taskid": 5,
+          "taskid": 2,
           "goalid": "free",
           "title": "free",
-          "duration": 4,
-          "start": "2022-10-01T18:00:00",
-          "deadline": "2022-10-01T22:00:00"
-        },
-        {
-          "taskid": 6,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 2,
-          "start": "2022-10-01T22:00:00",
+          "duration": 8,
+          "start": "2022-10-01T16:00:00",
           "deadline": "2022-10-02T00:00:00"
         }
       ]
@@ -65,31 +33,15 @@
       "day": "2022-10-02",
       "outputs": [
         {
-          "taskid": 7,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 6,
-          "start": "2022-10-02T00:00:00",
-          "deadline": "2022-10-02T06:00:00"
-        },
-        {
-          "taskid": 8,
+          "taskid": 3,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
-          "start": "2022-10-02T06:00:00",
-          "deadline": "2022-10-02T08:00:00"
-        },
-        {
-          "taskid": 9,
-          "goalid": "1",
-          "title": "work",
-          "duration": 3,
-          "start": "2022-10-02T08:00:00",
+          "duration": 11,
+          "start": "2022-10-02T00:00:00",
           "deadline": "2022-10-02T11:00:00"
         },
         {
-          "taskid": 10,
+          "taskid": 4,
           "goalid": "2",
           "title": "exercise",
           "duration": 5,
@@ -97,27 +49,11 @@
           "deadline": "2022-10-02T16:00:00"
         },
         {
-          "taskid": 11,
-          "goalid": "1",
-          "title": "work",
-          "duration": 2,
-          "start": "2022-10-02T16:00:00",
-          "deadline": "2022-10-02T18:00:00"
-        },
-        {
-          "taskid": 12,
+          "taskid": 5,
           "goalid": "free",
           "title": "free",
-          "duration": 4,
-          "start": "2022-10-02T18:00:00",
-          "deadline": "2022-10-02T22:00:00"
-        },
-        {
-          "taskid": 13,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 2,
-          "start": "2022-10-02T22:00:00",
+          "duration": 8,
+          "start": "2022-10-02T16:00:00",
           "deadline": "2022-10-03T00:00:00"
         }
       ]
@@ -126,31 +62,15 @@
       "day": "2022-10-03",
       "outputs": [
         {
-          "taskid": 14,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 6,
-          "start": "2022-10-03T00:00:00",
-          "deadline": "2022-10-03T06:00:00"
-        },
-        {
-          "taskid": 15,
+          "taskid": 6,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
-          "start": "2022-10-03T06:00:00",
-          "deadline": "2022-10-03T08:00:00"
-        },
-        {
-          "taskid": 16,
-          "goalid": "1",
-          "title": "work",
-          "duration": 3,
-          "start": "2022-10-03T08:00:00",
+          "duration": 11,
+          "start": "2022-10-03T00:00:00",
           "deadline": "2022-10-03T11:00:00"
         },
         {
-          "taskid": 17,
+          "taskid": 7,
           "goalid": "2",
           "title": "exercise",
           "duration": 5,
@@ -158,27 +78,11 @@
           "deadline": "2022-10-03T16:00:00"
         },
         {
-          "taskid": 18,
-          "goalid": "1",
-          "title": "work",
-          "duration": 2,
-          "start": "2022-10-03T16:00:00",
-          "deadline": "2022-10-03T18:00:00"
-        },
-        {
-          "taskid": 19,
+          "taskid": 8,
           "goalid": "free",
           "title": "free",
-          "duration": 4,
-          "start": "2022-10-03T18:00:00",
-          "deadline": "2022-10-03T22:00:00"
-        },
-        {
-          "taskid": 20,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 2,
-          "start": "2022-10-03T22:00:00",
+          "duration": 8,
+          "start": "2022-10-03T16:00:00",
           "deadline": "2022-10-04T00:00:00"
         }
       ]
@@ -187,31 +91,15 @@
       "day": "2022-10-04",
       "outputs": [
         {
-          "taskid": 21,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 6,
-          "start": "2022-10-04T00:00:00",
-          "deadline": "2022-10-04T06:00:00"
-        },
-        {
-          "taskid": 22,
+          "taskid": 9,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
-          "start": "2022-10-04T06:00:00",
-          "deadline": "2022-10-04T08:00:00"
-        },
-        {
-          "taskid": 23,
-          "goalid": "1",
-          "title": "work",
-          "duration": 3,
-          "start": "2022-10-04T08:00:00",
+          "duration": 11,
+          "start": "2022-10-04T00:00:00",
           "deadline": "2022-10-04T11:00:00"
         },
         {
-          "taskid": 24,
+          "taskid": 10,
           "goalid": "2",
           "title": "exercise",
           "duration": 5,
@@ -219,27 +107,11 @@
           "deadline": "2022-10-04T16:00:00"
         },
         {
-          "taskid": 25,
-          "goalid": "1",
-          "title": "work",
-          "duration": 2,
-          "start": "2022-10-04T16:00:00",
-          "deadline": "2022-10-04T18:00:00"
-        },
-        {
-          "taskid": 26,
+          "taskid": 11,
           "goalid": "free",
           "title": "free",
-          "duration": 4,
-          "start": "2022-10-04T18:00:00",
-          "deadline": "2022-10-04T22:00:00"
-        },
-        {
-          "taskid": 27,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 2,
-          "start": "2022-10-04T22:00:00",
+          "duration": 8,
+          "start": "2022-10-04T16:00:00",
           "deadline": "2022-10-05T00:00:00"
         }
       ]
@@ -248,31 +120,15 @@
       "day": "2022-10-05",
       "outputs": [
         {
-          "taskid": 28,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 6,
-          "start": "2022-10-05T00:00:00",
-          "deadline": "2022-10-05T06:00:00"
-        },
-        {
-          "taskid": 29,
+          "taskid": 12,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
-          "start": "2022-10-05T06:00:00",
-          "deadline": "2022-10-05T08:00:00"
-        },
-        {
-          "taskid": 30,
-          "goalid": "1",
-          "title": "work",
-          "duration": 3,
-          "start": "2022-10-05T08:00:00",
+          "duration": 11,
+          "start": "2022-10-05T00:00:00",
           "deadline": "2022-10-05T11:00:00"
         },
         {
-          "taskid": 31,
+          "taskid": 13,
           "goalid": "2",
           "title": "exercise",
           "duration": 5,
@@ -280,27 +136,11 @@
           "deadline": "2022-10-05T16:00:00"
         },
         {
-          "taskid": 32,
-          "goalid": "1",
-          "title": "work",
-          "duration": 2,
-          "start": "2022-10-05T16:00:00",
-          "deadline": "2022-10-05T18:00:00"
-        },
-        {
-          "taskid": 33,
+          "taskid": 14,
           "goalid": "free",
           "title": "free",
-          "duration": 4,
-          "start": "2022-10-05T18:00:00",
-          "deadline": "2022-10-05T22:00:00"
-        },
-        {
-          "taskid": 34,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 2,
-          "start": "2022-10-05T22:00:00",
+          "duration": 8,
+          "start": "2022-10-05T16:00:00",
           "deadline": "2022-10-06T00:00:00"
         }
       ]
@@ -309,31 +149,15 @@
       "day": "2022-10-06",
       "outputs": [
         {
-          "taskid": 35,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 6,
-          "start": "2022-10-06T00:00:00",
-          "deadline": "2022-10-06T06:00:00"
-        },
-        {
-          "taskid": 36,
+          "taskid": 15,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
-          "start": "2022-10-06T06:00:00",
-          "deadline": "2022-10-06T08:00:00"
-        },
-        {
-          "taskid": 37,
-          "goalid": "1",
-          "title": "work",
-          "duration": 3,
-          "start": "2022-10-06T08:00:00",
+          "duration": 11,
+          "start": "2022-10-06T00:00:00",
           "deadline": "2022-10-06T11:00:00"
         },
         {
-          "taskid": 38,
+          "taskid": 16,
           "goalid": "2",
           "title": "exercise",
           "duration": 5,
@@ -341,27 +165,11 @@
           "deadline": "2022-10-06T16:00:00"
         },
         {
-          "taskid": 39,
-          "goalid": "1",
-          "title": "work",
-          "duration": 2,
-          "start": "2022-10-06T16:00:00",
-          "deadline": "2022-10-06T18:00:00"
-        },
-        {
-          "taskid": 40,
+          "taskid": 17,
           "goalid": "free",
           "title": "free",
-          "duration": 4,
-          "start": "2022-10-06T18:00:00",
-          "deadline": "2022-10-06T22:00:00"
-        },
-        {
-          "taskid": 41,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 2,
-          "start": "2022-10-06T22:00:00",
+          "duration": 8,
+          "start": "2022-10-06T16:00:00",
           "deadline": "2022-10-07T00:00:00"
         }
       ]
@@ -370,31 +178,15 @@
       "day": "2022-10-07",
       "outputs": [
         {
-          "taskid": 42,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 6,
-          "start": "2022-10-07T00:00:00",
-          "deadline": "2022-10-07T06:00:00"
-        },
-        {
-          "taskid": 43,
+          "taskid": 18,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
-          "start": "2022-10-07T06:00:00",
-          "deadline": "2022-10-07T08:00:00"
-        },
-        {
-          "taskid": 44,
-          "goalid": "1",
-          "title": "work",
-          "duration": 3,
-          "start": "2022-10-07T08:00:00",
+          "duration": 11,
+          "start": "2022-10-07T00:00:00",
           "deadline": "2022-10-07T11:00:00"
         },
         {
-          "taskid": 45,
+          "taskid": 19,
           "goalid": "2",
           "title": "exercise",
           "duration": 5,
@@ -402,27 +194,11 @@
           "deadline": "2022-10-07T16:00:00"
         },
         {
-          "taskid": 46,
-          "goalid": "1",
-          "title": "work",
-          "duration": 2,
-          "start": "2022-10-07T16:00:00",
-          "deadline": "2022-10-07T18:00:00"
-        },
-        {
-          "taskid": 47,
+          "taskid": 20,
           "goalid": "free",
           "title": "free",
-          "duration": 4,
-          "start": "2022-10-07T18:00:00",
-          "deadline": "2022-10-07T22:00:00"
-        },
-        {
-          "taskid": 48,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 2,
-          "start": "2022-10-07T22:00:00",
+          "duration": 8,
+          "start": "2022-10-07T16:00:00",
           "deadline": "2022-10-08T00:00:00"
         }
       ]
@@ -431,31 +207,15 @@
       "day": "2022-10-08",
       "outputs": [
         {
-          "taskid": 49,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 6,
-          "start": "2022-10-08T00:00:00",
-          "deadline": "2022-10-08T06:00:00"
-        },
-        {
-          "taskid": 50,
+          "taskid": 21,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
-          "start": "2022-10-08T06:00:00",
-          "deadline": "2022-10-08T08:00:00"
-        },
-        {
-          "taskid": 51,
-          "goalid": "1",
-          "title": "work",
-          "duration": 3,
-          "start": "2022-10-08T08:00:00",
+          "duration": 11,
+          "start": "2022-10-08T00:00:00",
           "deadline": "2022-10-08T11:00:00"
         },
         {
-          "taskid": 52,
+          "taskid": 22,
           "goalid": "2",
           "title": "exercise",
           "duration": 5,
@@ -463,27 +223,11 @@
           "deadline": "2022-10-08T16:00:00"
         },
         {
-          "taskid": 53,
-          "goalid": "1",
-          "title": "work",
-          "duration": 2,
-          "start": "2022-10-08T16:00:00",
-          "deadline": "2022-10-08T18:00:00"
-        },
-        {
-          "taskid": 54,
+          "taskid": 23,
           "goalid": "free",
           "title": "free",
-          "duration": 4,
-          "start": "2022-10-08T18:00:00",
-          "deadline": "2022-10-08T22:00:00"
-        },
-        {
-          "taskid": 55,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 2,
-          "start": "2022-10-08T22:00:00",
+          "duration": 8,
+          "start": "2022-10-08T16:00:00",
           "deadline": "2022-10-09T00:00:00"
         }
       ]
@@ -492,31 +236,15 @@
       "day": "2022-10-09",
       "outputs": [
         {
-          "taskid": 56,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 6,
-          "start": "2022-10-09T00:00:00",
-          "deadline": "2022-10-09T06:00:00"
-        },
-        {
-          "taskid": 57,
+          "taskid": 24,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
-          "start": "2022-10-09T06:00:00",
-          "deadline": "2022-10-09T08:00:00"
-        },
-        {
-          "taskid": 58,
-          "goalid": "1",
-          "title": "work",
-          "duration": 3,
-          "start": "2022-10-09T08:00:00",
+          "duration": 11,
+          "start": "2022-10-09T00:00:00",
           "deadline": "2022-10-09T11:00:00"
         },
         {
-          "taskid": 59,
+          "taskid": 25,
           "goalid": "2",
           "title": "exercise",
           "duration": 5,
@@ -524,27 +252,11 @@
           "deadline": "2022-10-09T16:00:00"
         },
         {
-          "taskid": 60,
-          "goalid": "1",
-          "title": "work",
-          "duration": 2,
-          "start": "2022-10-09T16:00:00",
-          "deadline": "2022-10-09T18:00:00"
-        },
-        {
-          "taskid": 61,
+          "taskid": 26,
           "goalid": "free",
           "title": "free",
-          "duration": 4,
-          "start": "2022-10-09T18:00:00",
-          "deadline": "2022-10-09T22:00:00"
-        },
-        {
-          "taskid": 62,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 2,
-          "start": "2022-10-09T22:00:00",
+          "duration": 8,
+          "start": "2022-10-09T16:00:00",
           "deadline": "2022-10-10T00:00:00"
         }
       ]
@@ -553,31 +265,15 @@
       "day": "2022-10-10",
       "outputs": [
         {
-          "taskid": 63,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 6,
-          "start": "2022-10-10T00:00:00",
-          "deadline": "2022-10-10T06:00:00"
-        },
-        {
-          "taskid": 64,
+          "taskid": 27,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
-          "start": "2022-10-10T06:00:00",
-          "deadline": "2022-10-10T08:00:00"
-        },
-        {
-          "taskid": 65,
-          "goalid": "1",
-          "title": "work",
-          "duration": 3,
-          "start": "2022-10-10T08:00:00",
+          "duration": 11,
+          "start": "2022-10-10T00:00:00",
           "deadline": "2022-10-10T11:00:00"
         },
         {
-          "taskid": 66,
+          "taskid": 28,
           "goalid": "2",
           "title": "exercise",
           "duration": 5,
@@ -585,27 +281,11 @@
           "deadline": "2022-10-10T16:00:00"
         },
         {
-          "taskid": 67,
-          "goalid": "1",
-          "title": "work",
-          "duration": 2,
-          "start": "2022-10-10T16:00:00",
-          "deadline": "2022-10-10T18:00:00"
-        },
-        {
-          "taskid": 68,
+          "taskid": 29,
           "goalid": "free",
           "title": "free",
-          "duration": 4,
-          "start": "2022-10-10T18:00:00",
-          "deadline": "2022-10-10T22:00:00"
-        },
-        {
-          "taskid": 69,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 2,
-          "start": "2022-10-10T22:00:00",
+          "duration": 8,
+          "start": "2022-10-10T16:00:00",
           "deadline": "2022-10-11T00:00:00"
         }
       ]
@@ -614,31 +294,15 @@
       "day": "2022-10-11",
       "outputs": [
         {
-          "taskid": 70,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 6,
-          "start": "2022-10-11T00:00:00",
-          "deadline": "2022-10-11T06:00:00"
-        },
-        {
-          "taskid": 71,
+          "taskid": 30,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
-          "start": "2022-10-11T06:00:00",
-          "deadline": "2022-10-11T08:00:00"
-        },
-        {
-          "taskid": 72,
-          "goalid": "1",
-          "title": "work",
-          "duration": 3,
-          "start": "2022-10-11T08:00:00",
+          "duration": 11,
+          "start": "2022-10-11T00:00:00",
           "deadline": "2022-10-11T11:00:00"
         },
         {
-          "taskid": 73,
+          "taskid": 31,
           "goalid": "2",
           "title": "exercise",
           "duration": 5,
@@ -646,27 +310,11 @@
           "deadline": "2022-10-11T16:00:00"
         },
         {
-          "taskid": 74,
-          "goalid": "1",
-          "title": "work",
-          "duration": 2,
-          "start": "2022-10-11T16:00:00",
-          "deadline": "2022-10-11T18:00:00"
-        },
-        {
-          "taskid": 75,
+          "taskid": 32,
           "goalid": "free",
           "title": "free",
-          "duration": 4,
-          "start": "2022-10-11T18:00:00",
-          "deadline": "2022-10-11T22:00:00"
-        },
-        {
-          "taskid": 76,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 2,
-          "start": "2022-10-11T22:00:00",
+          "duration": 8,
+          "start": "2022-10-11T16:00:00",
           "deadline": "2022-10-12T00:00:00"
         }
       ]
@@ -675,31 +323,15 @@
       "day": "2022-10-12",
       "outputs": [
         {
-          "taskid": 77,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 6,
-          "start": "2022-10-12T00:00:00",
-          "deadline": "2022-10-12T06:00:00"
-        },
-        {
-          "taskid": 78,
+          "taskid": 33,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
-          "start": "2022-10-12T06:00:00",
-          "deadline": "2022-10-12T08:00:00"
-        },
-        {
-          "taskid": 79,
-          "goalid": "1",
-          "title": "work",
-          "duration": 3,
-          "start": "2022-10-12T08:00:00",
+          "duration": 11,
+          "start": "2022-10-12T00:00:00",
           "deadline": "2022-10-12T11:00:00"
         },
         {
-          "taskid": 80,
+          "taskid": 34,
           "goalid": "2",
           "title": "exercise",
           "duration": 5,
@@ -707,27 +339,11 @@
           "deadline": "2022-10-12T16:00:00"
         },
         {
-          "taskid": 81,
-          "goalid": "1",
-          "title": "work",
-          "duration": 2,
-          "start": "2022-10-12T16:00:00",
-          "deadline": "2022-10-12T18:00:00"
-        },
-        {
-          "taskid": 82,
+          "taskid": 35,
           "goalid": "free",
           "title": "free",
-          "duration": 4,
-          "start": "2022-10-12T18:00:00",
-          "deadline": "2022-10-12T22:00:00"
-        },
-        {
-          "taskid": 83,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 2,
-          "start": "2022-10-12T22:00:00",
+          "duration": 8,
+          "start": "2022-10-12T16:00:00",
           "deadline": "2022-10-13T00:00:00"
         }
       ]
@@ -736,31 +352,15 @@
       "day": "2022-10-13",
       "outputs": [
         {
-          "taskid": 84,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 6,
-          "start": "2022-10-13T00:00:00",
-          "deadline": "2022-10-13T06:00:00"
-        },
-        {
-          "taskid": 85,
+          "taskid": 36,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
-          "start": "2022-10-13T06:00:00",
-          "deadline": "2022-10-13T08:00:00"
-        },
-        {
-          "taskid": 86,
-          "goalid": "1",
-          "title": "work",
-          "duration": 3,
-          "start": "2022-10-13T08:00:00",
+          "duration": 11,
+          "start": "2022-10-13T00:00:00",
           "deadline": "2022-10-13T11:00:00"
         },
         {
-          "taskid": 87,
+          "taskid": 37,
           "goalid": "2",
           "title": "exercise",
           "duration": 5,
@@ -768,27 +368,11 @@
           "deadline": "2022-10-13T16:00:00"
         },
         {
-          "taskid": 88,
-          "goalid": "1",
-          "title": "work",
-          "duration": 2,
-          "start": "2022-10-13T16:00:00",
-          "deadline": "2022-10-13T18:00:00"
-        },
-        {
-          "taskid": 89,
+          "taskid": 38,
           "goalid": "free",
           "title": "free",
-          "duration": 4,
-          "start": "2022-10-13T18:00:00",
-          "deadline": "2022-10-13T22:00:00"
-        },
-        {
-          "taskid": 90,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 2,
-          "start": "2022-10-13T22:00:00",
+          "duration": 8,
+          "start": "2022-10-13T16:00:00",
           "deadline": "2022-10-14T00:00:00"
         }
       ]
@@ -797,31 +381,15 @@
       "day": "2022-10-14",
       "outputs": [
         {
-          "taskid": 91,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 6,
-          "start": "2022-10-14T00:00:00",
-          "deadline": "2022-10-14T06:00:00"
-        },
-        {
-          "taskid": 92,
+          "taskid": 39,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
-          "start": "2022-10-14T06:00:00",
-          "deadline": "2022-10-14T08:00:00"
-        },
-        {
-          "taskid": 93,
-          "goalid": "1",
-          "title": "work",
-          "duration": 3,
-          "start": "2022-10-14T08:00:00",
+          "duration": 11,
+          "start": "2022-10-14T00:00:00",
           "deadline": "2022-10-14T11:00:00"
         },
         {
-          "taskid": 94,
+          "taskid": 40,
           "goalid": "2",
           "title": "exercise",
           "duration": 5,
@@ -829,27 +397,11 @@
           "deadline": "2022-10-14T16:00:00"
         },
         {
-          "taskid": 95,
-          "goalid": "1",
-          "title": "work",
-          "duration": 2,
-          "start": "2022-10-14T16:00:00",
-          "deadline": "2022-10-14T18:00:00"
-        },
-        {
-          "taskid": 96,
+          "taskid": 41,
           "goalid": "free",
           "title": "free",
-          "duration": 4,
-          "start": "2022-10-14T18:00:00",
-          "deadline": "2022-10-14T22:00:00"
-        },
-        {
-          "taskid": 97,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 2,
-          "start": "2022-10-14T22:00:00",
+          "duration": 8,
+          "start": "2022-10-14T16:00:00",
           "deadline": "2022-10-15T00:00:00"
         }
       ]
@@ -860,10 +412,138 @@
       "day": "2022-10-01",
       "outputs": [
         {
-          "taskid": 98,
+          "taskid": 42,
+          "goalid": "1",
+          "title": "work",
+          "duration": 35,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 43,
+          "goalid": "1",
+          "title": "work",
+          "duration": 35,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 44,
           "goalid": "3",
           "title": "sleep",
-          "duration": 2,
+          "duration": 8,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 45,
+          "goalid": "3",
+          "title": "sleep",
+          "duration": 8,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 46,
+          "goalid": "3",
+          "title": "sleep",
+          "duration": 8,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 47,
+          "goalid": "3",
+          "title": "sleep",
+          "duration": 8,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 48,
+          "goalid": "3",
+          "title": "sleep",
+          "duration": 8,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 49,
+          "goalid": "3",
+          "title": "sleep",
+          "duration": 8,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 50,
+          "goalid": "3",
+          "title": "sleep",
+          "duration": 8,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 51,
+          "goalid": "3",
+          "title": "sleep",
+          "duration": 8,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 52,
+          "goalid": "3",
+          "title": "sleep",
+          "duration": 8,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 53,
+          "goalid": "3",
+          "title": "sleep",
+          "duration": 8,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 54,
+          "goalid": "3",
+          "title": "sleep",
+          "duration": 8,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 55,
+          "goalid": "3",
+          "title": "sleep",
+          "duration": 8,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 56,
+          "goalid": "3",
+          "title": "sleep",
+          "duration": 8,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 57,
+          "goalid": "3",
+          "title": "sleep",
+          "duration": 8,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 58,
+          "goalid": "3",
+          "title": "sleep",
+          "duration": 8,
           "start": "2022-10-01T00:00:00",
           "deadline": "2022-10-15T00:00:00"
         }

--- a/tests/jsons/flex-repeat-2/actual_output.json
+++ b/tests/jsons/flex-repeat-2/actual_output.json
@@ -13,8 +13,8 @@
         },
         {
           "taskid": 1,
-          "goalid": "3",
-          "title": "work",
+          "goalid": "free",
+          "title": "free",
           "duration": 9,
           "start": "2022-10-01T08:00:00",
           "deadline": "2022-10-01T17:00:00"
@@ -37,8 +37,8 @@
         },
         {
           "taskid": 4,
-          "goalid": "2",
-          "title": "sleep",
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-01T22:00:00",
           "deadline": "2022-10-02T00:00:00"
@@ -50,30 +50,14 @@
       "outputs": [
         {
           "taskid": 5,
-          "goalid": "2",
-          "title": "sleep",
-          "duration": 8,
-          "start": "2022-10-02T00:00:00",
-          "deadline": "2022-10-02T08:00:00"
-        },
-        {
-          "taskid": 6,
-          "goalid": "1-repeat-opt-1",
-          "title": "side project",
-          "duration": 8,
-          "start": "2022-10-02T08:00:00",
-          "deadline": "2022-10-02T16:00:00"
-        },
-        {
-          "taskid": 7,
           "goalid": "free",
           "title": "free",
-          "duration": 4,
-          "start": "2022-10-02T16:00:00",
+          "duration": 20,
+          "start": "2022-10-02T00:00:00",
           "deadline": "2022-10-02T20:00:00"
         },
         {
-          "taskid": 8,
+          "taskid": 6,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -81,9 +65,9 @@
           "deadline": "2022-10-02T22:00:00"
         },
         {
-          "taskid": 9,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 7,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-02T22:00:00",
           "deadline": "2022-10-03T00:00:00"
@@ -94,15 +78,15 @@
       "day": "2022-10-03",
       "outputs": [
         {
-          "taskid": 10,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 8,
+          "goalid": "free",
+          "title": "free",
           "duration": 8,
           "start": "2022-10-03T00:00:00",
           "deadline": "2022-10-03T08:00:00"
         },
         {
-          "taskid": 11,
+          "taskid": 9,
           "goalid": "3",
           "title": "work",
           "duration": 9,
@@ -110,7 +94,7 @@
           "deadline": "2022-10-03T17:00:00"
         },
         {
-          "taskid": 12,
+          "taskid": 10,
           "goalid": "4",
           "title": "exercise",
           "duration": 3,
@@ -118,7 +102,7 @@
           "deadline": "2022-10-03T20:00:00"
         },
         {
-          "taskid": 13,
+          "taskid": 11,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -126,9 +110,9 @@
           "deadline": "2022-10-03T22:00:00"
         },
         {
-          "taskid": 14,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 12,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-03T22:00:00",
           "deadline": "2022-10-04T00:00:00"
@@ -139,15 +123,15 @@
       "day": "2022-10-04",
       "outputs": [
         {
-          "taskid": 15,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 13,
+          "goalid": "free",
+          "title": "free",
           "duration": 8,
           "start": "2022-10-04T00:00:00",
           "deadline": "2022-10-04T08:00:00"
         },
         {
-          "taskid": 16,
+          "taskid": 14,
           "goalid": "3",
           "title": "work",
           "duration": 9,
@@ -155,7 +139,7 @@
           "deadline": "2022-10-04T17:00:00"
         },
         {
-          "taskid": 17,
+          "taskid": 15,
           "goalid": "4",
           "title": "exercise",
           "duration": 3,
@@ -163,7 +147,7 @@
           "deadline": "2022-10-04T20:00:00"
         },
         {
-          "taskid": 18,
+          "taskid": 16,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -171,9 +155,9 @@
           "deadline": "2022-10-04T22:00:00"
         },
         {
-          "taskid": 19,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 17,
+          "goalid": "1-repeat-opt-1",
+          "title": "side project",
           "duration": 2,
           "start": "2022-10-04T22:00:00",
           "deadline": "2022-10-05T00:00:00"
@@ -184,15 +168,23 @@
       "day": "2022-10-05",
       "outputs": [
         {
-          "taskid": 20,
-          "goalid": "2",
-          "title": "sleep",
-          "duration": 8,
+          "taskid": 18,
+          "goalid": "1-repeat-opt-1",
+          "title": "side project",
+          "duration": 6,
           "start": "2022-10-05T00:00:00",
+          "deadline": "2022-10-05T06:00:00"
+        },
+        {
+          "taskid": 19,
+          "goalid": "free",
+          "title": "free",
+          "duration": 2,
+          "start": "2022-10-05T06:00:00",
           "deadline": "2022-10-05T08:00:00"
         },
         {
-          "taskid": 21,
+          "taskid": 20,
           "goalid": "3",
           "title": "work",
           "duration": 9,
@@ -200,7 +192,7 @@
           "deadline": "2022-10-05T17:00:00"
         },
         {
-          "taskid": 22,
+          "taskid": 21,
           "goalid": "4",
           "title": "exercise",
           "duration": 3,
@@ -208,7 +200,7 @@
           "deadline": "2022-10-05T20:00:00"
         },
         {
-          "taskid": 23,
+          "taskid": 22,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -216,9 +208,9 @@
           "deadline": "2022-10-05T22:00:00"
         },
         {
-          "taskid": 24,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 23,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-05T22:00:00",
           "deadline": "2022-10-06T00:00:00"
@@ -229,15 +221,15 @@
       "day": "2022-10-06",
       "outputs": [
         {
-          "taskid": 25,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 24,
+          "goalid": "free",
+          "title": "free",
           "duration": 8,
           "start": "2022-10-06T00:00:00",
           "deadline": "2022-10-06T08:00:00"
         },
         {
-          "taskid": 26,
+          "taskid": 25,
           "goalid": "3",
           "title": "work",
           "duration": 9,
@@ -245,7 +237,7 @@
           "deadline": "2022-10-06T17:00:00"
         },
         {
-          "taskid": 27,
+          "taskid": 26,
           "goalid": "4",
           "title": "exercise",
           "duration": 3,
@@ -253,7 +245,7 @@
           "deadline": "2022-10-06T20:00:00"
         },
         {
-          "taskid": 28,
+          "taskid": 27,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -261,9 +253,9 @@
           "deadline": "2022-10-06T22:00:00"
         },
         {
-          "taskid": 29,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 28,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-06T22:00:00",
           "deadline": "2022-10-07T00:00:00"
@@ -274,15 +266,15 @@
       "day": "2022-10-07",
       "outputs": [
         {
-          "taskid": 30,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 29,
+          "goalid": "free",
+          "title": "free",
           "duration": 8,
           "start": "2022-10-07T00:00:00",
           "deadline": "2022-10-07T08:00:00"
         },
         {
-          "taskid": 31,
+          "taskid": 30,
           "goalid": "3",
           "title": "work",
           "duration": 9,
@@ -290,7 +282,7 @@
           "deadline": "2022-10-07T17:00:00"
         },
         {
-          "taskid": 32,
+          "taskid": 31,
           "goalid": "4",
           "title": "exercise",
           "duration": 3,
@@ -298,7 +290,7 @@
           "deadline": "2022-10-07T20:00:00"
         },
         {
-          "taskid": 33,
+          "taskid": 32,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -306,9 +298,9 @@
           "deadline": "2022-10-07T22:00:00"
         },
         {
-          "taskid": 34,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 33,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-07T22:00:00",
           "deadline": "2022-10-08T00:00:00"
@@ -319,7 +311,7 @@
       "day": "2022-10-08",
       "outputs": [
         {
-          "taskid": 35,
+          "taskid": 34,
           "goalid": "1",
           "title": "side project",
           "duration": 8,
@@ -327,15 +319,15 @@
           "deadline": "2022-10-08T08:00:00"
         },
         {
-          "taskid": 36,
-          "goalid": "3",
-          "title": "work",
+          "taskid": 35,
+          "goalid": "free",
+          "title": "free",
           "duration": 9,
           "start": "2022-10-08T08:00:00",
           "deadline": "2022-10-08T17:00:00"
         },
         {
-          "taskid": 37,
+          "taskid": 36,
           "goalid": "4",
           "title": "exercise",
           "duration": 3,
@@ -343,7 +335,7 @@
           "deadline": "2022-10-08T20:00:00"
         },
         {
-          "taskid": 38,
+          "taskid": 37,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -351,9 +343,9 @@
           "deadline": "2022-10-08T22:00:00"
         },
         {
-          "taskid": 39,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 38,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-08T22:00:00",
           "deadline": "2022-10-09T00:00:00"
@@ -364,31 +356,15 @@
       "day": "2022-10-09",
       "outputs": [
         {
-          "taskid": 40,
-          "goalid": "2",
-          "title": "sleep",
-          "duration": 8,
-          "start": "2022-10-09T00:00:00",
-          "deadline": "2022-10-09T08:00:00"
-        },
-        {
-          "taskid": 41,
-          "goalid": "1-repeat-opt-1",
-          "title": "side project",
-          "duration": 8,
-          "start": "2022-10-09T08:00:00",
-          "deadline": "2022-10-09T16:00:00"
-        },
-        {
-          "taskid": 42,
+          "taskid": 39,
           "goalid": "free",
           "title": "free",
-          "duration": 4,
-          "start": "2022-10-09T16:00:00",
+          "duration": 20,
+          "start": "2022-10-09T00:00:00",
           "deadline": "2022-10-09T20:00:00"
         },
         {
-          "taskid": 43,
+          "taskid": 40,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -396,9 +372,9 @@
           "deadline": "2022-10-09T22:00:00"
         },
         {
-          "taskid": 44,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 41,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-09T22:00:00",
           "deadline": "2022-10-10T00:00:00"
@@ -409,15 +385,15 @@
       "day": "2022-10-10",
       "outputs": [
         {
-          "taskid": 45,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 42,
+          "goalid": "free",
+          "title": "free",
           "duration": 8,
           "start": "2022-10-10T00:00:00",
           "deadline": "2022-10-10T08:00:00"
         },
         {
-          "taskid": 46,
+          "taskid": 43,
           "goalid": "3",
           "title": "work",
           "duration": 9,
@@ -425,7 +401,7 @@
           "deadline": "2022-10-10T17:00:00"
         },
         {
-          "taskid": 47,
+          "taskid": 44,
           "goalid": "4",
           "title": "exercise",
           "duration": 3,
@@ -433,7 +409,7 @@
           "deadline": "2022-10-10T20:00:00"
         },
         {
-          "taskid": 48,
+          "taskid": 45,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -441,9 +417,9 @@
           "deadline": "2022-10-10T22:00:00"
         },
         {
-          "taskid": 49,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 46,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-10T22:00:00",
           "deadline": "2022-10-11T00:00:00"
@@ -454,15 +430,15 @@
       "day": "2022-10-11",
       "outputs": [
         {
-          "taskid": 50,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 47,
+          "goalid": "free",
+          "title": "free",
           "duration": 8,
           "start": "2022-10-11T00:00:00",
           "deadline": "2022-10-11T08:00:00"
         },
         {
-          "taskid": 51,
+          "taskid": 48,
           "goalid": "3",
           "title": "work",
           "duration": 9,
@@ -470,7 +446,7 @@
           "deadline": "2022-10-11T17:00:00"
         },
         {
-          "taskid": 52,
+          "taskid": 49,
           "goalid": "4",
           "title": "exercise",
           "duration": 3,
@@ -478,7 +454,7 @@
           "deadline": "2022-10-11T20:00:00"
         },
         {
-          "taskid": 53,
+          "taskid": 50,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -486,9 +462,9 @@
           "deadline": "2022-10-11T22:00:00"
         },
         {
-          "taskid": 54,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 51,
+          "goalid": "1-repeat-opt-1",
+          "title": "side project",
           "duration": 2,
           "start": "2022-10-11T22:00:00",
           "deadline": "2022-10-12T00:00:00"
@@ -499,15 +475,23 @@
       "day": "2022-10-12",
       "outputs": [
         {
-          "taskid": 55,
-          "goalid": "2",
-          "title": "sleep",
-          "duration": 8,
+          "taskid": 52,
+          "goalid": "1-repeat-opt-1",
+          "title": "side project",
+          "duration": 6,
           "start": "2022-10-12T00:00:00",
+          "deadline": "2022-10-12T06:00:00"
+        },
+        {
+          "taskid": 53,
+          "goalid": "free",
+          "title": "free",
+          "duration": 2,
+          "start": "2022-10-12T06:00:00",
           "deadline": "2022-10-12T08:00:00"
         },
         {
-          "taskid": 56,
+          "taskid": 54,
           "goalid": "3",
           "title": "work",
           "duration": 9,
@@ -515,7 +499,7 @@
           "deadline": "2022-10-12T17:00:00"
         },
         {
-          "taskid": 57,
+          "taskid": 55,
           "goalid": "4",
           "title": "exercise",
           "duration": 3,
@@ -523,7 +507,7 @@
           "deadline": "2022-10-12T20:00:00"
         },
         {
-          "taskid": 58,
+          "taskid": 56,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -531,9 +515,9 @@
           "deadline": "2022-10-12T22:00:00"
         },
         {
-          "taskid": 59,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 57,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-12T22:00:00",
           "deadline": "2022-10-13T00:00:00"
@@ -544,15 +528,15 @@
       "day": "2022-10-13",
       "outputs": [
         {
-          "taskid": 60,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 58,
+          "goalid": "free",
+          "title": "free",
           "duration": 8,
           "start": "2022-10-13T00:00:00",
           "deadline": "2022-10-13T08:00:00"
         },
         {
-          "taskid": 61,
+          "taskid": 59,
           "goalid": "3",
           "title": "work",
           "duration": 9,
@@ -560,7 +544,7 @@
           "deadline": "2022-10-13T17:00:00"
         },
         {
-          "taskid": 62,
+          "taskid": 60,
           "goalid": "4",
           "title": "exercise",
           "duration": 3,
@@ -568,7 +552,7 @@
           "deadline": "2022-10-13T20:00:00"
         },
         {
-          "taskid": 63,
+          "taskid": 61,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -576,9 +560,9 @@
           "deadline": "2022-10-13T22:00:00"
         },
         {
-          "taskid": 64,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 62,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-13T22:00:00",
           "deadline": "2022-10-14T00:00:00"
@@ -589,15 +573,15 @@
       "day": "2022-10-14",
       "outputs": [
         {
-          "taskid": 65,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 63,
+          "goalid": "free",
+          "title": "free",
           "duration": 8,
           "start": "2022-10-14T00:00:00",
           "deadline": "2022-10-14T08:00:00"
         },
         {
-          "taskid": 66,
+          "taskid": 64,
           "goalid": "3",
           "title": "work",
           "duration": 9,
@@ -605,7 +589,7 @@
           "deadline": "2022-10-14T17:00:00"
         },
         {
-          "taskid": 67,
+          "taskid": 65,
           "goalid": "4",
           "title": "exercise",
           "duration": 3,
@@ -613,7 +597,7 @@
           "deadline": "2022-10-14T20:00:00"
         },
         {
-          "taskid": 68,
+          "taskid": 66,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -621,9 +605,9 @@
           "deadline": "2022-10-14T22:00:00"
         },
         {
-          "taskid": 69,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 67,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-14T22:00:00",
           "deadline": "2022-10-15T00:00:00"
@@ -634,7 +618,7 @@
       "day": "2022-10-15",
       "outputs": [
         {
-          "taskid": 70,
+          "taskid": 68,
           "goalid": "1",
           "title": "side project",
           "duration": 8,
@@ -642,15 +626,15 @@
           "deadline": "2022-10-15T08:00:00"
         },
         {
-          "taskid": 71,
-          "goalid": "3",
-          "title": "work",
+          "taskid": 69,
+          "goalid": "free",
+          "title": "free",
           "duration": 9,
           "start": "2022-10-15T08:00:00",
           "deadline": "2022-10-15T17:00:00"
         },
         {
-          "taskid": 72,
+          "taskid": 70,
           "goalid": "4",
           "title": "exercise",
           "duration": 3,
@@ -658,7 +642,7 @@
           "deadline": "2022-10-15T20:00:00"
         },
         {
-          "taskid": 73,
+          "taskid": 71,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -666,9 +650,9 @@
           "deadline": "2022-10-15T22:00:00"
         },
         {
-          "taskid": 74,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 72,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-15T22:00:00",
           "deadline": "2022-10-16T00:00:00"
@@ -679,31 +663,15 @@
       "day": "2022-10-16",
       "outputs": [
         {
-          "taskid": 75,
-          "goalid": "2",
-          "title": "sleep",
-          "duration": 8,
-          "start": "2022-10-16T00:00:00",
-          "deadline": "2022-10-16T08:00:00"
-        },
-        {
-          "taskid": 76,
-          "goalid": "1-repeat-opt-1",
-          "title": "side project",
-          "duration": 8,
-          "start": "2022-10-16T08:00:00",
-          "deadline": "2022-10-16T16:00:00"
-        },
-        {
-          "taskid": 77,
+          "taskid": 73,
           "goalid": "free",
           "title": "free",
-          "duration": 4,
-          "start": "2022-10-16T16:00:00",
+          "duration": 20,
+          "start": "2022-10-16T00:00:00",
           "deadline": "2022-10-16T20:00:00"
         },
         {
-          "taskid": 78,
+          "taskid": 74,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -711,9 +679,9 @@
           "deadline": "2022-10-16T22:00:00"
         },
         {
-          "taskid": 79,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 75,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-16T22:00:00",
           "deadline": "2022-10-17T00:00:00"
@@ -724,15 +692,15 @@
       "day": "2022-10-17",
       "outputs": [
         {
-          "taskid": 80,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 76,
+          "goalid": "free",
+          "title": "free",
           "duration": 8,
           "start": "2022-10-17T00:00:00",
           "deadline": "2022-10-17T08:00:00"
         },
         {
-          "taskid": 81,
+          "taskid": 77,
           "goalid": "3",
           "title": "work",
           "duration": 9,
@@ -740,7 +708,7 @@
           "deadline": "2022-10-17T17:00:00"
         },
         {
-          "taskid": 82,
+          "taskid": 78,
           "goalid": "4",
           "title": "exercise",
           "duration": 3,
@@ -748,7 +716,7 @@
           "deadline": "2022-10-17T20:00:00"
         },
         {
-          "taskid": 83,
+          "taskid": 79,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -756,9 +724,9 @@
           "deadline": "2022-10-17T22:00:00"
         },
         {
-          "taskid": 84,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 80,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-17T22:00:00",
           "deadline": "2022-10-18T00:00:00"
@@ -769,15 +737,15 @@
       "day": "2022-10-18",
       "outputs": [
         {
-          "taskid": 85,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 81,
+          "goalid": "free",
+          "title": "free",
           "duration": 8,
           "start": "2022-10-18T00:00:00",
           "deadline": "2022-10-18T08:00:00"
         },
         {
-          "taskid": 86,
+          "taskid": 82,
           "goalid": "3",
           "title": "work",
           "duration": 9,
@@ -785,7 +753,7 @@
           "deadline": "2022-10-18T17:00:00"
         },
         {
-          "taskid": 87,
+          "taskid": 83,
           "goalid": "4",
           "title": "exercise",
           "duration": 3,
@@ -793,7 +761,7 @@
           "deadline": "2022-10-18T20:00:00"
         },
         {
-          "taskid": 88,
+          "taskid": 84,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -801,9 +769,9 @@
           "deadline": "2022-10-18T22:00:00"
         },
         {
-          "taskid": 89,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 85,
+          "goalid": "1-repeat-opt-1",
+          "title": "side project",
           "duration": 2,
           "start": "2022-10-18T22:00:00",
           "deadline": "2022-10-19T00:00:00"
@@ -814,15 +782,23 @@
       "day": "2022-10-19",
       "outputs": [
         {
-          "taskid": 90,
-          "goalid": "2",
-          "title": "sleep",
-          "duration": 8,
+          "taskid": 86,
+          "goalid": "1-repeat-opt-1",
+          "title": "side project",
+          "duration": 6,
           "start": "2022-10-19T00:00:00",
+          "deadline": "2022-10-19T06:00:00"
+        },
+        {
+          "taskid": 87,
+          "goalid": "free",
+          "title": "free",
+          "duration": 2,
+          "start": "2022-10-19T06:00:00",
           "deadline": "2022-10-19T08:00:00"
         },
         {
-          "taskid": 91,
+          "taskid": 88,
           "goalid": "3",
           "title": "work",
           "duration": 9,
@@ -830,7 +806,7 @@
           "deadline": "2022-10-19T17:00:00"
         },
         {
-          "taskid": 92,
+          "taskid": 89,
           "goalid": "4",
           "title": "exercise",
           "duration": 3,
@@ -838,7 +814,7 @@
           "deadline": "2022-10-19T20:00:00"
         },
         {
-          "taskid": 93,
+          "taskid": 90,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -846,9 +822,9 @@
           "deadline": "2022-10-19T22:00:00"
         },
         {
-          "taskid": 94,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 91,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-19T22:00:00",
           "deadline": "2022-10-20T00:00:00"
@@ -859,15 +835,15 @@
       "day": "2022-10-20",
       "outputs": [
         {
-          "taskid": 95,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 92,
+          "goalid": "free",
+          "title": "free",
           "duration": 8,
           "start": "2022-10-20T00:00:00",
           "deadline": "2022-10-20T08:00:00"
         },
         {
-          "taskid": 96,
+          "taskid": 93,
           "goalid": "3",
           "title": "work",
           "duration": 9,
@@ -875,7 +851,7 @@
           "deadline": "2022-10-20T17:00:00"
         },
         {
-          "taskid": 97,
+          "taskid": 94,
           "goalid": "4",
           "title": "exercise",
           "duration": 3,
@@ -883,7 +859,7 @@
           "deadline": "2022-10-20T20:00:00"
         },
         {
-          "taskid": 98,
+          "taskid": 95,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -891,9 +867,9 @@
           "deadline": "2022-10-20T22:00:00"
         },
         {
-          "taskid": 99,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 96,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-20T22:00:00",
           "deadline": "2022-10-21T00:00:00"
@@ -904,15 +880,15 @@
       "day": "2022-10-21",
       "outputs": [
         {
-          "taskid": 100,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 97,
+          "goalid": "free",
+          "title": "free",
           "duration": 8,
           "start": "2022-10-21T00:00:00",
           "deadline": "2022-10-21T08:00:00"
         },
         {
-          "taskid": 101,
+          "taskid": 98,
           "goalid": "3",
           "title": "work",
           "duration": 9,
@@ -920,7 +896,7 @@
           "deadline": "2022-10-21T17:00:00"
         },
         {
-          "taskid": 102,
+          "taskid": 99,
           "goalid": "4",
           "title": "exercise",
           "duration": 3,
@@ -928,7 +904,7 @@
           "deadline": "2022-10-21T20:00:00"
         },
         {
-          "taskid": 103,
+          "taskid": 100,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -936,9 +912,9 @@
           "deadline": "2022-10-21T22:00:00"
         },
         {
-          "taskid": 104,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 101,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-21T22:00:00",
           "deadline": "2022-10-22T00:00:00"
@@ -949,7 +925,7 @@
       "day": "2022-10-22",
       "outputs": [
         {
-          "taskid": 105,
+          "taskid": 102,
           "goalid": "1",
           "title": "side project",
           "duration": 8,
@@ -957,15 +933,15 @@
           "deadline": "2022-10-22T08:00:00"
         },
         {
-          "taskid": 106,
-          "goalid": "3",
-          "title": "work",
+          "taskid": 103,
+          "goalid": "free",
+          "title": "free",
           "duration": 9,
           "start": "2022-10-22T08:00:00",
           "deadline": "2022-10-22T17:00:00"
         },
         {
-          "taskid": 107,
+          "taskid": 104,
           "goalid": "4",
           "title": "exercise",
           "duration": 3,
@@ -973,7 +949,7 @@
           "deadline": "2022-10-22T20:00:00"
         },
         {
-          "taskid": 108,
+          "taskid": 105,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -981,9 +957,9 @@
           "deadline": "2022-10-22T22:00:00"
         },
         {
-          "taskid": 109,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 106,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-22T22:00:00",
           "deadline": "2022-10-23T00:00:00"
@@ -994,31 +970,15 @@
       "day": "2022-10-23",
       "outputs": [
         {
-          "taskid": 110,
-          "goalid": "2",
-          "title": "sleep",
-          "duration": 8,
-          "start": "2022-10-23T00:00:00",
-          "deadline": "2022-10-23T08:00:00"
-        },
-        {
-          "taskid": 111,
-          "goalid": "1-repeat-opt-1",
-          "title": "side project",
-          "duration": 8,
-          "start": "2022-10-23T08:00:00",
-          "deadline": "2022-10-23T16:00:00"
-        },
-        {
-          "taskid": 112,
+          "taskid": 107,
           "goalid": "free",
           "title": "free",
-          "duration": 4,
-          "start": "2022-10-23T16:00:00",
+          "duration": 20,
+          "start": "2022-10-23T00:00:00",
           "deadline": "2022-10-23T20:00:00"
         },
         {
-          "taskid": 113,
+          "taskid": 108,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -1026,9 +986,9 @@
           "deadline": "2022-10-23T22:00:00"
         },
         {
-          "taskid": 114,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 109,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-23T22:00:00",
           "deadline": "2022-10-24T00:00:00"
@@ -1039,15 +999,15 @@
       "day": "2022-10-24",
       "outputs": [
         {
-          "taskid": 115,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 110,
+          "goalid": "free",
+          "title": "free",
           "duration": 8,
           "start": "2022-10-24T00:00:00",
           "deadline": "2022-10-24T08:00:00"
         },
         {
-          "taskid": 116,
+          "taskid": 111,
           "goalid": "3",
           "title": "work",
           "duration": 9,
@@ -1055,7 +1015,7 @@
           "deadline": "2022-10-24T17:00:00"
         },
         {
-          "taskid": 117,
+          "taskid": 112,
           "goalid": "4",
           "title": "exercise",
           "duration": 3,
@@ -1063,7 +1023,7 @@
           "deadline": "2022-10-24T20:00:00"
         },
         {
-          "taskid": 118,
+          "taskid": 113,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -1071,9 +1031,9 @@
           "deadline": "2022-10-24T22:00:00"
         },
         {
-          "taskid": 119,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 114,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-24T22:00:00",
           "deadline": "2022-10-25T00:00:00"
@@ -1084,15 +1044,15 @@
       "day": "2022-10-25",
       "outputs": [
         {
-          "taskid": 120,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 115,
+          "goalid": "free",
+          "title": "free",
           "duration": 8,
           "start": "2022-10-25T00:00:00",
           "deadline": "2022-10-25T08:00:00"
         },
         {
-          "taskid": 121,
+          "taskid": 116,
           "goalid": "3",
           "title": "work",
           "duration": 9,
@@ -1100,7 +1060,7 @@
           "deadline": "2022-10-25T17:00:00"
         },
         {
-          "taskid": 122,
+          "taskid": 117,
           "goalid": "4",
           "title": "exercise",
           "duration": 3,
@@ -1108,7 +1068,7 @@
           "deadline": "2022-10-25T20:00:00"
         },
         {
-          "taskid": 123,
+          "taskid": 118,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -1116,9 +1076,9 @@
           "deadline": "2022-10-25T22:00:00"
         },
         {
-          "taskid": 124,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 119,
+          "goalid": "1-repeat-opt-1",
+          "title": "side project",
           "duration": 2,
           "start": "2022-10-25T22:00:00",
           "deadline": "2022-10-26T00:00:00"
@@ -1129,15 +1089,23 @@
       "day": "2022-10-26",
       "outputs": [
         {
-          "taskid": 125,
-          "goalid": "2",
-          "title": "sleep",
-          "duration": 8,
+          "taskid": 120,
+          "goalid": "1-repeat-opt-1",
+          "title": "side project",
+          "duration": 6,
           "start": "2022-10-26T00:00:00",
+          "deadline": "2022-10-26T06:00:00"
+        },
+        {
+          "taskid": 121,
+          "goalid": "free",
+          "title": "free",
+          "duration": 2,
+          "start": "2022-10-26T06:00:00",
           "deadline": "2022-10-26T08:00:00"
         },
         {
-          "taskid": 126,
+          "taskid": 122,
           "goalid": "3",
           "title": "work",
           "duration": 9,
@@ -1145,7 +1113,7 @@
           "deadline": "2022-10-26T17:00:00"
         },
         {
-          "taskid": 127,
+          "taskid": 123,
           "goalid": "4",
           "title": "exercise",
           "duration": 3,
@@ -1153,7 +1121,7 @@
           "deadline": "2022-10-26T20:00:00"
         },
         {
-          "taskid": 128,
+          "taskid": 124,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -1161,9 +1129,9 @@
           "deadline": "2022-10-26T22:00:00"
         },
         {
-          "taskid": 129,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 125,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-26T22:00:00",
           "deadline": "2022-10-27T00:00:00"
@@ -1174,15 +1142,15 @@
       "day": "2022-10-27",
       "outputs": [
         {
-          "taskid": 130,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 126,
+          "goalid": "free",
+          "title": "free",
           "duration": 8,
           "start": "2022-10-27T00:00:00",
           "deadline": "2022-10-27T08:00:00"
         },
         {
-          "taskid": 131,
+          "taskid": 127,
           "goalid": "3",
           "title": "work",
           "duration": 9,
@@ -1190,7 +1158,7 @@
           "deadline": "2022-10-27T17:00:00"
         },
         {
-          "taskid": 132,
+          "taskid": 128,
           "goalid": "4",
           "title": "exercise",
           "duration": 3,
@@ -1198,7 +1166,7 @@
           "deadline": "2022-10-27T20:00:00"
         },
         {
-          "taskid": 133,
+          "taskid": 129,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -1206,9 +1174,9 @@
           "deadline": "2022-10-27T22:00:00"
         },
         {
-          "taskid": 134,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 130,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-27T22:00:00",
           "deadline": "2022-10-28T00:00:00"
@@ -1219,15 +1187,15 @@
       "day": "2022-10-28",
       "outputs": [
         {
-          "taskid": 135,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 131,
+          "goalid": "free",
+          "title": "free",
           "duration": 8,
           "start": "2022-10-28T00:00:00",
           "deadline": "2022-10-28T08:00:00"
         },
         {
-          "taskid": 136,
+          "taskid": 132,
           "goalid": "3",
           "title": "work",
           "duration": 9,
@@ -1235,7 +1203,7 @@
           "deadline": "2022-10-28T17:00:00"
         },
         {
-          "taskid": 137,
+          "taskid": 133,
           "goalid": "4",
           "title": "exercise",
           "duration": 3,
@@ -1243,7 +1211,7 @@
           "deadline": "2022-10-28T20:00:00"
         },
         {
-          "taskid": 138,
+          "taskid": 134,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -1251,9 +1219,9 @@
           "deadline": "2022-10-28T22:00:00"
         },
         {
-          "taskid": 139,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 135,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-28T22:00:00",
           "deadline": "2022-10-29T00:00:00"
@@ -1264,7 +1232,7 @@
       "day": "2022-10-29",
       "outputs": [
         {
-          "taskid": 140,
+          "taskid": 136,
           "goalid": "1",
           "title": "side project",
           "duration": 8,
@@ -1272,15 +1240,15 @@
           "deadline": "2022-10-29T08:00:00"
         },
         {
-          "taskid": 141,
-          "goalid": "3",
-          "title": "work",
+          "taskid": 137,
+          "goalid": "free",
+          "title": "free",
           "duration": 9,
           "start": "2022-10-29T08:00:00",
           "deadline": "2022-10-29T17:00:00"
         },
         {
-          "taskid": 142,
+          "taskid": 138,
           "goalid": "4",
           "title": "exercise",
           "duration": 3,
@@ -1288,7 +1256,7 @@
           "deadline": "2022-10-29T20:00:00"
         },
         {
-          "taskid": 143,
+          "taskid": 139,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -1296,9 +1264,9 @@
           "deadline": "2022-10-29T22:00:00"
         },
         {
-          "taskid": 144,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 140,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-29T22:00:00",
           "deadline": "2022-10-30T00:00:00"
@@ -1309,31 +1277,15 @@
       "day": "2022-10-30",
       "outputs": [
         {
-          "taskid": 145,
-          "goalid": "2",
-          "title": "sleep",
-          "duration": 8,
-          "start": "2022-10-30T00:00:00",
-          "deadline": "2022-10-30T08:00:00"
-        },
-        {
-          "taskid": 146,
-          "goalid": "1-repeat-opt-1",
-          "title": "side project",
-          "duration": 8,
-          "start": "2022-10-30T08:00:00",
-          "deadline": "2022-10-30T16:00:00"
-        },
-        {
-          "taskid": 147,
+          "taskid": 141,
           "goalid": "free",
           "title": "free",
-          "duration": 4,
-          "start": "2022-10-30T16:00:00",
+          "duration": 20,
+          "start": "2022-10-30T00:00:00",
           "deadline": "2022-10-30T20:00:00"
         },
         {
-          "taskid": 148,
+          "taskid": 142,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -1341,9 +1293,9 @@
           "deadline": "2022-10-30T22:00:00"
         },
         {
-          "taskid": 149,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 143,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-30T22:00:00",
           "deadline": "2022-10-31T00:00:00"
@@ -1354,15 +1306,15 @@
       "day": "2022-10-31",
       "outputs": [
         {
-          "taskid": 150,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 144,
+          "goalid": "free",
+          "title": "free",
           "duration": 8,
           "start": "2022-10-31T00:00:00",
           "deadline": "2022-10-31T08:00:00"
         },
         {
-          "taskid": 151,
+          "taskid": 145,
           "goalid": "3",
           "title": "work",
           "duration": 9,
@@ -1370,7 +1322,7 @@
           "deadline": "2022-10-31T17:00:00"
         },
         {
-          "taskid": 152,
+          "taskid": 146,
           "goalid": "4",
           "title": "exercise",
           "duration": 3,
@@ -1378,7 +1330,7 @@
           "deadline": "2022-10-31T20:00:00"
         },
         {
-          "taskid": 153,
+          "taskid": 147,
           "goalid": "5",
           "title": "family time",
           "duration": 2,
@@ -1386,12 +1338,12 @@
           "deadline": "2022-10-31T22:00:00"
         },
         {
-          "taskid": 154,
-          "goalid": "2",
-          "title": "sleep",
-          "duration": 10,
+          "taskid": 148,
+          "goalid": "free",
+          "title": "free",
+          "duration": 2,
           "start": "2022-10-31T22:00:00",
-          "deadline": "2022-11-01T08:00:00"
+          "deadline": "2022-11-01T00:00:00"
         }
       ]
     }
@@ -1401,10 +1353,58 @@
       "day": "2022-10-01",
       "outputs": [
         {
+          "taskid": 149,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 150,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 151,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 152,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 153,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 154,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
           "taskid": 155,
           "goalid": "2",
           "title": "sleep",
-          "duration": 8,
+          "duration": 10,
           "start": "2022-10-01T00:00:00",
           "deadline": "2022-11-01T00:00:00"
         },
@@ -1412,7 +1412,7 @@
           "taskid": 156,
           "goalid": "2",
           "title": "sleep",
-          "duration": 8,
+          "duration": 10,
           "start": "2022-10-01T00:00:00",
           "deadline": "2022-11-01T00:00:00"
         },
@@ -1420,7 +1420,7 @@
           "taskid": 157,
           "goalid": "2",
           "title": "sleep",
-          "duration": 8,
+          "duration": 10,
           "start": "2022-10-01T00:00:00",
           "deadline": "2022-11-01T00:00:00"
         },
@@ -1428,7 +1428,7 @@
           "taskid": 158,
           "goalid": "2",
           "title": "sleep",
-          "duration": 8,
+          "duration": 10,
           "start": "2022-10-01T00:00:00",
           "deadline": "2022-11-01T00:00:00"
         },
@@ -1436,7 +1436,7 @@
           "taskid": 159,
           "goalid": "2",
           "title": "sleep",
-          "duration": 8,
+          "duration": 10,
           "start": "2022-10-01T00:00:00",
           "deadline": "2022-11-01T00:00:00"
         },
@@ -1444,7 +1444,207 @@
           "taskid": 160,
           "goalid": "2",
           "title": "sleep",
-          "duration": 2,
+          "duration": 10,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 161,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 162,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 163,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 164,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 165,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 166,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 167,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 168,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 169,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 170,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 171,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 172,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 173,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 174,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 175,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 176,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 177,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 178,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 179,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 180,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 181,
+          "goalid": "3",
+          "title": "work",
+          "duration": 9,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 182,
+          "goalid": "3",
+          "title": "work",
+          "duration": 9,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 183,
+          "goalid": "3",
+          "title": "work",
+          "duration": 9,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 184,
+          "goalid": "3",
+          "title": "work",
+          "duration": 9,
+          "start": "2022-10-01T00:00:00",
+          "deadline": "2022-11-01T00:00:00"
+        },
+        {
+          "taskid": 185,
+          "goalid": "3",
+          "title": "work",
+          "duration": 9,
           "start": "2022-10-01T00:00:00",
           "deadline": "2022-11-01T00:00:00"
         }

--- a/tests/jsons/flex-repeat-3/actual_output.json
+++ b/tests/jsons/flex-repeat-3/actual_output.json
@@ -13,8 +13,8 @@
         },
         {
           "taskid": 1,
-          "goalid": "3",
-          "title": "work",
+          "goalid": "4",
+          "title": "family",
           "duration": 6,
           "start": "2022-10-01T08:00:00",
           "deadline": "2022-10-01T14:00:00"
@@ -29,8 +29,8 @@
         },
         {
           "taskid": 3,
-          "goalid": "1-repeat-1",
-          "title": "side project",
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-01T22:00:00",
           "deadline": "2022-10-02T00:00:00"
@@ -42,50 +42,10 @@
       "outputs": [
         {
           "taskid": 4,
-          "goalid": "1-repeat-1",
-          "title": "side project",
-          "duration": 6,
+          "goalid": "free",
+          "title": "free",
+          "duration": 24,
           "start": "2022-10-02T00:00:00",
-          "deadline": "2022-10-02T06:00:00"
-        },
-        {
-          "taskid": 5,
-          "goalid": "1-repeat-2",
-          "title": "side project",
-          "duration": 2,
-          "start": "2022-10-02T06:00:00",
-          "deadline": "2022-10-02T08:00:00"
-        },
-        {
-          "taskid": 6,
-          "goalid": "3",
-          "title": "work",
-          "duration": 6,
-          "start": "2022-10-02T08:00:00",
-          "deadline": "2022-10-02T14:00:00"
-        },
-        {
-          "taskid": 7,
-          "goalid": "1-repeat-2",
-          "title": "side project",
-          "duration": 6,
-          "start": "2022-10-02T14:00:00",
-          "deadline": "2022-10-02T20:00:00"
-        },
-        {
-          "taskid": 8,
-          "goalid": "3",
-          "title": "work",
-          "duration": 2,
-          "start": "2022-10-02T20:00:00",
-          "deadline": "2022-10-02T22:00:00"
-        },
-        {
-          "taskid": 9,
-          "goalid": "2",
-          "title": "sleep",
-          "duration": 2,
-          "start": "2022-10-02T22:00:00",
           "deadline": "2022-10-03T00:00:00"
         }
       ]
@@ -94,15 +54,15 @@
       "day": "2022-10-03",
       "outputs": [
         {
-          "taskid": 10,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 5,
+          "goalid": "free",
+          "title": "free",
           "duration": 8,
           "start": "2022-10-03T00:00:00",
           "deadline": "2022-10-03T08:00:00"
         },
         {
-          "taskid": 11,
+          "taskid": 6,
           "goalid": "3",
           "title": "work",
           "duration": 14,
@@ -110,9 +70,9 @@
           "deadline": "2022-10-03T22:00:00"
         },
         {
-          "taskid": 12,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 7,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-03T22:00:00",
           "deadline": "2022-10-04T00:00:00"
@@ -123,15 +83,15 @@
       "day": "2022-10-04",
       "outputs": [
         {
-          "taskid": 13,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 8,
+          "goalid": "free",
+          "title": "free",
           "duration": 8,
           "start": "2022-10-04T00:00:00",
           "deadline": "2022-10-04T08:00:00"
         },
         {
-          "taskid": 14,
+          "taskid": 9,
           "goalid": "3",
           "title": "work",
           "duration": 14,
@@ -139,9 +99,9 @@
           "deadline": "2022-10-04T22:00:00"
         },
         {
-          "taskid": 15,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 10,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-04T22:00:00",
           "deadline": "2022-10-05T00:00:00"
@@ -152,15 +112,15 @@
       "day": "2022-10-05",
       "outputs": [
         {
-          "taskid": 16,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 11,
+          "goalid": "free",
+          "title": "free",
           "duration": 8,
           "start": "2022-10-05T00:00:00",
           "deadline": "2022-10-05T08:00:00"
         },
         {
-          "taskid": 17,
+          "taskid": 12,
           "goalid": "3",
           "title": "work",
           "duration": 14,
@@ -168,9 +128,9 @@
           "deadline": "2022-10-05T22:00:00"
         },
         {
-          "taskid": 18,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 13,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-05T22:00:00",
           "deadline": "2022-10-06T00:00:00"
@@ -181,15 +141,15 @@
       "day": "2022-10-06",
       "outputs": [
         {
-          "taskid": 19,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 14,
+          "goalid": "free",
+          "title": "free",
           "duration": 8,
           "start": "2022-10-06T00:00:00",
           "deadline": "2022-10-06T08:00:00"
         },
         {
-          "taskid": 20,
+          "taskid": 15,
           "goalid": "3",
           "title": "work",
           "duration": 14,
@@ -197,9 +157,9 @@
           "deadline": "2022-10-06T22:00:00"
         },
         {
-          "taskid": 21,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 16,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-06T22:00:00",
           "deadline": "2022-10-07T00:00:00"
@@ -210,15 +170,15 @@
       "day": "2022-10-07",
       "outputs": [
         {
-          "taskid": 22,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 17,
+          "goalid": "free",
+          "title": "free",
           "duration": 8,
           "start": "2022-10-07T00:00:00",
           "deadline": "2022-10-07T08:00:00"
         },
         {
-          "taskid": 23,
+          "taskid": 18,
           "goalid": "3",
           "title": "work",
           "duration": 14,
@@ -226,9 +186,9 @@
           "deadline": "2022-10-07T22:00:00"
         },
         {
-          "taskid": 24,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 19,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-07T22:00:00",
           "deadline": "2022-10-08T00:00:00"
@@ -239,7 +199,7 @@
       "day": "2022-10-08",
       "outputs": [
         {
-          "taskid": 25,
+          "taskid": 20,
           "goalid": "1",
           "title": "side project",
           "duration": 8,
@@ -247,27 +207,19 @@
           "deadline": "2022-10-08T08:00:00"
         },
         {
-          "taskid": 26,
-          "goalid": "3",
-          "title": "work",
+          "taskid": 21,
+          "goalid": "4",
+          "title": "family",
           "duration": 6,
           "start": "2022-10-08T08:00:00",
           "deadline": "2022-10-08T14:00:00"
         },
         {
-          "taskid": 27,
-          "goalid": "1-repeat-1",
-          "title": "side project",
-          "duration": 8,
+          "taskid": 22,
+          "goalid": "free",
+          "title": "free",
+          "duration": 10,
           "start": "2022-10-08T14:00:00",
-          "deadline": "2022-10-08T22:00:00"
-        },
-        {
-          "taskid": 28,
-          "goalid": "1-repeat-2",
-          "title": "side project",
-          "duration": 2,
-          "start": "2022-10-08T22:00:00",
           "deadline": "2022-10-09T00:00:00"
         }
       ]
@@ -276,43 +228,11 @@
       "day": "2022-10-09",
       "outputs": [
         {
-          "taskid": 29,
-          "goalid": "1-repeat-2",
-          "title": "side project",
-          "duration": 6,
+          "taskid": 23,
+          "goalid": "free",
+          "title": "free",
+          "duration": 24,
           "start": "2022-10-09T00:00:00",
-          "deadline": "2022-10-09T06:00:00"
-        },
-        {
-          "taskid": 30,
-          "goalid": "2",
-          "title": "sleep",
-          "duration": 2,
-          "start": "2022-10-09T06:00:00",
-          "deadline": "2022-10-09T08:00:00"
-        },
-        {
-          "taskid": 31,
-          "goalid": "4",
-          "title": "family",
-          "duration": 6,
-          "start": "2022-10-09T08:00:00",
-          "deadline": "2022-10-09T14:00:00"
-        },
-        {
-          "taskid": 32,
-          "goalid": "3",
-          "title": "work",
-          "duration": 8,
-          "start": "2022-10-09T14:00:00",
-          "deadline": "2022-10-09T22:00:00"
-        },
-        {
-          "taskid": 33,
-          "goalid": "2",
-          "title": "sleep",
-          "duration": 2,
-          "start": "2022-10-09T22:00:00",
           "deadline": "2022-10-10T00:00:00"
         }
       ]
@@ -321,15 +241,15 @@
       "day": "2022-10-10",
       "outputs": [
         {
-          "taskid": 34,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 24,
+          "goalid": "free",
+          "title": "free",
           "duration": 8,
           "start": "2022-10-10T00:00:00",
           "deadline": "2022-10-10T08:00:00"
         },
         {
-          "taskid": 35,
+          "taskid": 25,
           "goalid": "3",
           "title": "work",
           "duration": 14,
@@ -337,9 +257,9 @@
           "deadline": "2022-10-10T22:00:00"
         },
         {
-          "taskid": 36,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 26,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-10T22:00:00",
           "deadline": "2022-10-11T00:00:00"
@@ -350,15 +270,15 @@
       "day": "2022-10-11",
       "outputs": [
         {
-          "taskid": 37,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 27,
+          "goalid": "free",
+          "title": "free",
           "duration": 8,
           "start": "2022-10-11T00:00:00",
           "deadline": "2022-10-11T08:00:00"
         },
         {
-          "taskid": 38,
+          "taskid": 28,
           "goalid": "3",
           "title": "work",
           "duration": 14,
@@ -366,9 +286,9 @@
           "deadline": "2022-10-11T22:00:00"
         },
         {
-          "taskid": 39,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 29,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-11T22:00:00",
           "deadline": "2022-10-12T00:00:00"
@@ -379,15 +299,15 @@
       "day": "2022-10-12",
       "outputs": [
         {
-          "taskid": 40,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 30,
+          "goalid": "free",
+          "title": "free",
           "duration": 8,
           "start": "2022-10-12T00:00:00",
           "deadline": "2022-10-12T08:00:00"
         },
         {
-          "taskid": 41,
+          "taskid": 31,
           "goalid": "3",
           "title": "work",
           "duration": 14,
@@ -395,9 +315,9 @@
           "deadline": "2022-10-12T22:00:00"
         },
         {
-          "taskid": 42,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 32,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-12T22:00:00",
           "deadline": "2022-10-13T00:00:00"
@@ -408,15 +328,15 @@
       "day": "2022-10-13",
       "outputs": [
         {
-          "taskid": 43,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 33,
+          "goalid": "free",
+          "title": "free",
           "duration": 8,
           "start": "2022-10-13T00:00:00",
           "deadline": "2022-10-13T08:00:00"
         },
         {
-          "taskid": 44,
+          "taskid": 34,
           "goalid": "3",
           "title": "work",
           "duration": 14,
@@ -424,9 +344,9 @@
           "deadline": "2022-10-13T22:00:00"
         },
         {
-          "taskid": 45,
-          "goalid": "2",
-          "title": "sleep",
+          "taskid": 35,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-10-13T22:00:00",
           "deadline": "2022-10-14T00:00:00"
@@ -439,10 +359,90 @@
       "day": "2022-10-01",
       "outputs": [
         {
+          "taskid": 36,
+          "goalid": "1-repeat-2",
+          "title": "side project",
+          "duration": 8,
+          "start": "2022-10-01T08:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 37,
+          "goalid": "1-repeat-1",
+          "title": "side project",
+          "duration": 8,
+          "start": "2022-10-01T08:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 38,
+          "goalid": "1-repeat-2",
+          "title": "side project",
+          "duration": 8,
+          "start": "2022-10-01T08:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 39,
+          "goalid": "3",
+          "title": "work",
+          "duration": 14,
+          "start": "2022-10-01T08:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 40,
+          "goalid": "3",
+          "title": "work",
+          "duration": 14,
+          "start": "2022-10-01T08:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 41,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T08:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 42,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T08:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 43,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T08:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 44,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T08:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 45,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T08:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
           "taskid": 46,
           "goalid": "2",
           "title": "sleep",
-          "duration": 8,
+          "duration": 10,
           "start": "2022-10-01T08:00:00",
           "deadline": "2022-10-15T00:00:00"
         },
@@ -450,7 +450,7 @@
           "taskid": 47,
           "goalid": "2",
           "title": "sleep",
-          "duration": 6,
+          "duration": 10,
           "start": "2022-10-01T08:00:00",
           "deadline": "2022-10-15T00:00:00"
         },
@@ -458,15 +458,15 @@
           "taskid": 48,
           "goalid": "2",
           "title": "sleep",
-          "duration": 2,
+          "duration": 10,
           "start": "2022-10-01T08:00:00",
           "deadline": "2022-10-15T00:00:00"
         },
         {
           "taskid": 49,
-          "goalid": "4",
-          "title": "family",
-          "duration": 6,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
           "start": "2022-10-01T08:00:00",
           "deadline": "2022-10-15T00:00:00"
         },
@@ -480,6 +480,38 @@
         },
         {
           "taskid": 51,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T08:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 52,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T08:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 53,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T08:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 54,
+          "goalid": "2",
+          "title": "sleep",
+          "duration": 10,
+          "start": "2022-10-01T08:00:00",
+          "deadline": "2022-10-15T00:00:00"
+        },
+        {
+          "taskid": 55,
           "goalid": "2",
           "title": "sleep",
           "duration": 10,

--- a/tests/jsons/goals-dependency/actual_output.json
+++ b/tests/jsons/goals-dependency/actual_output.json
@@ -29,18 +29,10 @@
         },
         {
           "taskid": 3,
-          "goalid": "2",
-          "title": "program a ZinZen app in rust",
-          "duration": 2,
-          "start": "2018-01-01T14:00:00",
-          "deadline": "2018-01-01T16:00:00"
-        },
-        {
-          "taskid": 4,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
-          "start": "2018-01-01T16:00:00",
+          "duration": 10,
+          "start": "2018-01-01T14:00:00",
           "deadline": "2018-01-02T00:00:00"
         }
       ]
@@ -49,35 +41,11 @@
       "day": "2018-01-02",
       "outputs": [
         {
-          "taskid": 5,
+          "taskid": 4,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2018-01-02T00:00:00",
-          "deadline": "2018-01-02T08:00:00"
-        },
-        {
-          "taskid": 6,
-          "goalid": "2",
-          "title": "program a ZinZen app in rust",
-          "duration": 6,
-          "start": "2018-01-02T08:00:00",
-          "deadline": "2018-01-02T14:00:00"
-        },
-        {
-          "taskid": 7,
-          "goalid": "3",
-          "title": "learn rust programming",
-          "duration": 2,
-          "start": "2018-01-02T14:00:00",
-          "deadline": "2018-01-02T16:00:00"
-        },
-        {
-          "taskid": 8,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2018-01-02T16:00:00",
           "deadline": "2018-01-03T00:00:00"
         }
       ]
@@ -86,7 +54,7 @@
       "day": "2018-01-03",
       "outputs": [
         {
-          "taskid": 9,
+          "taskid": 5,
           "goalid": "free",
           "title": "free",
           "duration": 8,
@@ -94,19 +62,19 @@
           "deadline": "2018-01-03T08:00:00"
         },
         {
-          "taskid": 10,
-          "goalid": "3",
-          "title": "learn rust programming",
-          "duration": 6,
+          "taskid": 6,
+          "goalid": "2",
+          "title": "program a ZinZen app in rust",
+          "duration": 8,
           "start": "2018-01-03T08:00:00",
-          "deadline": "2018-01-03T14:00:00"
+          "deadline": "2018-01-03T16:00:00"
         },
         {
-          "taskid": 11,
+          "taskid": 7,
           "goalid": "free",
           "title": "free",
-          "duration": 10,
-          "start": "2018-01-03T14:00:00",
+          "duration": 8,
+          "start": "2018-01-03T16:00:00",
           "deadline": "2018-01-04T00:00:00"
         }
       ]
@@ -115,7 +83,7 @@
       "day": "2018-01-04",
       "outputs": [
         {
-          "taskid": 12,
+          "taskid": 8,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -128,7 +96,7 @@
       "day": "2018-01-05",
       "outputs": [
         {
-          "taskid": 13,
+          "taskid": 9,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -141,7 +109,16 @@
   "impossible": [
     {
       "day": "2018-01-01",
-      "outputs": []
+      "outputs": [
+        {
+          "taskid": 10,
+          "goalid": "3",
+          "title": "learn rust programming",
+          "duration": 8,
+          "start": "2018-01-01T00:00:00",
+          "deadline": "2018-01-06T00:00:00"
+        }
+      ]
     },
     {
       "day": "2018-01-02",

--- a/tests/jsons/goals-hierarchy/actual_output.json
+++ b/tests/jsons/goals-hierarchy/actual_output.json
@@ -7,24 +7,8 @@
           "taskid": 0,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2018-01-01T00:00:00",
-          "deadline": "2018-01-01T08:00:00"
-        },
-        {
-          "taskid": 1,
-          "goalid": "2",
-          "title": "Project X",
-          "duration": 8,
-          "start": "2018-01-01T08:00:00",
-          "deadline": "2018-01-01T16:00:00"
-        },
-        {
-          "taskid": 2,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2018-01-01T16:00:00",
           "deadline": "2018-01-02T00:00:00"
         }
       ]
@@ -33,35 +17,11 @@
       "day": "2018-01-02",
       "outputs": [
         {
-          "taskid": 3,
+          "taskid": 1,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2018-01-02T00:00:00",
-          "deadline": "2018-01-02T08:00:00"
-        },
-        {
-          "taskid": 4,
-          "goalid": "2",
-          "title": "Project X",
-          "duration": 2,
-          "start": "2018-01-02T08:00:00",
-          "deadline": "2018-01-02T10:00:00"
-        },
-        {
-          "taskid": 5,
-          "goalid": "1",
-          "title": "Day job filler",
-          "duration": 6,
-          "start": "2018-01-02T10:00:00",
-          "deadline": "2018-01-02T16:00:00"
-        },
-        {
-          "taskid": 6,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2018-01-02T16:00:00",
           "deadline": "2018-01-03T00:00:00"
         }
       ]
@@ -70,27 +30,11 @@
       "day": "2018-01-03",
       "outputs": [
         {
-          "taskid": 7,
+          "taskid": 2,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2018-01-03T00:00:00",
-          "deadline": "2018-01-03T08:00:00"
-        },
-        {
-          "taskid": 8,
-          "goalid": "1",
-          "title": "Day job filler",
-          "duration": 8,
-          "start": "2018-01-03T08:00:00",
-          "deadline": "2018-01-03T16:00:00"
-        },
-        {
-          "taskid": 9,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2018-01-03T16:00:00",
           "deadline": "2018-01-04T00:00:00"
         }
       ]
@@ -99,27 +43,11 @@
       "day": "2018-01-04",
       "outputs": [
         {
-          "taskid": 10,
+          "taskid": 3,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2018-01-04T00:00:00",
-          "deadline": "2018-01-04T08:00:00"
-        },
-        {
-          "taskid": 11,
-          "goalid": "1",
-          "title": "Day job filler",
-          "duration": 8,
-          "start": "2018-01-04T08:00:00",
-          "deadline": "2018-01-04T16:00:00"
-        },
-        {
-          "taskid": 12,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2018-01-04T16:00:00",
           "deadline": "2018-01-05T00:00:00"
         }
       ]
@@ -128,27 +56,11 @@
       "day": "2018-01-05",
       "outputs": [
         {
-          "taskid": 13,
+          "taskid": 4,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2018-01-05T00:00:00",
-          "deadline": "2018-01-05T08:00:00"
-        },
-        {
-          "taskid": 14,
-          "goalid": "1",
-          "title": "Day job filler",
-          "duration": 8,
-          "start": "2018-01-05T08:00:00",
-          "deadline": "2018-01-05T16:00:00"
-        },
-        {
-          "taskid": 15,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2018-01-05T16:00:00",
           "deadline": "2018-01-06T00:00:00"
         }
       ]
@@ -157,7 +69,24 @@
   "impossible": [
     {
       "day": "2018-01-01",
-      "outputs": []
+      "outputs": [
+        {
+          "taskid": 5,
+          "goalid": "2",
+          "title": "Project X",
+          "duration": 10,
+          "start": "2018-01-01T00:00:00",
+          "deadline": "2018-01-06T00:00:00"
+        },
+        {
+          "taskid": 6,
+          "goalid": "1",
+          "title": "Day job filler",
+          "duration": 30,
+          "start": "2018-01-01T00:00:00",
+          "deadline": "2018-01-06T00:00:00"
+        }
+      ]
     },
     {
       "day": "2018-01-02",

--- a/tests/jsons/i287-mix-budgets-many-goals/actual_output.json
+++ b/tests/jsons/i287-mix-budgets-many-goals/actual_output.json
@@ -13,18 +13,26 @@
         },
         {
           "taskid": 1,
-          "goalid": "1",
-          "title": "work",
-          "duration": 5,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
           "start": "2022-10-01T02:00:00",
-          "deadline": "2022-10-01T07:00:00"
+          "deadline": "2022-10-01T03:00:00"
         },
         {
           "taskid": 2,
+          "goalid": "1",
+          "title": "work",
+          "duration": 5,
+          "start": "2022-10-01T03:00:00",
+          "deadline": "2022-10-01T08:00:00"
+        },
+        {
+          "taskid": 3,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-01T07:00:00",
+          "duration": 16,
+          "start": "2022-10-01T08:00:00",
           "deadline": "2022-10-02T00:00:00"
         }
       ]
@@ -33,7 +41,7 @@
       "day": "2022-10-02",
       "outputs": [
         {
-          "taskid": 3,
+          "taskid": 4,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -41,19 +49,27 @@
           "deadline": "2022-10-02T02:00:00"
         },
         {
-          "taskid": 4,
-          "goalid": "1",
-          "title": "work",
-          "duration": 5,
-          "start": "2022-10-02T02:00:00",
-          "deadline": "2022-10-02T07:00:00"
-        },
-        {
           "taskid": 5,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-02T07:00:00",
+          "duration": 1,
+          "start": "2022-10-02T02:00:00",
+          "deadline": "2022-10-02T03:00:00"
+        },
+        {
+          "taskid": 6,
+          "goalid": "1",
+          "title": "work",
+          "duration": 5,
+          "start": "2022-10-02T03:00:00",
+          "deadline": "2022-10-02T08:00:00"
+        },
+        {
+          "taskid": 7,
+          "goalid": "free",
+          "title": "free",
+          "duration": 16,
+          "start": "2022-10-02T08:00:00",
           "deadline": "2022-10-03T00:00:00"
         }
       ]
@@ -62,7 +78,7 @@
       "day": "2022-10-03",
       "outputs": [
         {
-          "taskid": 6,
+          "taskid": 8,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -70,19 +86,27 @@
           "deadline": "2022-10-03T02:00:00"
         },
         {
-          "taskid": 7,
+          "taskid": 9,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-03T02:00:00",
+          "deadline": "2022-10-03T03:00:00"
+        },
+        {
+          "taskid": 10,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-03T02:00:00",
-          "deadline": "2022-10-03T07:00:00"
+          "start": "2022-10-03T03:00:00",
+          "deadline": "2022-10-03T08:00:00"
         },
         {
-          "taskid": 8,
+          "taskid": 11,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-03T07:00:00",
+          "duration": 16,
+          "start": "2022-10-03T08:00:00",
           "deadline": "2022-10-04T00:00:00"
         }
       ]
@@ -91,7 +115,7 @@
       "day": "2022-10-04",
       "outputs": [
         {
-          "taskid": 9,
+          "taskid": 12,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -99,19 +123,27 @@
           "deadline": "2022-10-04T02:00:00"
         },
         {
-          "taskid": 10,
+          "taskid": 13,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-04T02:00:00",
+          "deadline": "2022-10-04T03:00:00"
+        },
+        {
+          "taskid": 14,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-04T02:00:00",
-          "deadline": "2022-10-04T07:00:00"
+          "start": "2022-10-04T03:00:00",
+          "deadline": "2022-10-04T08:00:00"
         },
         {
-          "taskid": 11,
+          "taskid": 15,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-04T07:00:00",
+          "duration": 16,
+          "start": "2022-10-04T08:00:00",
           "deadline": "2022-10-05T00:00:00"
         }
       ]
@@ -120,7 +152,7 @@
       "day": "2022-10-05",
       "outputs": [
         {
-          "taskid": 12,
+          "taskid": 16,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -128,19 +160,27 @@
           "deadline": "2022-10-05T02:00:00"
         },
         {
-          "taskid": 13,
+          "taskid": 17,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-05T02:00:00",
+          "deadline": "2022-10-05T03:00:00"
+        },
+        {
+          "taskid": 18,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-05T02:00:00",
-          "deadline": "2022-10-05T07:00:00"
+          "start": "2022-10-05T03:00:00",
+          "deadline": "2022-10-05T08:00:00"
         },
         {
-          "taskid": 14,
+          "taskid": 19,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-05T07:00:00",
+          "duration": 16,
+          "start": "2022-10-05T08:00:00",
           "deadline": "2022-10-06T00:00:00"
         }
       ]
@@ -149,7 +189,7 @@
       "day": "2022-10-06",
       "outputs": [
         {
-          "taskid": 15,
+          "taskid": 20,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -157,19 +197,27 @@
           "deadline": "2022-10-06T02:00:00"
         },
         {
-          "taskid": 16,
+          "taskid": 21,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-06T02:00:00",
+          "deadline": "2022-10-06T03:00:00"
+        },
+        {
+          "taskid": 22,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-06T02:00:00",
-          "deadline": "2022-10-06T07:00:00"
+          "start": "2022-10-06T03:00:00",
+          "deadline": "2022-10-06T08:00:00"
         },
         {
-          "taskid": 17,
+          "taskid": 23,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-06T07:00:00",
+          "duration": 16,
+          "start": "2022-10-06T08:00:00",
           "deadline": "2022-10-07T00:00:00"
         }
       ]
@@ -178,7 +226,7 @@
       "day": "2022-10-07",
       "outputs": [
         {
-          "taskid": 18,
+          "taskid": 24,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -186,19 +234,27 @@
           "deadline": "2022-10-07T02:00:00"
         },
         {
-          "taskid": 19,
+          "taskid": 25,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-07T02:00:00",
+          "deadline": "2022-10-07T03:00:00"
+        },
+        {
+          "taskid": 26,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-07T02:00:00",
-          "deadline": "2022-10-07T07:00:00"
+          "start": "2022-10-07T03:00:00",
+          "deadline": "2022-10-07T08:00:00"
         },
         {
-          "taskid": 20,
+          "taskid": 27,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-07T07:00:00",
+          "duration": 16,
+          "start": "2022-10-07T08:00:00",
           "deadline": "2022-10-08T00:00:00"
         }
       ]
@@ -207,7 +263,7 @@
       "day": "2022-10-08",
       "outputs": [
         {
-          "taskid": 21,
+          "taskid": 28,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -215,19 +271,27 @@
           "deadline": "2022-10-08T02:00:00"
         },
         {
-          "taskid": 22,
+          "taskid": 29,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-08T02:00:00",
+          "deadline": "2022-10-08T03:00:00"
+        },
+        {
+          "taskid": 30,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-08T02:00:00",
-          "deadline": "2022-10-08T07:00:00"
+          "start": "2022-10-08T03:00:00",
+          "deadline": "2022-10-08T08:00:00"
         },
         {
-          "taskid": 23,
+          "taskid": 31,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-08T07:00:00",
+          "duration": 16,
+          "start": "2022-10-08T08:00:00",
           "deadline": "2022-10-09T00:00:00"
         }
       ]
@@ -236,7 +300,7 @@
       "day": "2022-10-09",
       "outputs": [
         {
-          "taskid": 24,
+          "taskid": 32,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -244,19 +308,27 @@
           "deadline": "2022-10-09T02:00:00"
         },
         {
-          "taskid": 25,
+          "taskid": 33,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-09T02:00:00",
+          "deadline": "2022-10-09T03:00:00"
+        },
+        {
+          "taskid": 34,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-09T02:00:00",
-          "deadline": "2022-10-09T07:00:00"
+          "start": "2022-10-09T03:00:00",
+          "deadline": "2022-10-09T08:00:00"
         },
         {
-          "taskid": 26,
+          "taskid": 35,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-09T07:00:00",
+          "duration": 16,
+          "start": "2022-10-09T08:00:00",
           "deadline": "2022-10-10T00:00:00"
         }
       ]
@@ -265,7 +337,7 @@
       "day": "2022-10-10",
       "outputs": [
         {
-          "taskid": 27,
+          "taskid": 36,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -273,19 +345,27 @@
           "deadline": "2022-10-10T02:00:00"
         },
         {
-          "taskid": 28,
+          "taskid": 37,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-10T02:00:00",
+          "deadline": "2022-10-10T03:00:00"
+        },
+        {
+          "taskid": 38,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-10T02:00:00",
-          "deadline": "2022-10-10T07:00:00"
+          "start": "2022-10-10T03:00:00",
+          "deadline": "2022-10-10T08:00:00"
         },
         {
-          "taskid": 29,
+          "taskid": 39,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-10T07:00:00",
+          "duration": 16,
+          "start": "2022-10-10T08:00:00",
           "deadline": "2022-10-11T00:00:00"
         }
       ]
@@ -294,7 +374,7 @@
       "day": "2022-10-11",
       "outputs": [
         {
-          "taskid": 30,
+          "taskid": 40,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -302,19 +382,27 @@
           "deadline": "2022-10-11T02:00:00"
         },
         {
-          "taskid": 31,
+          "taskid": 41,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-11T02:00:00",
+          "deadline": "2022-10-11T03:00:00"
+        },
+        {
+          "taskid": 42,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-11T02:00:00",
-          "deadline": "2022-10-11T07:00:00"
+          "start": "2022-10-11T03:00:00",
+          "deadline": "2022-10-11T08:00:00"
         },
         {
-          "taskid": 32,
+          "taskid": 43,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-11T07:00:00",
+          "duration": 16,
+          "start": "2022-10-11T08:00:00",
           "deadline": "2022-10-12T00:00:00"
         }
       ]
@@ -323,7 +411,7 @@
       "day": "2022-10-12",
       "outputs": [
         {
-          "taskid": 33,
+          "taskid": 44,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -331,19 +419,27 @@
           "deadline": "2022-10-12T02:00:00"
         },
         {
-          "taskid": 34,
+          "taskid": 45,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-12T02:00:00",
+          "deadline": "2022-10-12T03:00:00"
+        },
+        {
+          "taskid": 46,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-12T02:00:00",
-          "deadline": "2022-10-12T07:00:00"
+          "start": "2022-10-12T03:00:00",
+          "deadline": "2022-10-12T08:00:00"
         },
         {
-          "taskid": 35,
+          "taskid": 47,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-12T07:00:00",
+          "duration": 16,
+          "start": "2022-10-12T08:00:00",
           "deadline": "2022-10-13T00:00:00"
         }
       ]
@@ -352,7 +448,7 @@
       "day": "2022-10-13",
       "outputs": [
         {
-          "taskid": 36,
+          "taskid": 48,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -360,19 +456,27 @@
           "deadline": "2022-10-13T02:00:00"
         },
         {
-          "taskid": 37,
+          "taskid": 49,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-13T02:00:00",
+          "deadline": "2022-10-13T03:00:00"
+        },
+        {
+          "taskid": 50,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-13T02:00:00",
-          "deadline": "2022-10-13T07:00:00"
+          "start": "2022-10-13T03:00:00",
+          "deadline": "2022-10-13T08:00:00"
         },
         {
-          "taskid": 38,
+          "taskid": 51,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-13T07:00:00",
+          "duration": 16,
+          "start": "2022-10-13T08:00:00",
           "deadline": "2022-10-14T00:00:00"
         }
       ]
@@ -381,7 +485,7 @@
       "day": "2022-10-14",
       "outputs": [
         {
-          "taskid": 39,
+          "taskid": 52,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -389,19 +493,27 @@
           "deadline": "2022-10-14T02:00:00"
         },
         {
-          "taskid": 40,
+          "taskid": 53,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-14T02:00:00",
+          "deadline": "2022-10-14T03:00:00"
+        },
+        {
+          "taskid": 54,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-14T02:00:00",
-          "deadline": "2022-10-14T07:00:00"
+          "start": "2022-10-14T03:00:00",
+          "deadline": "2022-10-14T08:00:00"
         },
         {
-          "taskid": 41,
+          "taskid": 55,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-14T07:00:00",
+          "duration": 16,
+          "start": "2022-10-14T08:00:00",
           "deadline": "2022-10-15T00:00:00"
         }
       ]
@@ -410,7 +522,7 @@
       "day": "2022-10-15",
       "outputs": [
         {
-          "taskid": 42,
+          "taskid": 56,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -418,19 +530,27 @@
           "deadline": "2022-10-15T02:00:00"
         },
         {
-          "taskid": 43,
+          "taskid": 57,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-15T02:00:00",
+          "deadline": "2022-10-15T03:00:00"
+        },
+        {
+          "taskid": 58,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-15T02:00:00",
-          "deadline": "2022-10-15T07:00:00"
+          "start": "2022-10-15T03:00:00",
+          "deadline": "2022-10-15T08:00:00"
         },
         {
-          "taskid": 44,
+          "taskid": 59,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-15T07:00:00",
+          "duration": 16,
+          "start": "2022-10-15T08:00:00",
           "deadline": "2022-10-16T00:00:00"
         }
       ]
@@ -439,7 +559,7 @@
       "day": "2022-10-16",
       "outputs": [
         {
-          "taskid": 45,
+          "taskid": 60,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -447,19 +567,27 @@
           "deadline": "2022-10-16T02:00:00"
         },
         {
-          "taskid": 46,
+          "taskid": 61,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-16T02:00:00",
+          "deadline": "2022-10-16T03:00:00"
+        },
+        {
+          "taskid": 62,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-16T02:00:00",
-          "deadline": "2022-10-16T07:00:00"
+          "start": "2022-10-16T03:00:00",
+          "deadline": "2022-10-16T08:00:00"
         },
         {
-          "taskid": 47,
+          "taskid": 63,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-16T07:00:00",
+          "duration": 16,
+          "start": "2022-10-16T08:00:00",
           "deadline": "2022-10-17T00:00:00"
         }
       ]
@@ -468,7 +596,7 @@
       "day": "2022-10-17",
       "outputs": [
         {
-          "taskid": 48,
+          "taskid": 64,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -476,19 +604,27 @@
           "deadline": "2022-10-17T02:00:00"
         },
         {
-          "taskid": 49,
+          "taskid": 65,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-17T02:00:00",
+          "deadline": "2022-10-17T03:00:00"
+        },
+        {
+          "taskid": 66,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-17T02:00:00",
-          "deadline": "2022-10-17T07:00:00"
+          "start": "2022-10-17T03:00:00",
+          "deadline": "2022-10-17T08:00:00"
         },
         {
-          "taskid": 50,
+          "taskid": 67,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-17T07:00:00",
+          "duration": 16,
+          "start": "2022-10-17T08:00:00",
           "deadline": "2022-10-18T00:00:00"
         }
       ]
@@ -497,7 +633,7 @@
       "day": "2022-10-18",
       "outputs": [
         {
-          "taskid": 51,
+          "taskid": 68,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -505,19 +641,27 @@
           "deadline": "2022-10-18T02:00:00"
         },
         {
-          "taskid": 52,
+          "taskid": 69,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-18T02:00:00",
+          "deadline": "2022-10-18T03:00:00"
+        },
+        {
+          "taskid": 70,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-18T02:00:00",
-          "deadline": "2022-10-18T07:00:00"
+          "start": "2022-10-18T03:00:00",
+          "deadline": "2022-10-18T08:00:00"
         },
         {
-          "taskid": 53,
+          "taskid": 71,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-18T07:00:00",
+          "duration": 16,
+          "start": "2022-10-18T08:00:00",
           "deadline": "2022-10-19T00:00:00"
         }
       ]
@@ -526,7 +670,7 @@
       "day": "2022-10-19",
       "outputs": [
         {
-          "taskid": 54,
+          "taskid": 72,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -534,19 +678,27 @@
           "deadline": "2022-10-19T02:00:00"
         },
         {
-          "taskid": 55,
+          "taskid": 73,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-19T02:00:00",
+          "deadline": "2022-10-19T03:00:00"
+        },
+        {
+          "taskid": 74,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-19T02:00:00",
-          "deadline": "2022-10-19T07:00:00"
+          "start": "2022-10-19T03:00:00",
+          "deadline": "2022-10-19T08:00:00"
         },
         {
-          "taskid": 56,
+          "taskid": 75,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-19T07:00:00",
+          "duration": 16,
+          "start": "2022-10-19T08:00:00",
           "deadline": "2022-10-20T00:00:00"
         }
       ]
@@ -555,7 +707,7 @@
       "day": "2022-10-20",
       "outputs": [
         {
-          "taskid": 57,
+          "taskid": 76,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -563,19 +715,27 @@
           "deadline": "2022-10-20T02:00:00"
         },
         {
-          "taskid": 58,
+          "taskid": 77,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-20T02:00:00",
+          "deadline": "2022-10-20T03:00:00"
+        },
+        {
+          "taskid": 78,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-20T02:00:00",
-          "deadline": "2022-10-20T07:00:00"
+          "start": "2022-10-20T03:00:00",
+          "deadline": "2022-10-20T08:00:00"
         },
         {
-          "taskid": 59,
+          "taskid": 79,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-20T07:00:00",
+          "duration": 16,
+          "start": "2022-10-20T08:00:00",
           "deadline": "2022-10-21T00:00:00"
         }
       ]
@@ -584,7 +744,7 @@
       "day": "2022-10-21",
       "outputs": [
         {
-          "taskid": 60,
+          "taskid": 80,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -592,19 +752,27 @@
           "deadline": "2022-10-21T02:00:00"
         },
         {
-          "taskid": 61,
+          "taskid": 81,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-21T02:00:00",
+          "deadline": "2022-10-21T03:00:00"
+        },
+        {
+          "taskid": 82,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-21T02:00:00",
-          "deadline": "2022-10-21T07:00:00"
+          "start": "2022-10-21T03:00:00",
+          "deadline": "2022-10-21T08:00:00"
         },
         {
-          "taskid": 62,
+          "taskid": 83,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-21T07:00:00",
+          "duration": 16,
+          "start": "2022-10-21T08:00:00",
           "deadline": "2022-10-22T00:00:00"
         }
       ]
@@ -613,7 +781,7 @@
       "day": "2022-10-22",
       "outputs": [
         {
-          "taskid": 63,
+          "taskid": 84,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -621,19 +789,27 @@
           "deadline": "2022-10-22T02:00:00"
         },
         {
-          "taskid": 64,
+          "taskid": 85,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-22T02:00:00",
+          "deadline": "2022-10-22T03:00:00"
+        },
+        {
+          "taskid": 86,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-22T02:00:00",
-          "deadline": "2022-10-22T07:00:00"
+          "start": "2022-10-22T03:00:00",
+          "deadline": "2022-10-22T08:00:00"
         },
         {
-          "taskid": 65,
+          "taskid": 87,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-22T07:00:00",
+          "duration": 16,
+          "start": "2022-10-22T08:00:00",
           "deadline": "2022-10-23T00:00:00"
         }
       ]
@@ -642,7 +818,7 @@
       "day": "2022-10-23",
       "outputs": [
         {
-          "taskid": 66,
+          "taskid": 88,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -650,19 +826,27 @@
           "deadline": "2022-10-23T02:00:00"
         },
         {
-          "taskid": 67,
+          "taskid": 89,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-23T02:00:00",
+          "deadline": "2022-10-23T03:00:00"
+        },
+        {
+          "taskid": 90,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-23T02:00:00",
-          "deadline": "2022-10-23T07:00:00"
+          "start": "2022-10-23T03:00:00",
+          "deadline": "2022-10-23T08:00:00"
         },
         {
-          "taskid": 68,
+          "taskid": 91,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-23T07:00:00",
+          "duration": 16,
+          "start": "2022-10-23T08:00:00",
           "deadline": "2022-10-24T00:00:00"
         }
       ]
@@ -671,7 +855,7 @@
       "day": "2022-10-24",
       "outputs": [
         {
-          "taskid": 69,
+          "taskid": 92,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -679,19 +863,27 @@
           "deadline": "2022-10-24T02:00:00"
         },
         {
-          "taskid": 70,
+          "taskid": 93,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-24T02:00:00",
+          "deadline": "2022-10-24T03:00:00"
+        },
+        {
+          "taskid": 94,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-24T02:00:00",
-          "deadline": "2022-10-24T07:00:00"
+          "start": "2022-10-24T03:00:00",
+          "deadline": "2022-10-24T08:00:00"
         },
         {
-          "taskid": 71,
+          "taskid": 95,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-24T07:00:00",
+          "duration": 16,
+          "start": "2022-10-24T08:00:00",
           "deadline": "2022-10-25T00:00:00"
         }
       ]
@@ -700,7 +892,7 @@
       "day": "2022-10-25",
       "outputs": [
         {
-          "taskid": 72,
+          "taskid": 96,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -708,19 +900,27 @@
           "deadline": "2022-10-25T02:00:00"
         },
         {
-          "taskid": 73,
+          "taskid": 97,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-25T02:00:00",
+          "deadline": "2022-10-25T03:00:00"
+        },
+        {
+          "taskid": 98,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-25T02:00:00",
-          "deadline": "2022-10-25T07:00:00"
+          "start": "2022-10-25T03:00:00",
+          "deadline": "2022-10-25T08:00:00"
         },
         {
-          "taskid": 74,
+          "taskid": 99,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-25T07:00:00",
+          "duration": 16,
+          "start": "2022-10-25T08:00:00",
           "deadline": "2022-10-26T00:00:00"
         }
       ]
@@ -729,7 +929,7 @@
       "day": "2022-10-26",
       "outputs": [
         {
-          "taskid": 75,
+          "taskid": 100,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -737,19 +937,27 @@
           "deadline": "2022-10-26T02:00:00"
         },
         {
-          "taskid": 76,
+          "taskid": 101,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-26T02:00:00",
+          "deadline": "2022-10-26T03:00:00"
+        },
+        {
+          "taskid": 102,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-26T02:00:00",
-          "deadline": "2022-10-26T07:00:00"
+          "start": "2022-10-26T03:00:00",
+          "deadline": "2022-10-26T08:00:00"
         },
         {
-          "taskid": 77,
+          "taskid": 103,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-26T07:00:00",
+          "duration": 16,
+          "start": "2022-10-26T08:00:00",
           "deadline": "2022-10-27T00:00:00"
         }
       ]
@@ -758,7 +966,7 @@
       "day": "2022-10-27",
       "outputs": [
         {
-          "taskid": 78,
+          "taskid": 104,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -766,19 +974,27 @@
           "deadline": "2022-10-27T02:00:00"
         },
         {
-          "taskid": 79,
+          "taskid": 105,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-27T02:00:00",
+          "deadline": "2022-10-27T03:00:00"
+        },
+        {
+          "taskid": 106,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-27T02:00:00",
-          "deadline": "2022-10-27T07:00:00"
+          "start": "2022-10-27T03:00:00",
+          "deadline": "2022-10-27T08:00:00"
         },
         {
-          "taskid": 80,
+          "taskid": 107,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-27T07:00:00",
+          "duration": 16,
+          "start": "2022-10-27T08:00:00",
           "deadline": "2022-10-28T00:00:00"
         }
       ]
@@ -787,7 +1003,7 @@
       "day": "2022-10-28",
       "outputs": [
         {
-          "taskid": 81,
+          "taskid": 108,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -795,19 +1011,27 @@
           "deadline": "2022-10-28T02:00:00"
         },
         {
-          "taskid": 82,
+          "taskid": 109,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-28T02:00:00",
+          "deadline": "2022-10-28T03:00:00"
+        },
+        {
+          "taskid": 110,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-28T02:00:00",
-          "deadline": "2022-10-28T07:00:00"
+          "start": "2022-10-28T03:00:00",
+          "deadline": "2022-10-28T08:00:00"
         },
         {
-          "taskid": 83,
+          "taskid": 111,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-28T07:00:00",
+          "duration": 16,
+          "start": "2022-10-28T08:00:00",
           "deadline": "2022-10-29T00:00:00"
         }
       ]
@@ -816,7 +1040,7 @@
       "day": "2022-10-29",
       "outputs": [
         {
-          "taskid": 84,
+          "taskid": 112,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -824,19 +1048,27 @@
           "deadline": "2022-10-29T02:00:00"
         },
         {
-          "taskid": 85,
+          "taskid": 113,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-29T02:00:00",
+          "deadline": "2022-10-29T03:00:00"
+        },
+        {
+          "taskid": 114,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-29T02:00:00",
-          "deadline": "2022-10-29T07:00:00"
+          "start": "2022-10-29T03:00:00",
+          "deadline": "2022-10-29T08:00:00"
         },
         {
-          "taskid": 86,
+          "taskid": 115,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-29T07:00:00",
+          "duration": 16,
+          "start": "2022-10-29T08:00:00",
           "deadline": "2022-10-30T00:00:00"
         }
       ]
@@ -845,7 +1077,7 @@
       "day": "2022-10-30",
       "outputs": [
         {
-          "taskid": 87,
+          "taskid": 116,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -853,19 +1085,27 @@
           "deadline": "2022-10-30T02:00:00"
         },
         {
-          "taskid": 88,
+          "taskid": 117,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-30T02:00:00",
+          "deadline": "2022-10-30T03:00:00"
+        },
+        {
+          "taskid": 118,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-30T02:00:00",
-          "deadline": "2022-10-30T07:00:00"
+          "start": "2022-10-30T03:00:00",
+          "deadline": "2022-10-30T08:00:00"
         },
         {
-          "taskid": 89,
+          "taskid": 119,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-30T07:00:00",
+          "duration": 16,
+          "start": "2022-10-30T08:00:00",
           "deadline": "2022-10-31T00:00:00"
         }
       ]
@@ -874,7 +1114,7 @@
       "day": "2022-10-31",
       "outputs": [
         {
-          "taskid": 90,
+          "taskid": 120,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -882,19 +1122,27 @@
           "deadline": "2022-10-31T02:00:00"
         },
         {
-          "taskid": 91,
+          "taskid": 121,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-10-31T02:00:00",
+          "deadline": "2022-10-31T03:00:00"
+        },
+        {
+          "taskid": 122,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-31T02:00:00",
-          "deadline": "2022-10-31T07:00:00"
+          "start": "2022-10-31T03:00:00",
+          "deadline": "2022-10-31T08:00:00"
         },
         {
-          "taskid": 92,
+          "taskid": 123,
           "goalid": "free",
           "title": "free",
-          "duration": 17,
-          "start": "2022-10-31T07:00:00",
+          "duration": 16,
+          "start": "2022-10-31T08:00:00",
           "deadline": "2022-11-01T00:00:00"
         }
       ]

--- a/tests/jsons/i293-postpone-2/actual_output.json
+++ b/tests/jsons/i293-postpone-2/actual_output.json
@@ -7,40 +7,24 @@
           "taskid": 0,
           "goalid": "free",
           "title": "free",
-          "duration": 3,
+          "duration": 6,
           "start": "2023-04-01T00:00:00",
-          "deadline": "2023-04-01T03:00:00"
+          "deadline": "2023-04-01T06:00:00"
         },
         {
           "taskid": 1,
           "goalid": "1",
           "title": "study Rust",
-          "duration": 2,
-          "start": "2023-04-01T03:00:00",
-          "deadline": "2023-04-01T05:00:00"
+          "duration": 3,
+          "start": "2023-04-01T06:00:00",
+          "deadline": "2023-04-01T09:00:00"
         },
         {
           "taskid": 2,
           "goalid": "free",
           "title": "free",
-          "duration": 1,
-          "start": "2023-04-01T05:00:00",
-          "deadline": "2023-04-01T06:00:00"
-        },
-        {
-          "taskid": 3,
-          "goalid": "1",
-          "title": "study Rust",
-          "duration": 1,
-          "start": "2023-04-01T06:00:00",
-          "deadline": "2023-04-01T07:00:00"
-        },
-        {
-          "taskid": 4,
-          "goalid": "free",
-          "title": "free",
-          "duration": 17,
-          "start": "2023-04-01T07:00:00",
+          "duration": 15,
+          "start": "2023-04-01T09:00:00",
           "deadline": "2023-04-02T00:00:00"
         }
       ]
@@ -49,7 +33,7 @@
       "day": "2023-04-02",
       "outputs": [
         {
-          "taskid": 5,
+          "taskid": 3,
           "goalid": "1",
           "title": "study Rust",
           "duration": 3,
@@ -57,7 +41,7 @@
           "deadline": "2023-04-02T03:00:00"
         },
         {
-          "taskid": 6,
+          "taskid": 4,
           "goalid": "free",
           "title": "free",
           "duration": 21,
@@ -70,7 +54,7 @@
       "day": "2023-04-03",
       "outputs": [
         {
-          "taskid": 7,
+          "taskid": 5,
           "goalid": "1",
           "title": "study Rust",
           "duration": 3,
@@ -78,7 +62,7 @@
           "deadline": "2023-04-03T03:00:00"
         },
         {
-          "taskid": 8,
+          "taskid": 6,
           "goalid": "free",
           "title": "free",
           "duration": 21,
@@ -91,7 +75,7 @@
       "day": "2023-04-04",
       "outputs": [
         {
-          "taskid": 9,
+          "taskid": 7,
           "goalid": "1",
           "title": "study Rust",
           "duration": 3,
@@ -99,7 +83,7 @@
           "deadline": "2023-04-04T03:00:00"
         },
         {
-          "taskid": 10,
+          "taskid": 8,
           "goalid": "free",
           "title": "free",
           "duration": 21,
@@ -112,7 +96,7 @@
       "day": "2023-04-05",
       "outputs": [
         {
-          "taskid": 11,
+          "taskid": 9,
           "goalid": "1",
           "title": "study Rust",
           "duration": 3,
@@ -120,7 +104,7 @@
           "deadline": "2023-04-05T03:00:00"
         },
         {
-          "taskid": 12,
+          "taskid": 10,
           "goalid": "free",
           "title": "free",
           "duration": 21,
@@ -133,7 +117,7 @@
       "day": "2023-04-06",
       "outputs": [
         {
-          "taskid": 13,
+          "taskid": 11,
           "goalid": "1",
           "title": "study Rust",
           "duration": 3,
@@ -141,7 +125,7 @@
           "deadline": "2023-04-06T03:00:00"
         },
         {
-          "taskid": 14,
+          "taskid": 12,
           "goalid": "free",
           "title": "free",
           "duration": 21,

--- a/tests/jsons/i309/actual_output.json
+++ b/tests/jsons/i309/actual_output.json
@@ -13,30 +13,22 @@
         },
         {
           "taskid": 1,
-          "goalid": "ebc34193-e5ff-4fc4-9dab-de6f29c3bf34",
-          "title": "Presentation",
+          "goalid": "f704cdd6-c02c-465a-bfbd-37b7f2d54823",
+          "title": "Breakfast 🥐🥣",
           "duration": 1,
           "start": "2023-05-10T06:00:00",
           "deadline": "2023-05-10T07:00:00"
         },
         {
           "taskid": 2,
-          "goalid": "f704cdd6-c02c-465a-bfbd-37b7f2d54823",
-          "title": "Breakfast 🥐🥣",
-          "duration": 1,
+          "goalid": "free",
+          "title": "free",
+          "duration": 2,
           "start": "2023-05-10T07:00:00",
-          "deadline": "2023-05-10T08:00:00"
-        },
-        {
-          "taskid": 3,
-          "goalid": "a7992b3e-6f51-42ec-98ad-c0d5dc633b67",
-          "title": "Project B filler",
-          "duration": 1,
-          "start": "2023-05-10T08:00:00",
           "deadline": "2023-05-10T09:00:00"
         },
         {
-          "taskid": 4,
+          "taskid": 3,
           "goalid": "900dfa10-6fe0-486c-af98-f160360f81b9",
           "title": "Me time 🧘🏽😌",
           "duration": 1,
@@ -44,15 +36,15 @@
           "deadline": "2023-05-10T10:00:00"
         },
         {
-          "taskid": 5,
-          "goalid": "a7992b3e-6f51-42ec-98ad-c0d5dc633b67",
-          "title": "Project B filler",
+          "taskid": 4,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2023-05-10T10:00:00",
           "deadline": "2023-05-10T12:00:00"
         },
         {
-          "taskid": 6,
+          "taskid": 5,
           "goalid": "9e65959b-4645-4b19-b4d4-b5896afa00a1",
           "title": "Lunch 🥪",
           "duration": 2,
@@ -60,7 +52,7 @@
           "deadline": "2023-05-10T14:00:00"
         },
         {
-          "taskid": 7,
+          "taskid": 6,
           "goalid": "ab599a7e-8a1c-4eb0-88ec-f2d1fbd5d46b",
           "title": "Walk 🚶🏽",
           "duration": 1,
@@ -68,15 +60,15 @@
           "deadline": "2023-05-10T15:00:00"
         },
         {
-          "taskid": 8,
-          "goalid": "a7992b3e-6f51-42ec-98ad-c0d5dc633b67",
-          "title": "Project B filler",
+          "taskid": 7,
+          "goalid": "free",
+          "title": "free",
           "duration": 3,
           "start": "2023-05-10T15:00:00",
           "deadline": "2023-05-10T18:00:00"
         },
         {
-          "taskid": 9,
+          "taskid": 8,
           "goalid": "713c5d0e-c91a-4324-83d7-9e53aaae572d",
           "title": "Dinner 🍽️",
           "duration": 1,
@@ -84,19 +76,27 @@
           "deadline": "2023-05-10T19:00:00"
         },
         {
-          "taskid": 10,
-          "goalid": "a7992b3e-6f51-42ec-98ad-c0d5dc633b67",
-          "title": "Project B filler",
+          "taskid": 9,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2023-05-10T19:00:00",
           "deadline": "2023-05-10T21:00:00"
         },
         {
-          "taskid": 11,
-          "goalid": "8abeb0b6-dc36-4c74-9f56-935de7b4eb19",
-          "title": "Project A",
-          "duration": 3,
+          "taskid": 10,
+          "goalid": "ebc34193-e5ff-4fc4-9dab-de6f29c3bf34",
+          "title": "Presentation",
+          "duration": 2,
           "start": "2023-05-10T21:00:00",
+          "deadline": "2023-05-10T23:00:00"
+        },
+        {
+          "taskid": 11,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2023-05-10T23:00:00",
           "deadline": "2023-05-11T00:00:00"
         }
       ]
@@ -122,8 +122,8 @@
         },
         {
           "taskid": 14,
-          "goalid": "dc914376-3313-41b3-aed4-d3c1cda3e01c",
-          "title": "Work",
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2023-05-11T07:00:00",
           "deadline": "2023-05-11T09:00:00"
@@ -138,8 +138,8 @@
         },
         {
           "taskid": 16,
-          "goalid": "dc914376-3313-41b3-aed4-d3c1cda3e01c",
-          "title": "Work",
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2023-05-11T10:00:00",
           "deadline": "2023-05-11T12:00:00"
@@ -162,8 +162,8 @@
         },
         {
           "taskid": 19,
-          "goalid": "dc914376-3313-41b3-aed4-d3c1cda3e01c",
-          "title": "Work",
+          "goalid": "free",
+          "title": "free",
           "duration": 3,
           "start": "2023-05-11T15:00:00",
           "deadline": "2023-05-11T18:00:00"
@@ -178,18 +178,10 @@
         },
         {
           "taskid": 21,
-          "goalid": "dc914376-3313-41b3-aed4-d3c1cda3e01c",
-          "title": "Work",
-          "duration": 2,
+          "goalid": "free",
+          "title": "free",
+          "duration": 5,
           "start": "2023-05-11T19:00:00",
-          "deadline": "2023-05-11T21:00:00"
-        },
-        {
-          "taskid": 22,
-          "goalid": "8abeb0b6-dc36-4c74-9f56-935de7b4eb19",
-          "title": "Project A",
-          "duration": 3,
-          "start": "2023-05-11T21:00:00",
           "deadline": "2023-05-12T00:00:00"
         }
       ]
@@ -198,7 +190,7 @@
       "day": "2023-05-12",
       "outputs": [
         {
-          "taskid": 23,
+          "taskid": 22,
           "goalid": "95438911-95ee-47bc-ba4f-090a560f46e2",
           "title": "Sleep 😴🌙",
           "duration": 6,
@@ -206,7 +198,7 @@
           "deadline": "2023-05-12T06:00:00"
         },
         {
-          "taskid": 24,
+          "taskid": 23,
           "goalid": "f704cdd6-c02c-465a-bfbd-37b7f2d54823",
           "title": "Breakfast 🥐🥣",
           "duration": 1,
@@ -214,15 +206,15 @@
           "deadline": "2023-05-12T07:00:00"
         },
         {
-          "taskid": 25,
-          "goalid": "dc914376-3313-41b3-aed4-d3c1cda3e01c",
-          "title": "Work",
+          "taskid": 24,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2023-05-12T07:00:00",
           "deadline": "2023-05-12T09:00:00"
         },
         {
-          "taskid": 26,
+          "taskid": 25,
           "goalid": "900dfa10-6fe0-486c-af98-f160360f81b9",
           "title": "Me time 🧘🏽😌",
           "duration": 1,
@@ -230,15 +222,15 @@
           "deadline": "2023-05-12T10:00:00"
         },
         {
-          "taskid": 27,
-          "goalid": "dc914376-3313-41b3-aed4-d3c1cda3e01c",
-          "title": "Work",
+          "taskid": 26,
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2023-05-12T10:00:00",
           "deadline": "2023-05-12T12:00:00"
         },
         {
-          "taskid": 28,
+          "taskid": 27,
           "goalid": "9e65959b-4645-4b19-b4d4-b5896afa00a1",
           "title": "Lunch 🥪",
           "duration": 2,
@@ -246,7 +238,7 @@
           "deadline": "2023-05-12T14:00:00"
         },
         {
-          "taskid": 29,
+          "taskid": 28,
           "goalid": "ab599a7e-8a1c-4eb0-88ec-f2d1fbd5d46b",
           "title": "Walk 🚶🏽",
           "duration": 1,
@@ -254,23 +246,15 @@
           "deadline": "2023-05-12T15:00:00"
         },
         {
-          "taskid": 30,
-          "goalid": "dc914376-3313-41b3-aed4-d3c1cda3e01c",
-          "title": "Work",
-          "duration": 2,
-          "start": "2023-05-12T15:00:00",
-          "deadline": "2023-05-12T17:00:00"
-        },
-        {
-          "taskid": 31,
+          "taskid": 29,
           "goalid": "free",
           "title": "free",
-          "duration": 1,
-          "start": "2023-05-12T17:00:00",
+          "duration": 3,
+          "start": "2023-05-12T15:00:00",
           "deadline": "2023-05-12T18:00:00"
         },
         {
-          "taskid": 32,
+          "taskid": 30,
           "goalid": "713c5d0e-c91a-4324-83d7-9e53aaae572d",
           "title": "Dinner 🍽️",
           "duration": 1,
@@ -278,19 +262,11 @@
           "deadline": "2023-05-12T19:00:00"
         },
         {
-          "taskid": 33,
+          "taskid": 31,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
+          "duration": 5,
           "start": "2023-05-12T19:00:00",
-          "deadline": "2023-05-12T21:00:00"
-        },
-        {
-          "taskid": 34,
-          "goalid": "8abeb0b6-dc36-4c74-9f56-935de7b4eb19",
-          "title": "Project A",
-          "duration": 3,
-          "start": "2023-05-12T21:00:00",
           "deadline": "2023-05-13T00:00:00"
         }
       ]
@@ -299,7 +275,7 @@
       "day": "2023-05-13",
       "outputs": [
         {
-          "taskid": 35,
+          "taskid": 32,
           "goalid": "95438911-95ee-47bc-ba4f-090a560f46e2",
           "title": "Sleep 😴🌙",
           "duration": 6,
@@ -307,7 +283,7 @@
           "deadline": "2023-05-13T06:00:00"
         },
         {
-          "taskid": 36,
+          "taskid": 33,
           "goalid": "f704cdd6-c02c-465a-bfbd-37b7f2d54823",
           "title": "Breakfast 🥐🥣",
           "duration": 1,
@@ -315,7 +291,7 @@
           "deadline": "2023-05-13T07:00:00"
         },
         {
-          "taskid": 37,
+          "taskid": 34,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -323,7 +299,7 @@
           "deadline": "2023-05-13T09:00:00"
         },
         {
-          "taskid": 38,
+          "taskid": 35,
           "goalid": "900dfa10-6fe0-486c-af98-f160360f81b9",
           "title": "Me time 🧘🏽😌",
           "duration": 1,
@@ -331,7 +307,7 @@
           "deadline": "2023-05-13T10:00:00"
         },
         {
-          "taskid": 39,
+          "taskid": 36,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -339,7 +315,7 @@
           "deadline": "2023-05-13T12:00:00"
         },
         {
-          "taskid": 40,
+          "taskid": 37,
           "goalid": "9e65959b-4645-4b19-b4d4-b5896afa00a1",
           "title": "Lunch 🥪",
           "duration": 2,
@@ -347,7 +323,7 @@
           "deadline": "2023-05-13T14:00:00"
         },
         {
-          "taskid": 41,
+          "taskid": 38,
           "goalid": "ab599a7e-8a1c-4eb0-88ec-f2d1fbd5d46b",
           "title": "Walk 🚶🏽",
           "duration": 1,
@@ -355,7 +331,7 @@
           "deadline": "2023-05-13T15:00:00"
         },
         {
-          "taskid": 42,
+          "taskid": 39,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -363,7 +339,7 @@
           "deadline": "2023-05-13T18:00:00"
         },
         {
-          "taskid": 43,
+          "taskid": 40,
           "goalid": "713c5d0e-c91a-4324-83d7-9e53aaae572d",
           "title": "Dinner 🍽️",
           "duration": 1,
@@ -371,19 +347,11 @@
           "deadline": "2023-05-13T19:00:00"
         },
         {
-          "taskid": 44,
+          "taskid": 41,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
+          "duration": 5,
           "start": "2023-05-13T19:00:00",
-          "deadline": "2023-05-13T21:00:00"
-        },
-        {
-          "taskid": 45,
-          "goalid": "8abeb0b6-dc36-4c74-9f56-935de7b4eb19",
-          "title": "Project A",
-          "duration": 3,
-          "start": "2023-05-13T21:00:00",
           "deadline": "2023-05-14T00:00:00"
         }
       ]
@@ -392,7 +360,7 @@
       "day": "2023-05-14",
       "outputs": [
         {
-          "taskid": 46,
+          "taskid": 42,
           "goalid": "95438911-95ee-47bc-ba4f-090a560f46e2",
           "title": "Sleep 😴🌙",
           "duration": 6,
@@ -400,7 +368,7 @@
           "deadline": "2023-05-14T06:00:00"
         },
         {
-          "taskid": 47,
+          "taskid": 43,
           "goalid": "f704cdd6-c02c-465a-bfbd-37b7f2d54823",
           "title": "Breakfast 🥐🥣",
           "duration": 1,
@@ -408,7 +376,7 @@
           "deadline": "2023-05-14T07:00:00"
         },
         {
-          "taskid": 48,
+          "taskid": 44,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -416,7 +384,7 @@
           "deadline": "2023-05-14T09:00:00"
         },
         {
-          "taskid": 49,
+          "taskid": 45,
           "goalid": "900dfa10-6fe0-486c-af98-f160360f81b9",
           "title": "Me time 🧘🏽😌",
           "duration": 1,
@@ -424,7 +392,7 @@
           "deadline": "2023-05-14T10:00:00"
         },
         {
-          "taskid": 50,
+          "taskid": 46,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -432,7 +400,7 @@
           "deadline": "2023-05-14T12:00:00"
         },
         {
-          "taskid": 51,
+          "taskid": 47,
           "goalid": "9e65959b-4645-4b19-b4d4-b5896afa00a1",
           "title": "Lunch 🥪",
           "duration": 2,
@@ -440,7 +408,7 @@
           "deadline": "2023-05-14T14:00:00"
         },
         {
-          "taskid": 52,
+          "taskid": 48,
           "goalid": "ab599a7e-8a1c-4eb0-88ec-f2d1fbd5d46b",
           "title": "Walk 🚶🏽",
           "duration": 1,
@@ -448,7 +416,7 @@
           "deadline": "2023-05-14T15:00:00"
         },
         {
-          "taskid": 53,
+          "taskid": 49,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -456,7 +424,7 @@
           "deadline": "2023-05-14T18:00:00"
         },
         {
-          "taskid": 54,
+          "taskid": 50,
           "goalid": "713c5d0e-c91a-4324-83d7-9e53aaae572d",
           "title": "Dinner 🍽️",
           "duration": 1,
@@ -464,19 +432,11 @@
           "deadline": "2023-05-14T19:00:00"
         },
         {
-          "taskid": 55,
+          "taskid": 51,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
+          "duration": 5,
           "start": "2023-05-14T19:00:00",
-          "deadline": "2023-05-14T21:00:00"
-        },
-        {
-          "taskid": 56,
-          "goalid": "8abeb0b6-dc36-4c74-9f56-935de7b4eb19",
-          "title": "Project A",
-          "duration": 3,
-          "start": "2023-05-14T21:00:00",
           "deadline": "2023-05-15T00:00:00"
         }
       ]
@@ -485,7 +445,7 @@
       "day": "2023-05-15",
       "outputs": [
         {
-          "taskid": 57,
+          "taskid": 52,
           "goalid": "95438911-95ee-47bc-ba4f-090a560f46e2",
           "title": "Sleep 😴🌙",
           "duration": 6,
@@ -493,7 +453,7 @@
           "deadline": "2023-05-15T06:00:00"
         },
         {
-          "taskid": 58,
+          "taskid": 53,
           "goalid": "f704cdd6-c02c-465a-bfbd-37b7f2d54823",
           "title": "Breakfast 🥐🥣",
           "duration": 1,
@@ -501,7 +461,7 @@
           "deadline": "2023-05-15T07:00:00"
         },
         {
-          "taskid": 59,
+          "taskid": 54,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -509,7 +469,7 @@
           "deadline": "2023-05-15T09:00:00"
         },
         {
-          "taskid": 60,
+          "taskid": 55,
           "goalid": "900dfa10-6fe0-486c-af98-f160360f81b9",
           "title": "Me time 🧘🏽😌",
           "duration": 1,
@@ -517,7 +477,7 @@
           "deadline": "2023-05-15T10:00:00"
         },
         {
-          "taskid": 61,
+          "taskid": 56,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -525,7 +485,7 @@
           "deadline": "2023-05-15T12:00:00"
         },
         {
-          "taskid": 62,
+          "taskid": 57,
           "goalid": "9e65959b-4645-4b19-b4d4-b5896afa00a1",
           "title": "Lunch 🥪",
           "duration": 2,
@@ -533,7 +493,7 @@
           "deadline": "2023-05-15T14:00:00"
         },
         {
-          "taskid": 63,
+          "taskid": 58,
           "goalid": "ab599a7e-8a1c-4eb0-88ec-f2d1fbd5d46b",
           "title": "Walk 🚶🏽",
           "duration": 1,
@@ -541,7 +501,7 @@
           "deadline": "2023-05-15T15:00:00"
         },
         {
-          "taskid": 64,
+          "taskid": 59,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -549,7 +509,7 @@
           "deadline": "2023-05-15T18:00:00"
         },
         {
-          "taskid": 65,
+          "taskid": 60,
           "goalid": "713c5d0e-c91a-4324-83d7-9e53aaae572d",
           "title": "Dinner 🍽️",
           "duration": 1,
@@ -557,19 +517,11 @@
           "deadline": "2023-05-15T19:00:00"
         },
         {
-          "taskid": 66,
+          "taskid": 61,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
+          "duration": 5,
           "start": "2023-05-15T19:00:00",
-          "deadline": "2023-05-15T21:00:00"
-        },
-        {
-          "taskid": 67,
-          "goalid": "8abeb0b6-dc36-4c74-9f56-935de7b4eb19",
-          "title": "Project A",
-          "duration": 3,
-          "start": "2023-05-15T21:00:00",
           "deadline": "2023-05-16T00:00:00"
         }
       ]
@@ -578,7 +530,7 @@
       "day": "2023-05-16",
       "outputs": [
         {
-          "taskid": 68,
+          "taskid": 62,
           "goalid": "95438911-95ee-47bc-ba4f-090a560f46e2",
           "title": "Sleep 😴🌙",
           "duration": 6,
@@ -586,7 +538,7 @@
           "deadline": "2023-05-16T06:00:00"
         },
         {
-          "taskid": 69,
+          "taskid": 63,
           "goalid": "f704cdd6-c02c-465a-bfbd-37b7f2d54823",
           "title": "Breakfast 🥐🥣",
           "duration": 1,
@@ -594,7 +546,7 @@
           "deadline": "2023-05-16T07:00:00"
         },
         {
-          "taskid": 70,
+          "taskid": 64,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -602,7 +554,7 @@
           "deadline": "2023-05-16T09:00:00"
         },
         {
-          "taskid": 71,
+          "taskid": 65,
           "goalid": "900dfa10-6fe0-486c-af98-f160360f81b9",
           "title": "Me time 🧘🏽😌",
           "duration": 1,
@@ -610,7 +562,7 @@
           "deadline": "2023-05-16T10:00:00"
         },
         {
-          "taskid": 72,
+          "taskid": 66,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -618,7 +570,7 @@
           "deadline": "2023-05-16T12:00:00"
         },
         {
-          "taskid": 73,
+          "taskid": 67,
           "goalid": "9e65959b-4645-4b19-b4d4-b5896afa00a1",
           "title": "Lunch 🥪",
           "duration": 2,
@@ -626,7 +578,7 @@
           "deadline": "2023-05-16T14:00:00"
         },
         {
-          "taskid": 74,
+          "taskid": 68,
           "goalid": "ab599a7e-8a1c-4eb0-88ec-f2d1fbd5d46b",
           "title": "Walk 🚶🏽",
           "duration": 1,
@@ -634,7 +586,7 @@
           "deadline": "2023-05-16T15:00:00"
         },
         {
-          "taskid": 75,
+          "taskid": 69,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -642,7 +594,7 @@
           "deadline": "2023-05-16T18:00:00"
         },
         {
-          "taskid": 76,
+          "taskid": 70,
           "goalid": "713c5d0e-c91a-4324-83d7-9e53aaae572d",
           "title": "Dinner 🍽️",
           "duration": 1,
@@ -650,27 +602,11 @@
           "deadline": "2023-05-16T19:00:00"
         },
         {
-          "taskid": 77,
+          "taskid": 71,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
+          "duration": 5,
           "start": "2023-05-16T19:00:00",
-          "deadline": "2023-05-16T21:00:00"
-        },
-        {
-          "taskid": 78,
-          "goalid": "8abeb0b6-dc36-4c74-9f56-935de7b4eb19",
-          "title": "Project A",
-          "duration": 2,
-          "start": "2023-05-16T21:00:00",
-          "deadline": "2023-05-16T23:00:00"
-        },
-        {
-          "taskid": 79,
-          "goalid": "ebc34193-e5ff-4fc4-9dab-de6f29c3bf34",
-          "title": "Presentation",
-          "duration": 1,
-          "start": "2023-05-16T23:00:00",
           "deadline": "2023-05-17T00:00:00"
         }
       ]
@@ -679,7 +615,32 @@
   "impossible": [
     {
       "day": "2023-05-10",
-      "outputs": []
+      "outputs": [
+        {
+          "taskid": 72,
+          "goalid": "8abeb0b6-dc36-4c74-9f56-935de7b4eb19",
+          "title": "Project A",
+          "duration": 20,
+          "start": "2023-05-10T00:00:00",
+          "deadline": "2023-05-17T00:00:00"
+        },
+        {
+          "taskid": 73,
+          "goalid": "dc914376-3313-41b3-aed4-d3c1cda3e01c",
+          "title": "Work",
+          "duration": 43,
+          "start": "2023-05-10T00:00:00",
+          "deadline": "2023-05-17T00:00:00"
+        },
+        {
+          "taskid": 74,
+          "goalid": "a7992b3e-6f51-42ec-98ad-c0d5dc633b67",
+          "title": "Project B filler",
+          "duration": 8,
+          "start": "2023-05-10T00:00:00",
+          "deadline": "2023-05-17T00:00:00"
+        }
+      ]
     },
     {
       "day": "2023-05-11",

--- a/tests/jsons/impossible-2/actual_output.json
+++ b/tests/jsons/impossible-2/actual_output.json
@@ -21,6 +21,14 @@
         },
         {
           "taskid": 2,
+          "goalid": "2",
+          "title": "gym",
+          "duration": 1,
+          "start": "2022-11-28T09:00:00",
+          "deadline": "2022-11-28T10:00:00"
+        },
+        {
+          "taskid": 3,
           "goalid": "free",
           "title": "free",
           "duration": 6,
@@ -33,7 +41,7 @@
       "day": "2022-11-29",
       "outputs": [
         {
-          "taskid": 3,
+          "taskid": 4,
           "goalid": "free",
           "title": "free",
           "duration": 9,
@@ -41,7 +49,7 @@
           "deadline": "2022-11-29T09:00:00"
         },
         {
-          "taskid": 4,
+          "taskid": 5,
           "goalid": "1",
           "title": "work",
           "duration": 9,
@@ -49,7 +57,15 @@
           "deadline": "2022-11-29T18:00:00"
         },
         {
-          "taskid": 5,
+          "taskid": 6,
+          "goalid": "2",
+          "title": "gym",
+          "duration": 1,
+          "start": "2022-11-29T09:00:00",
+          "deadline": "2022-11-29T10:00:00"
+        },
+        {
+          "taskid": 7,
           "goalid": "free",
           "title": "free",
           "duration": 6,
@@ -62,7 +78,7 @@
       "day": "2022-11-30",
       "outputs": [
         {
-          "taskid": 6,
+          "taskid": 8,
           "goalid": "free",
           "title": "free",
           "duration": 9,
@@ -70,7 +86,7 @@
           "deadline": "2022-11-30T09:00:00"
         },
         {
-          "taskid": 7,
+          "taskid": 9,
           "goalid": "1",
           "title": "work",
           "duration": 9,
@@ -78,7 +94,15 @@
           "deadline": "2022-11-30T18:00:00"
         },
         {
-          "taskid": 8,
+          "taskid": 10,
+          "goalid": "2",
+          "title": "gym",
+          "duration": 1,
+          "start": "2022-11-30T09:00:00",
+          "deadline": "2022-11-30T10:00:00"
+        },
+        {
+          "taskid": 11,
           "goalid": "free",
           "title": "free",
           "duration": 6,
@@ -91,7 +115,7 @@
       "day": "2022-12-01",
       "outputs": [
         {
-          "taskid": 9,
+          "taskid": 12,
           "goalid": "free",
           "title": "free",
           "duration": 9,
@@ -99,7 +123,7 @@
           "deadline": "2022-12-01T09:00:00"
         },
         {
-          "taskid": 10,
+          "taskid": 13,
           "goalid": "1",
           "title": "work",
           "duration": 9,
@@ -107,7 +131,15 @@
           "deadline": "2022-12-01T18:00:00"
         },
         {
-          "taskid": 11,
+          "taskid": 14,
+          "goalid": "2",
+          "title": "gym",
+          "duration": 1,
+          "start": "2022-12-01T09:00:00",
+          "deadline": "2022-12-01T10:00:00"
+        },
+        {
+          "taskid": 15,
           "goalid": "free",
           "title": "free",
           "duration": 6,
@@ -120,7 +152,7 @@
       "day": "2022-12-02",
       "outputs": [
         {
-          "taskid": 12,
+          "taskid": 16,
           "goalid": "free",
           "title": "free",
           "duration": 9,
@@ -128,7 +160,7 @@
           "deadline": "2022-12-02T09:00:00"
         },
         {
-          "taskid": 13,
+          "taskid": 17,
           "goalid": "1",
           "title": "work",
           "duration": 9,
@@ -136,7 +168,15 @@
           "deadline": "2022-12-02T18:00:00"
         },
         {
-          "taskid": 14,
+          "taskid": 18,
+          "goalid": "2",
+          "title": "gym",
+          "duration": 1,
+          "start": "2022-12-02T09:00:00",
+          "deadline": "2022-12-02T10:00:00"
+        },
+        {
+          "taskid": 19,
           "goalid": "free",
           "title": "free",
           "duration": 6,
@@ -149,7 +189,7 @@
       "day": "2022-12-03",
       "outputs": [
         {
-          "taskid": 15,
+          "taskid": 20,
           "goalid": "free",
           "title": "free",
           "duration": 9,
@@ -157,39 +197,23 @@
           "deadline": "2022-12-03T09:00:00"
         },
         {
-          "taskid": 16,
-          "goalid": "1",
-          "title": "work",
+          "taskid": 21,
+          "goalid": "2",
+          "title": "gym",
           "duration": 1,
           "start": "2022-12-03T09:00:00",
           "deadline": "2022-12-03T10:00:00"
         },
         {
-          "taskid": 17,
-          "goalid": "2",
-          "title": "gym",
-          "duration": 1,
-          "start": "2022-12-03T10:00:00",
-          "deadline": "2022-12-03T11:00:00"
-        },
-        {
-          "taskid": 18,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-12-03T11:00:00",
-          "deadline": "2022-12-03T12:00:00"
-        },
-        {
-          "taskid": 19,
+          "taskid": 22,
           "goalid": "1",
           "title": "work",
-          "duration": 6,
-          "start": "2022-12-03T12:00:00",
+          "duration": 9,
+          "start": "2022-12-03T09:00:00",
           "deadline": "2022-12-03T18:00:00"
         },
         {
-          "taskid": 20,
+          "taskid": 23,
           "goalid": "free",
           "title": "free",
           "duration": 6,
@@ -202,7 +226,7 @@
       "day": "2022-12-04",
       "outputs": [
         {
-          "taskid": 21,
+          "taskid": 24,
           "goalid": "free",
           "title": "free",
           "duration": 9,
@@ -210,43 +234,19 @@
           "deadline": "2022-12-04T09:00:00"
         },
         {
-          "taskid": 22,
-          "goalid": "1",
-          "title": "work",
+          "taskid": 25,
+          "goalid": "2",
+          "title": "gym",
           "duration": 1,
           "start": "2022-12-04T09:00:00",
           "deadline": "2022-12-04T10:00:00"
         },
         {
-          "taskid": 23,
-          "goalid": "2",
-          "title": "gym",
-          "duration": 1,
-          "start": "2022-12-04T10:00:00",
-          "deadline": "2022-12-04T11:00:00"
-        },
-        {
-          "taskid": 24,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-12-04T11:00:00",
-          "deadline": "2022-12-04T12:00:00"
-        },
-        {
-          "taskid": 25,
-          "goalid": "1",
-          "title": "work",
-          "duration": 1,
-          "start": "2022-12-04T12:00:00",
-          "deadline": "2022-12-04T13:00:00"
-        },
-        {
           "taskid": 26,
           "goalid": "free",
           "title": "free",
-          "duration": 11,
-          "start": "2022-12-04T13:00:00",
+          "duration": 14,
+          "start": "2022-12-04T10:00:00",
           "deadline": "2022-12-05T00:00:00"
         }
       ]
@@ -255,48 +255,7 @@
   "impossible": [
     {
       "day": "2022-11-28",
-      "outputs": [
-        {
-          "taskid": 27,
-          "goalid": "2",
-          "title": "gym",
-          "duration": 1,
-          "start": "2022-11-28T00:00:00",
-          "deadline": "2022-12-05T00:00:00"
-        },
-        {
-          "taskid": 28,
-          "goalid": "2",
-          "title": "gym",
-          "duration": 1,
-          "start": "2022-11-28T00:00:00",
-          "deadline": "2022-12-05T00:00:00"
-        },
-        {
-          "taskid": 29,
-          "goalid": "2",
-          "title": "gym",
-          "duration": 1,
-          "start": "2022-11-28T00:00:00",
-          "deadline": "2022-12-05T00:00:00"
-        },
-        {
-          "taskid": 30,
-          "goalid": "2",
-          "title": "gym",
-          "duration": 1,
-          "start": "2022-11-28T00:00:00",
-          "deadline": "2022-12-05T00:00:00"
-        },
-        {
-          "taskid": 31,
-          "goalid": "2",
-          "title": "gym",
-          "duration": 1,
-          "start": "2022-11-28T00:00:00",
-          "deadline": "2022-12-05T00:00:00"
-        }
-      ]
+      "outputs": []
     },
     {
       "day": "2022-11-29",

--- a/tests/jsons/issue-276-weekdays-filter-on-budget/actual_output.json
+++ b/tests/jsons/issue-276-weekdays-filter-on-budget/actual_output.json
@@ -7,24 +7,8 @@
           "taskid": 0,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2023-03-09T00:00:00",
-          "deadline": "2023-03-09T08:00:00"
-        },
-        {
-          "taskid": 1,
-          "goalid": "1",
-          "title": "work",
-          "duration": 8,
-          "start": "2023-03-09T08:00:00",
-          "deadline": "2023-03-09T16:00:00"
-        },
-        {
-          "taskid": 2,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2023-03-09T16:00:00",
           "deadline": "2023-03-10T00:00:00"
         }
       ]
@@ -33,27 +17,11 @@
       "day": "2023-03-10",
       "outputs": [
         {
-          "taskid": 3,
+          "taskid": 1,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2023-03-10T00:00:00",
-          "deadline": "2023-03-10T08:00:00"
-        },
-        {
-          "taskid": 4,
-          "goalid": "1",
-          "title": "work",
-          "duration": 8,
-          "start": "2023-03-10T08:00:00",
-          "deadline": "2023-03-10T16:00:00"
-        },
-        {
-          "taskid": 5,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2023-03-10T16:00:00",
           "deadline": "2023-03-11T00:00:00"
         }
       ]
@@ -62,7 +30,7 @@
       "day": "2023-03-11",
       "outputs": [
         {
-          "taskid": 6,
+          "taskid": 2,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -75,7 +43,7 @@
       "day": "2023-03-12",
       "outputs": [
         {
-          "taskid": 7,
+          "taskid": 3,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -88,27 +56,11 @@
       "day": "2023-03-13",
       "outputs": [
         {
-          "taskid": 8,
+          "taskid": 4,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2023-03-13T00:00:00",
-          "deadline": "2023-03-13T08:00:00"
-        },
-        {
-          "taskid": 9,
-          "goalid": "1",
-          "title": "work",
-          "duration": 8,
-          "start": "2023-03-13T08:00:00",
-          "deadline": "2023-03-13T16:00:00"
-        },
-        {
-          "taskid": 10,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2023-03-13T16:00:00",
           "deadline": "2023-03-14T00:00:00"
         }
       ]
@@ -117,27 +69,11 @@
       "day": "2023-03-14",
       "outputs": [
         {
-          "taskid": 11,
+          "taskid": 5,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2023-03-14T00:00:00",
-          "deadline": "2023-03-14T08:00:00"
-        },
-        {
-          "taskid": 12,
-          "goalid": "1",
-          "title": "work",
-          "duration": 8,
-          "start": "2023-03-14T08:00:00",
-          "deadline": "2023-03-14T16:00:00"
-        },
-        {
-          "taskid": 13,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2023-03-14T16:00:00",
           "deadline": "2023-03-15T00:00:00"
         }
       ]
@@ -146,27 +82,11 @@
       "day": "2023-03-15",
       "outputs": [
         {
-          "taskid": 14,
+          "taskid": 6,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2023-03-15T00:00:00",
-          "deadline": "2023-03-15T08:00:00"
-        },
-        {
-          "taskid": 15,
-          "goalid": "1",
-          "title": "work",
-          "duration": 3,
-          "start": "2023-03-15T08:00:00",
-          "deadline": "2023-03-15T11:00:00"
-        },
-        {
-          "taskid": 16,
-          "goalid": "free",
-          "title": "free",
-          "duration": 13,
-          "start": "2023-03-15T11:00:00",
           "deadline": "2023-03-16T00:00:00"
         }
       ]
@@ -175,27 +95,11 @@
       "day": "2023-03-16",
       "outputs": [
         {
-          "taskid": 17,
+          "taskid": 7,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2023-03-16T00:00:00",
-          "deadline": "2023-03-16T08:00:00"
-        },
-        {
-          "taskid": 18,
-          "goalid": "1",
-          "title": "work",
-          "duration": 8,
-          "start": "2023-03-16T08:00:00",
-          "deadline": "2023-03-16T16:00:00"
-        },
-        {
-          "taskid": 19,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2023-03-16T16:00:00",
           "deadline": "2023-03-17T00:00:00"
         }
       ]
@@ -204,27 +108,11 @@
       "day": "2023-03-17",
       "outputs": [
         {
-          "taskid": 20,
+          "taskid": 8,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2023-03-17T00:00:00",
-          "deadline": "2023-03-17T08:00:00"
-        },
-        {
-          "taskid": 21,
-          "goalid": "1",
-          "title": "work",
-          "duration": 8,
-          "start": "2023-03-17T08:00:00",
-          "deadline": "2023-03-17T16:00:00"
-        },
-        {
-          "taskid": 22,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2023-03-17T16:00:00",
           "deadline": "2023-03-18T00:00:00"
         }
       ]
@@ -233,7 +121,7 @@
       "day": "2023-03-18",
       "outputs": [
         {
-          "taskid": 23,
+          "taskid": 9,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -246,7 +134,7 @@
       "day": "2023-03-19",
       "outputs": [
         {
-          "taskid": 24,
+          "taskid": 10,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -261,10 +149,18 @@
       "day": "2023-03-09",
       "outputs": [
         {
-          "taskid": 25,
+          "taskid": 11,
           "goalid": "1",
           "title": "work",
-          "duration": 19,
+          "duration": 35,
+          "start": "2023-03-09T00:00:00",
+          "deadline": "2023-03-20T00:00:00"
+        },
+        {
+          "taskid": 12,
+          "goalid": "1",
+          "title": "work",
+          "duration": 35,
           "start": "2023-03-09T00:00:00",
           "deadline": "2023-03-20T00:00:00"
         }

--- a/tests/jsons/issue-284-filter-days-of-week-with-impossible/actual_output.json
+++ b/tests/jsons/issue-284-filter-days-of-week-with-impossible/actual_output.json
@@ -7,24 +7,8 @@
           "taskid": 0,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2023-03-09T00:00:00",
-          "deadline": "2023-03-09T08:00:00"
-        },
-        {
-          "taskid": 1,
-          "goalid": "1",
-          "title": "learn rust",
-          "duration": 2,
-          "start": "2023-03-09T08:00:00",
-          "deadline": "2023-03-09T10:00:00"
-        },
-        {
-          "taskid": 2,
-          "goalid": "free",
-          "title": "free",
-          "duration": 14,
-          "start": "2023-03-09T10:00:00",
           "deadline": "2023-03-10T00:00:00"
         }
       ]
@@ -33,27 +17,11 @@
       "day": "2023-03-10",
       "outputs": [
         {
-          "taskid": 3,
+          "taskid": 1,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2023-03-10T00:00:00",
-          "deadline": "2023-03-10T08:00:00"
-        },
-        {
-          "taskid": 4,
-          "goalid": "1",
-          "title": "learn rust",
-          "duration": 2,
-          "start": "2023-03-10T08:00:00",
-          "deadline": "2023-03-10T10:00:00"
-        },
-        {
-          "taskid": 5,
-          "goalid": "free",
-          "title": "free",
-          "duration": 14,
-          "start": "2023-03-10T10:00:00",
           "deadline": "2023-03-11T00:00:00"
         }
       ]
@@ -62,27 +30,11 @@
       "day": "2023-03-11",
       "outputs": [
         {
-          "taskid": 6,
+          "taskid": 2,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2023-03-11T00:00:00",
-          "deadline": "2023-03-11T08:00:00"
-        },
-        {
-          "taskid": 7,
-          "goalid": "1",
-          "title": "learn rust",
-          "duration": 2,
-          "start": "2023-03-11T08:00:00",
-          "deadline": "2023-03-11T10:00:00"
-        },
-        {
-          "taskid": 8,
-          "goalid": "free",
-          "title": "free",
-          "duration": 14,
-          "start": "2023-03-11T10:00:00",
           "deadline": "2023-03-12T00:00:00"
         }
       ]
@@ -91,7 +43,7 @@
       "day": "2023-03-12",
       "outputs": [
         {
-          "taskid": 9,
+          "taskid": 3,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -104,7 +56,7 @@
       "day": "2023-03-13",
       "outputs": [
         {
-          "taskid": 10,
+          "taskid": 4,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -117,7 +69,7 @@
       "day": "2023-03-14",
       "outputs": [
         {
-          "taskid": 11,
+          "taskid": 5,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -130,7 +82,7 @@
       "day": "2023-03-15",
       "outputs": [
         {
-          "taskid": 12,
+          "taskid": 6,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -143,27 +95,11 @@
       "day": "2023-03-16",
       "outputs": [
         {
-          "taskid": 13,
+          "taskid": 7,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2023-03-16T00:00:00",
-          "deadline": "2023-03-16T08:00:00"
-        },
-        {
-          "taskid": 14,
-          "goalid": "1",
-          "title": "learn rust",
-          "duration": 2,
-          "start": "2023-03-16T08:00:00",
-          "deadline": "2023-03-16T10:00:00"
-        },
-        {
-          "taskid": 15,
-          "goalid": "free",
-          "title": "free",
-          "duration": 14,
-          "start": "2023-03-16T10:00:00",
           "deadline": "2023-03-17T00:00:00"
         }
       ]
@@ -172,27 +108,11 @@
       "day": "2023-03-17",
       "outputs": [
         {
-          "taskid": 16,
+          "taskid": 8,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2023-03-17T00:00:00",
-          "deadline": "2023-03-17T08:00:00"
-        },
-        {
-          "taskid": 17,
-          "goalid": "1",
-          "title": "learn rust",
-          "duration": 2,
-          "start": "2023-03-17T08:00:00",
-          "deadline": "2023-03-17T10:00:00"
-        },
-        {
-          "taskid": 18,
-          "goalid": "free",
-          "title": "free",
-          "duration": 14,
-          "start": "2023-03-17T10:00:00",
           "deadline": "2023-03-18T00:00:00"
         }
       ]
@@ -201,27 +121,11 @@
       "day": "2023-03-18",
       "outputs": [
         {
-          "taskid": 19,
+          "taskid": 9,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2023-03-18T00:00:00",
-          "deadline": "2023-03-18T08:00:00"
-        },
-        {
-          "taskid": 20,
-          "goalid": "1",
-          "title": "learn rust",
-          "duration": 2,
-          "start": "2023-03-18T08:00:00",
-          "deadline": "2023-03-18T10:00:00"
-        },
-        {
-          "taskid": 21,
-          "goalid": "free",
-          "title": "free",
-          "duration": 14,
-          "start": "2023-03-18T10:00:00",
           "deadline": "2023-03-19T00:00:00"
         }
       ]
@@ -230,7 +134,7 @@
       "day": "2023-03-19",
       "outputs": [
         {
-          "taskid": 22,
+          "taskid": 10,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -245,50 +149,50 @@
       "day": "2023-03-09",
       "outputs": [
         {
-          "taskid": 23,
+          "taskid": 11,
           "goalid": "1",
           "title": "learn rust",
-          "duration": 3,
+          "duration": 5,
           "start": "2023-03-09T00:00:00",
           "deadline": "2023-03-20T00:00:00"
         },
         {
-          "taskid": 24,
+          "taskid": 12,
           "goalid": "1",
           "title": "learn rust",
-          "duration": 3,
+          "duration": 5,
           "start": "2023-03-09T00:00:00",
           "deadline": "2023-03-20T00:00:00"
         },
         {
-          "taskid": 25,
+          "taskid": 13,
           "goalid": "1",
           "title": "learn rust",
-          "duration": 3,
+          "duration": 5,
           "start": "2023-03-09T00:00:00",
           "deadline": "2023-03-20T00:00:00"
         },
         {
-          "taskid": 26,
+          "taskid": 14,
           "goalid": "1",
           "title": "learn rust",
-          "duration": 3,
+          "duration": 5,
           "start": "2023-03-09T00:00:00",
           "deadline": "2023-03-20T00:00:00"
         },
         {
-          "taskid": 27,
+          "taskid": 15,
           "goalid": "1",
           "title": "learn rust",
-          "duration": 3,
+          "duration": 5,
           "start": "2023-03-09T00:00:00",
           "deadline": "2023-03-20T00:00:00"
         },
         {
-          "taskid": 28,
+          "taskid": 16,
           "goalid": "1",
           "title": "learn rust",
-          "duration": 3,
+          "duration": 5,
           "start": "2023-03-09T00:00:00",
           "deadline": "2023-03-20T00:00:00"
         }

--- a/tests/jsons/issue-284-no-repeat-large-dur-and-timespan/actual_output.json
+++ b/tests/jsons/issue-284-no-repeat-large-dur-and-timespan/actual_output.json
@@ -33,24 +33,8 @@
           "taskid": 2,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-03-03T00:00:00",
-          "deadline": "2023-03-03T05:00:00"
-        },
-        {
-          "taskid": 3,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-03-03T05:00:00",
-          "deadline": "2023-03-03T06:00:00"
-        },
-        {
-          "taskid": 4,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-03-03T06:00:00",
           "deadline": "2023-03-04T00:00:00"
         }
       ]
@@ -59,27 +43,11 @@
       "day": "2023-03-04",
       "outputs": [
         {
-          "taskid": 5,
+          "taskid": 3,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-03-04T00:00:00",
-          "deadline": "2023-03-04T05:00:00"
-        },
-        {
-          "taskid": 6,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-03-04T05:00:00",
-          "deadline": "2023-03-04T06:00:00"
-        },
-        {
-          "taskid": 7,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-03-04T06:00:00",
           "deadline": "2023-03-05T00:00:00"
         }
       ]
@@ -88,7 +56,7 @@
       "day": "2023-03-05",
       "outputs": [
         {
-          "taskid": 8,
+          "taskid": 4,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -101,7 +69,7 @@
       "day": "2023-03-06",
       "outputs": [
         {
-          "taskid": 9,
+          "taskid": 5,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -114,7 +82,7 @@
       "day": "2023-03-07",
       "outputs": [
         {
-          "taskid": 10,
+          "taskid": 6,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -127,7 +95,7 @@
       "day": "2023-03-08",
       "outputs": [
         {
-          "taskid": 11,
+          "taskid": 7,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -140,7 +108,7 @@
       "day": "2023-03-09",
       "outputs": [
         {
-          "taskid": 12,
+          "taskid": 8,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -153,27 +121,11 @@
       "day": "2023-03-10",
       "outputs": [
         {
-          "taskid": 13,
+          "taskid": 9,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-03-10T00:00:00",
-          "deadline": "2023-03-10T05:00:00"
-        },
-        {
-          "taskid": 14,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-03-10T05:00:00",
-          "deadline": "2023-03-10T06:00:00"
-        },
-        {
-          "taskid": 15,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-03-10T06:00:00",
           "deadline": "2023-03-11T00:00:00"
         }
       ]
@@ -182,27 +134,11 @@
       "day": "2023-03-11",
       "outputs": [
         {
-          "taskid": 16,
+          "taskid": 10,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-03-11T00:00:00",
-          "deadline": "2023-03-11T05:00:00"
-        },
-        {
-          "taskid": 17,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-03-11T05:00:00",
-          "deadline": "2023-03-11T06:00:00"
-        },
-        {
-          "taskid": 18,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-03-11T06:00:00",
           "deadline": "2023-03-12T00:00:00"
         }
       ]
@@ -211,7 +147,7 @@
       "day": "2023-03-12",
       "outputs": [
         {
-          "taskid": 19,
+          "taskid": 11,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -224,7 +160,7 @@
       "day": "2023-03-13",
       "outputs": [
         {
-          "taskid": 20,
+          "taskid": 12,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -237,7 +173,7 @@
       "day": "2023-03-14",
       "outputs": [
         {
-          "taskid": 21,
+          "taskid": 13,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -250,7 +186,7 @@
       "day": "2023-03-15",
       "outputs": [
         {
-          "taskid": 22,
+          "taskid": 14,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -263,7 +199,7 @@
       "day": "2023-03-16",
       "outputs": [
         {
-          "taskid": 23,
+          "taskid": 15,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -276,27 +212,11 @@
       "day": "2023-03-17",
       "outputs": [
         {
-          "taskid": 24,
+          "taskid": 16,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-03-17T00:00:00",
-          "deadline": "2023-03-17T05:00:00"
-        },
-        {
-          "taskid": 25,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-03-17T05:00:00",
-          "deadline": "2023-03-17T06:00:00"
-        },
-        {
-          "taskid": 26,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-03-17T06:00:00",
           "deadline": "2023-03-18T00:00:00"
         }
       ]
@@ -305,27 +225,11 @@
       "day": "2023-03-18",
       "outputs": [
         {
-          "taskid": 27,
+          "taskid": 17,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-03-18T00:00:00",
-          "deadline": "2023-03-18T05:00:00"
-        },
-        {
-          "taskid": 28,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-03-18T05:00:00",
-          "deadline": "2023-03-18T06:00:00"
-        },
-        {
-          "taskid": 29,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-03-18T06:00:00",
           "deadline": "2023-03-19T00:00:00"
         }
       ]
@@ -334,7 +238,7 @@
       "day": "2023-03-19",
       "outputs": [
         {
-          "taskid": 30,
+          "taskid": 18,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -347,7 +251,7 @@
       "day": "2023-03-20",
       "outputs": [
         {
-          "taskid": 31,
+          "taskid": 19,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -360,7 +264,7 @@
       "day": "2023-03-21",
       "outputs": [
         {
-          "taskid": 32,
+          "taskid": 20,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -373,7 +277,7 @@
       "day": "2023-03-22",
       "outputs": [
         {
-          "taskid": 33,
+          "taskid": 21,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -386,7 +290,7 @@
       "day": "2023-03-23",
       "outputs": [
         {
-          "taskid": 34,
+          "taskid": 22,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -399,27 +303,11 @@
       "day": "2023-03-24",
       "outputs": [
         {
-          "taskid": 35,
+          "taskid": 23,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-03-24T00:00:00",
-          "deadline": "2023-03-24T05:00:00"
-        },
-        {
-          "taskid": 36,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-03-24T05:00:00",
-          "deadline": "2023-03-24T06:00:00"
-        },
-        {
-          "taskid": 37,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-03-24T06:00:00",
           "deadline": "2023-03-25T00:00:00"
         }
       ]
@@ -428,27 +316,11 @@
       "day": "2023-03-25",
       "outputs": [
         {
-          "taskid": 38,
+          "taskid": 24,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-03-25T00:00:00",
-          "deadline": "2023-03-25T05:00:00"
-        },
-        {
-          "taskid": 39,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-03-25T05:00:00",
-          "deadline": "2023-03-25T06:00:00"
-        },
-        {
-          "taskid": 40,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-03-25T06:00:00",
           "deadline": "2023-03-26T00:00:00"
         }
       ]
@@ -457,7 +329,7 @@
       "day": "2023-03-26",
       "outputs": [
         {
-          "taskid": 41,
+          "taskid": 25,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -470,7 +342,7 @@
       "day": "2023-03-27",
       "outputs": [
         {
-          "taskid": 42,
+          "taskid": 26,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -483,7 +355,7 @@
       "day": "2023-03-28",
       "outputs": [
         {
-          "taskid": 43,
+          "taskid": 27,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -496,7 +368,7 @@
       "day": "2023-03-29",
       "outputs": [
         {
-          "taskid": 44,
+          "taskid": 28,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -509,7 +381,7 @@
       "day": "2023-03-30",
       "outputs": [
         {
-          "taskid": 45,
+          "taskid": 29,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -522,27 +394,11 @@
       "day": "2023-03-31",
       "outputs": [
         {
-          "taskid": 46,
+          "taskid": 30,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-03-31T00:00:00",
-          "deadline": "2023-03-31T05:00:00"
-        },
-        {
-          "taskid": 47,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-03-31T05:00:00",
-          "deadline": "2023-03-31T06:00:00"
-        },
-        {
-          "taskid": 48,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-03-31T06:00:00",
           "deadline": "2023-04-01T00:00:00"
         }
       ]
@@ -551,27 +407,11 @@
       "day": "2023-04-01",
       "outputs": [
         {
-          "taskid": 49,
+          "taskid": 31,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-04-01T00:00:00",
-          "deadline": "2023-04-01T05:00:00"
-        },
-        {
-          "taskid": 50,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-04-01T05:00:00",
-          "deadline": "2023-04-01T06:00:00"
-        },
-        {
-          "taskid": 51,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-04-01T06:00:00",
           "deadline": "2023-04-02T00:00:00"
         }
       ]
@@ -580,7 +420,7 @@
       "day": "2023-04-02",
       "outputs": [
         {
-          "taskid": 52,
+          "taskid": 32,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -593,7 +433,7 @@
       "day": "2023-04-03",
       "outputs": [
         {
-          "taskid": 53,
+          "taskid": 33,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -606,7 +446,7 @@
       "day": "2023-04-04",
       "outputs": [
         {
-          "taskid": 54,
+          "taskid": 34,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -619,7 +459,7 @@
       "day": "2023-04-05",
       "outputs": [
         {
-          "taskid": 55,
+          "taskid": 35,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -632,7 +472,7 @@
       "day": "2023-04-06",
       "outputs": [
         {
-          "taskid": 56,
+          "taskid": 36,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -645,27 +485,11 @@
       "day": "2023-04-07",
       "outputs": [
         {
-          "taskid": 57,
+          "taskid": 37,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-04-07T00:00:00",
-          "deadline": "2023-04-07T05:00:00"
-        },
-        {
-          "taskid": 58,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-04-07T05:00:00",
-          "deadline": "2023-04-07T06:00:00"
-        },
-        {
-          "taskid": 59,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-04-07T06:00:00",
           "deadline": "2023-04-08T00:00:00"
         }
       ]
@@ -674,27 +498,11 @@
       "day": "2023-04-08",
       "outputs": [
         {
-          "taskid": 60,
+          "taskid": 38,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-04-08T00:00:00",
-          "deadline": "2023-04-08T05:00:00"
-        },
-        {
-          "taskid": 61,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-04-08T05:00:00",
-          "deadline": "2023-04-08T06:00:00"
-        },
-        {
-          "taskid": 62,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-04-08T06:00:00",
           "deadline": "2023-04-09T00:00:00"
         }
       ]
@@ -703,7 +511,7 @@
       "day": "2023-04-09",
       "outputs": [
         {
-          "taskid": 63,
+          "taskid": 39,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -716,7 +524,7 @@
       "day": "2023-04-10",
       "outputs": [
         {
-          "taskid": 64,
+          "taskid": 40,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -729,7 +537,7 @@
       "day": "2023-04-11",
       "outputs": [
         {
-          "taskid": 65,
+          "taskid": 41,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -742,7 +550,7 @@
       "day": "2023-04-12",
       "outputs": [
         {
-          "taskid": 66,
+          "taskid": 42,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -755,7 +563,7 @@
       "day": "2023-04-13",
       "outputs": [
         {
-          "taskid": 67,
+          "taskid": 43,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -768,27 +576,11 @@
       "day": "2023-04-14",
       "outputs": [
         {
-          "taskid": 68,
+          "taskid": 44,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-04-14T00:00:00",
-          "deadline": "2023-04-14T05:00:00"
-        },
-        {
-          "taskid": 69,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-04-14T05:00:00",
-          "deadline": "2023-04-14T06:00:00"
-        },
-        {
-          "taskid": 70,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-04-14T06:00:00",
           "deadline": "2023-04-15T00:00:00"
         }
       ]
@@ -797,27 +589,11 @@
       "day": "2023-04-15",
       "outputs": [
         {
-          "taskid": 71,
+          "taskid": 45,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-04-15T00:00:00",
-          "deadline": "2023-04-15T05:00:00"
-        },
-        {
-          "taskid": 72,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-04-15T05:00:00",
-          "deadline": "2023-04-15T06:00:00"
-        },
-        {
-          "taskid": 73,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-04-15T06:00:00",
           "deadline": "2023-04-16T00:00:00"
         }
       ]
@@ -826,7 +602,7 @@
       "day": "2023-04-16",
       "outputs": [
         {
-          "taskid": 74,
+          "taskid": 46,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -839,7 +615,7 @@
       "day": "2023-04-17",
       "outputs": [
         {
-          "taskid": 75,
+          "taskid": 47,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -852,7 +628,7 @@
       "day": "2023-04-18",
       "outputs": [
         {
-          "taskid": 76,
+          "taskid": 48,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -865,7 +641,7 @@
       "day": "2023-04-19",
       "outputs": [
         {
-          "taskid": 77,
+          "taskid": 49,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -878,7 +654,7 @@
       "day": "2023-04-20",
       "outputs": [
         {
-          "taskid": 78,
+          "taskid": 50,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -891,27 +667,11 @@
       "day": "2023-04-21",
       "outputs": [
         {
-          "taskid": 79,
+          "taskid": 51,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-04-21T00:00:00",
-          "deadline": "2023-04-21T05:00:00"
-        },
-        {
-          "taskid": 80,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-04-21T05:00:00",
-          "deadline": "2023-04-21T06:00:00"
-        },
-        {
-          "taskid": 81,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-04-21T06:00:00",
           "deadline": "2023-04-22T00:00:00"
         }
       ]
@@ -920,27 +680,11 @@
       "day": "2023-04-22",
       "outputs": [
         {
-          "taskid": 82,
+          "taskid": 52,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-04-22T00:00:00",
-          "deadline": "2023-04-22T05:00:00"
-        },
-        {
-          "taskid": 83,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-04-22T05:00:00",
-          "deadline": "2023-04-22T06:00:00"
-        },
-        {
-          "taskid": 84,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-04-22T06:00:00",
           "deadline": "2023-04-23T00:00:00"
         }
       ]
@@ -949,7 +693,7 @@
       "day": "2023-04-23",
       "outputs": [
         {
-          "taskid": 85,
+          "taskid": 53,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -962,7 +706,7 @@
       "day": "2023-04-24",
       "outputs": [
         {
-          "taskid": 86,
+          "taskid": 54,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -975,7 +719,7 @@
       "day": "2023-04-25",
       "outputs": [
         {
-          "taskid": 87,
+          "taskid": 55,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -988,7 +732,7 @@
       "day": "2023-04-26",
       "outputs": [
         {
-          "taskid": 88,
+          "taskid": 56,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1001,7 +745,7 @@
       "day": "2023-04-27",
       "outputs": [
         {
-          "taskid": 89,
+          "taskid": 57,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1014,27 +758,11 @@
       "day": "2023-04-28",
       "outputs": [
         {
-          "taskid": 90,
+          "taskid": 58,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-04-28T00:00:00",
-          "deadline": "2023-04-28T05:00:00"
-        },
-        {
-          "taskid": 91,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-04-28T05:00:00",
-          "deadline": "2023-04-28T06:00:00"
-        },
-        {
-          "taskid": 92,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-04-28T06:00:00",
           "deadline": "2023-04-29T00:00:00"
         }
       ]
@@ -1043,27 +771,11 @@
       "day": "2023-04-29",
       "outputs": [
         {
-          "taskid": 93,
+          "taskid": 59,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-04-29T00:00:00",
-          "deadline": "2023-04-29T05:00:00"
-        },
-        {
-          "taskid": 94,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-04-29T05:00:00",
-          "deadline": "2023-04-29T06:00:00"
-        },
-        {
-          "taskid": 95,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-04-29T06:00:00",
           "deadline": "2023-04-30T00:00:00"
         }
       ]
@@ -1072,7 +784,7 @@
       "day": "2023-04-30",
       "outputs": [
         {
-          "taskid": 96,
+          "taskid": 60,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1085,7 +797,7 @@
       "day": "2023-05-01",
       "outputs": [
         {
-          "taskid": 97,
+          "taskid": 61,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1098,7 +810,7 @@
       "day": "2023-05-02",
       "outputs": [
         {
-          "taskid": 98,
+          "taskid": 62,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1111,7 +823,7 @@
       "day": "2023-05-03",
       "outputs": [
         {
-          "taskid": 99,
+          "taskid": 63,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1124,7 +836,7 @@
       "day": "2023-05-04",
       "outputs": [
         {
-          "taskid": 100,
+          "taskid": 64,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1137,27 +849,11 @@
       "day": "2023-05-05",
       "outputs": [
         {
-          "taskid": 101,
+          "taskid": 65,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-05-05T00:00:00",
-          "deadline": "2023-05-05T05:00:00"
-        },
-        {
-          "taskid": 102,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-05-05T05:00:00",
-          "deadline": "2023-05-05T06:00:00"
-        },
-        {
-          "taskid": 103,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-05-05T06:00:00",
           "deadline": "2023-05-06T00:00:00"
         }
       ]
@@ -1166,27 +862,11 @@
       "day": "2023-05-06",
       "outputs": [
         {
-          "taskid": 104,
+          "taskid": 66,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-05-06T00:00:00",
-          "deadline": "2023-05-06T05:00:00"
-        },
-        {
-          "taskid": 105,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-05-06T05:00:00",
-          "deadline": "2023-05-06T06:00:00"
-        },
-        {
-          "taskid": 106,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-05-06T06:00:00",
           "deadline": "2023-05-07T00:00:00"
         }
       ]
@@ -1195,7 +875,7 @@
       "day": "2023-05-07",
       "outputs": [
         {
-          "taskid": 107,
+          "taskid": 67,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1208,7 +888,7 @@
       "day": "2023-05-08",
       "outputs": [
         {
-          "taskid": 108,
+          "taskid": 68,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1221,7 +901,7 @@
       "day": "2023-05-09",
       "outputs": [
         {
-          "taskid": 109,
+          "taskid": 69,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1234,7 +914,7 @@
       "day": "2023-05-10",
       "outputs": [
         {
-          "taskid": 110,
+          "taskid": 70,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1247,7 +927,7 @@
       "day": "2023-05-11",
       "outputs": [
         {
-          "taskid": 111,
+          "taskid": 71,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1260,27 +940,11 @@
       "day": "2023-05-12",
       "outputs": [
         {
-          "taskid": 112,
+          "taskid": 72,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-05-12T00:00:00",
-          "deadline": "2023-05-12T05:00:00"
-        },
-        {
-          "taskid": 113,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-05-12T05:00:00",
-          "deadline": "2023-05-12T06:00:00"
-        },
-        {
-          "taskid": 114,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-05-12T06:00:00",
           "deadline": "2023-05-13T00:00:00"
         }
       ]
@@ -1289,27 +953,11 @@
       "day": "2023-05-13",
       "outputs": [
         {
-          "taskid": 115,
+          "taskid": 73,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-05-13T00:00:00",
-          "deadline": "2023-05-13T05:00:00"
-        },
-        {
-          "taskid": 116,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-05-13T05:00:00",
-          "deadline": "2023-05-13T06:00:00"
-        },
-        {
-          "taskid": 117,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-05-13T06:00:00",
           "deadline": "2023-05-14T00:00:00"
         }
       ]
@@ -1318,7 +966,7 @@
       "day": "2023-05-14",
       "outputs": [
         {
-          "taskid": 118,
+          "taskid": 74,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1331,7 +979,7 @@
       "day": "2023-05-15",
       "outputs": [
         {
-          "taskid": 119,
+          "taskid": 75,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1344,7 +992,7 @@
       "day": "2023-05-16",
       "outputs": [
         {
-          "taskid": 120,
+          "taskid": 76,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1357,7 +1005,7 @@
       "day": "2023-05-17",
       "outputs": [
         {
-          "taskid": 121,
+          "taskid": 77,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1370,7 +1018,7 @@
       "day": "2023-05-18",
       "outputs": [
         {
-          "taskid": 122,
+          "taskid": 78,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1383,27 +1031,11 @@
       "day": "2023-05-19",
       "outputs": [
         {
-          "taskid": 123,
+          "taskid": 79,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-05-19T00:00:00",
-          "deadline": "2023-05-19T05:00:00"
-        },
-        {
-          "taskid": 124,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-05-19T05:00:00",
-          "deadline": "2023-05-19T06:00:00"
-        },
-        {
-          "taskid": 125,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-05-19T06:00:00",
           "deadline": "2023-05-20T00:00:00"
         }
       ]
@@ -1412,27 +1044,11 @@
       "day": "2023-05-20",
       "outputs": [
         {
-          "taskid": 126,
+          "taskid": 80,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-05-20T00:00:00",
-          "deadline": "2023-05-20T05:00:00"
-        },
-        {
-          "taskid": 127,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-05-20T05:00:00",
-          "deadline": "2023-05-20T06:00:00"
-        },
-        {
-          "taskid": 128,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-05-20T06:00:00",
           "deadline": "2023-05-21T00:00:00"
         }
       ]
@@ -1441,7 +1057,7 @@
       "day": "2023-05-21",
       "outputs": [
         {
-          "taskid": 129,
+          "taskid": 81,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1454,7 +1070,7 @@
       "day": "2023-05-22",
       "outputs": [
         {
-          "taskid": 130,
+          "taskid": 82,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1467,7 +1083,7 @@
       "day": "2023-05-23",
       "outputs": [
         {
-          "taskid": 131,
+          "taskid": 83,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1480,7 +1096,7 @@
       "day": "2023-05-24",
       "outputs": [
         {
-          "taskid": 132,
+          "taskid": 84,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1493,7 +1109,7 @@
       "day": "2023-05-25",
       "outputs": [
         {
-          "taskid": 133,
+          "taskid": 85,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1506,27 +1122,11 @@
       "day": "2023-05-26",
       "outputs": [
         {
-          "taskid": 134,
+          "taskid": 86,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-05-26T00:00:00",
-          "deadline": "2023-05-26T05:00:00"
-        },
-        {
-          "taskid": 135,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-05-26T05:00:00",
-          "deadline": "2023-05-26T06:00:00"
-        },
-        {
-          "taskid": 136,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-05-26T06:00:00",
           "deadline": "2023-05-27T00:00:00"
         }
       ]
@@ -1535,27 +1135,11 @@
       "day": "2023-05-27",
       "outputs": [
         {
-          "taskid": 137,
+          "taskid": 87,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-05-27T00:00:00",
-          "deadline": "2023-05-27T05:00:00"
-        },
-        {
-          "taskid": 138,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-05-27T05:00:00",
-          "deadline": "2023-05-27T06:00:00"
-        },
-        {
-          "taskid": 139,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-05-27T06:00:00",
           "deadline": "2023-05-28T00:00:00"
         }
       ]
@@ -1564,7 +1148,7 @@
       "day": "2023-05-28",
       "outputs": [
         {
-          "taskid": 140,
+          "taskid": 88,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1577,7 +1161,7 @@
       "day": "2023-05-29",
       "outputs": [
         {
-          "taskid": 141,
+          "taskid": 89,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1590,7 +1174,7 @@
       "day": "2023-05-30",
       "outputs": [
         {
-          "taskid": 142,
+          "taskid": 90,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1603,7 +1187,7 @@
       "day": "2023-05-31",
       "outputs": [
         {
-          "taskid": 143,
+          "taskid": 91,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1616,7 +1200,7 @@
       "day": "2023-06-01",
       "outputs": [
         {
-          "taskid": 144,
+          "taskid": 92,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1629,27 +1213,11 @@
       "day": "2023-06-02",
       "outputs": [
         {
-          "taskid": 145,
+          "taskid": 93,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-06-02T00:00:00",
-          "deadline": "2023-06-02T05:00:00"
-        },
-        {
-          "taskid": 146,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-06-02T05:00:00",
-          "deadline": "2023-06-02T06:00:00"
-        },
-        {
-          "taskid": 147,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-06-02T06:00:00",
           "deadline": "2023-06-03T00:00:00"
         }
       ]
@@ -1658,27 +1226,11 @@
       "day": "2023-06-03",
       "outputs": [
         {
-          "taskid": 148,
+          "taskid": 94,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-06-03T00:00:00",
-          "deadline": "2023-06-03T05:00:00"
-        },
-        {
-          "taskid": 149,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-06-03T05:00:00",
-          "deadline": "2023-06-03T06:00:00"
-        },
-        {
-          "taskid": 150,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-06-03T06:00:00",
           "deadline": "2023-06-04T00:00:00"
         }
       ]
@@ -1687,7 +1239,7 @@
       "day": "2023-06-04",
       "outputs": [
         {
-          "taskid": 151,
+          "taskid": 95,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1700,7 +1252,7 @@
       "day": "2023-06-05",
       "outputs": [
         {
-          "taskid": 152,
+          "taskid": 96,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1713,7 +1265,7 @@
       "day": "2023-06-06",
       "outputs": [
         {
-          "taskid": 153,
+          "taskid": 97,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1726,7 +1278,7 @@
       "day": "2023-06-07",
       "outputs": [
         {
-          "taskid": 154,
+          "taskid": 98,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1739,7 +1291,7 @@
       "day": "2023-06-08",
       "outputs": [
         {
-          "taskid": 155,
+          "taskid": 99,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1752,27 +1304,11 @@
       "day": "2023-06-09",
       "outputs": [
         {
-          "taskid": 156,
+          "taskid": 100,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-06-09T00:00:00",
-          "deadline": "2023-06-09T05:00:00"
-        },
-        {
-          "taskid": 157,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-06-09T05:00:00",
-          "deadline": "2023-06-09T06:00:00"
-        },
-        {
-          "taskid": 158,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-06-09T06:00:00",
           "deadline": "2023-06-10T00:00:00"
         }
       ]
@@ -1781,27 +1317,11 @@
       "day": "2023-06-10",
       "outputs": [
         {
-          "taskid": 159,
+          "taskid": 101,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-06-10T00:00:00",
-          "deadline": "2023-06-10T05:00:00"
-        },
-        {
-          "taskid": 160,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-06-10T05:00:00",
-          "deadline": "2023-06-10T06:00:00"
-        },
-        {
-          "taskid": 161,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-06-10T06:00:00",
           "deadline": "2023-06-11T00:00:00"
         }
       ]
@@ -1810,7 +1330,7 @@
       "day": "2023-06-11",
       "outputs": [
         {
-          "taskid": 162,
+          "taskid": 102,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1823,7 +1343,7 @@
       "day": "2023-06-12",
       "outputs": [
         {
-          "taskid": 163,
+          "taskid": 103,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1836,7 +1356,7 @@
       "day": "2023-06-13",
       "outputs": [
         {
-          "taskid": 164,
+          "taskid": 104,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1849,7 +1369,7 @@
       "day": "2023-06-14",
       "outputs": [
         {
-          "taskid": 165,
+          "taskid": 105,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1862,7 +1382,7 @@
       "day": "2023-06-15",
       "outputs": [
         {
-          "taskid": 166,
+          "taskid": 106,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1875,27 +1395,11 @@
       "day": "2023-06-16",
       "outputs": [
         {
-          "taskid": 167,
+          "taskid": 107,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-06-16T00:00:00",
-          "deadline": "2023-06-16T05:00:00"
-        },
-        {
-          "taskid": 168,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-06-16T05:00:00",
-          "deadline": "2023-06-16T06:00:00"
-        },
-        {
-          "taskid": 169,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-06-16T06:00:00",
           "deadline": "2023-06-17T00:00:00"
         }
       ]
@@ -1904,27 +1408,11 @@
       "day": "2023-06-17",
       "outputs": [
         {
-          "taskid": 170,
+          "taskid": 108,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-06-17T00:00:00",
-          "deadline": "2023-06-17T05:00:00"
-        },
-        {
-          "taskid": 171,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-06-17T05:00:00",
-          "deadline": "2023-06-17T06:00:00"
-        },
-        {
-          "taskid": 172,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-06-17T06:00:00",
           "deadline": "2023-06-18T00:00:00"
         }
       ]
@@ -1933,7 +1421,7 @@
       "day": "2023-06-18",
       "outputs": [
         {
-          "taskid": 173,
+          "taskid": 109,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1946,7 +1434,7 @@
       "day": "2023-06-19",
       "outputs": [
         {
-          "taskid": 174,
+          "taskid": 110,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1959,7 +1447,7 @@
       "day": "2023-06-20",
       "outputs": [
         {
-          "taskid": 175,
+          "taskid": 111,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1972,7 +1460,7 @@
       "day": "2023-06-21",
       "outputs": [
         {
-          "taskid": 176,
+          "taskid": 112,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1985,7 +1473,7 @@
       "day": "2023-06-22",
       "outputs": [
         {
-          "taskid": 177,
+          "taskid": 113,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -1998,27 +1486,11 @@
       "day": "2023-06-23",
       "outputs": [
         {
-          "taskid": 178,
+          "taskid": 114,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-06-23T00:00:00",
-          "deadline": "2023-06-23T05:00:00"
-        },
-        {
-          "taskid": 179,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-06-23T05:00:00",
-          "deadline": "2023-06-23T06:00:00"
-        },
-        {
-          "taskid": 180,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-06-23T06:00:00",
           "deadline": "2023-06-24T00:00:00"
         }
       ]
@@ -2027,27 +1499,11 @@
       "day": "2023-06-24",
       "outputs": [
         {
-          "taskid": 181,
+          "taskid": 115,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-06-24T00:00:00",
-          "deadline": "2023-06-24T05:00:00"
-        },
-        {
-          "taskid": 182,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-06-24T05:00:00",
-          "deadline": "2023-06-24T06:00:00"
-        },
-        {
-          "taskid": 183,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-06-24T06:00:00",
           "deadline": "2023-06-25T00:00:00"
         }
       ]
@@ -2056,7 +1512,7 @@
       "day": "2023-06-25",
       "outputs": [
         {
-          "taskid": 184,
+          "taskid": 116,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -2069,7 +1525,7 @@
       "day": "2023-06-26",
       "outputs": [
         {
-          "taskid": 185,
+          "taskid": 117,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -2082,7 +1538,7 @@
       "day": "2023-06-27",
       "outputs": [
         {
-          "taskid": 186,
+          "taskid": 118,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -2095,7 +1551,7 @@
       "day": "2023-06-28",
       "outputs": [
         {
-          "taskid": 187,
+          "taskid": 119,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -2108,7 +1564,7 @@
       "day": "2023-06-29",
       "outputs": [
         {
-          "taskid": 188,
+          "taskid": 120,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -2121,27 +1577,11 @@
       "day": "2023-06-30",
       "outputs": [
         {
-          "taskid": 189,
+          "taskid": 121,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-06-30T00:00:00",
-          "deadline": "2023-06-30T05:00:00"
-        },
-        {
-          "taskid": 190,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-06-30T05:00:00",
-          "deadline": "2023-06-30T06:00:00"
-        },
-        {
-          "taskid": 191,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-06-30T06:00:00",
           "deadline": "2023-07-01T00:00:00"
         }
       ]
@@ -2150,27 +1590,11 @@
       "day": "2023-07-01",
       "outputs": [
         {
-          "taskid": 192,
+          "taskid": 122,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-07-01T00:00:00",
-          "deadline": "2023-07-01T05:00:00"
-        },
-        {
-          "taskid": 193,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-07-01T05:00:00",
-          "deadline": "2023-07-01T06:00:00"
-        },
-        {
-          "taskid": 194,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-07-01T06:00:00",
           "deadline": "2023-07-02T00:00:00"
         }
       ]
@@ -2179,7 +1603,7 @@
       "day": "2023-07-02",
       "outputs": [
         {
-          "taskid": 195,
+          "taskid": 123,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -2192,7 +1616,7 @@
       "day": "2023-07-03",
       "outputs": [
         {
-          "taskid": 196,
+          "taskid": 124,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -2205,7 +1629,7 @@
       "day": "2023-07-04",
       "outputs": [
         {
-          "taskid": 197,
+          "taskid": 125,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -2218,7 +1642,7 @@
       "day": "2023-07-05",
       "outputs": [
         {
-          "taskid": 198,
+          "taskid": 126,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -2231,7 +1655,7 @@
       "day": "2023-07-06",
       "outputs": [
         {
-          "taskid": 199,
+          "taskid": 127,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -2244,27 +1668,11 @@
       "day": "2023-07-07",
       "outputs": [
         {
-          "taskid": 200,
+          "taskid": 128,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-07-07T00:00:00",
-          "deadline": "2023-07-07T05:00:00"
-        },
-        {
-          "taskid": 201,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-07-07T05:00:00",
-          "deadline": "2023-07-07T06:00:00"
-        },
-        {
-          "taskid": 202,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-07-07T06:00:00",
           "deadline": "2023-07-08T00:00:00"
         }
       ]
@@ -2273,27 +1681,11 @@
       "day": "2023-07-08",
       "outputs": [
         {
-          "taskid": 203,
+          "taskid": 129,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-07-08T00:00:00",
-          "deadline": "2023-07-08T05:00:00"
-        },
-        {
-          "taskid": 204,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-07-08T05:00:00",
-          "deadline": "2023-07-08T06:00:00"
-        },
-        {
-          "taskid": 205,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-07-08T06:00:00",
           "deadline": "2023-07-09T00:00:00"
         }
       ]
@@ -2302,7 +1694,7 @@
       "day": "2023-07-09",
       "outputs": [
         {
-          "taskid": 206,
+          "taskid": 130,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -2315,7 +1707,7 @@
       "day": "2023-07-10",
       "outputs": [
         {
-          "taskid": 207,
+          "taskid": 131,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -2328,7 +1720,7 @@
       "day": "2023-07-11",
       "outputs": [
         {
-          "taskid": 208,
+          "taskid": 132,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -2341,7 +1733,7 @@
       "day": "2023-07-12",
       "outputs": [
         {
-          "taskid": 209,
+          "taskid": 133,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -2354,7 +1746,7 @@
       "day": "2023-07-13",
       "outputs": [
         {
-          "taskid": 210,
+          "taskid": 134,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -2367,27 +1759,11 @@
       "day": "2023-07-14",
       "outputs": [
         {
-          "taskid": 211,
+          "taskid": 135,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-07-14T00:00:00",
-          "deadline": "2023-07-14T05:00:00"
-        },
-        {
-          "taskid": 212,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-07-14T05:00:00",
-          "deadline": "2023-07-14T06:00:00"
-        },
-        {
-          "taskid": 213,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-07-14T06:00:00",
           "deadline": "2023-07-15T00:00:00"
         }
       ]
@@ -2396,27 +1772,11 @@
       "day": "2023-07-15",
       "outputs": [
         {
-          "taskid": 214,
+          "taskid": 136,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
+          "duration": 24,
           "start": "2023-07-15T00:00:00",
-          "deadline": "2023-07-15T05:00:00"
-        },
-        {
-          "taskid": 215,
-          "goalid": "1",
-          "title": "Rust project",
-          "duration": 1,
-          "start": "2023-07-15T05:00:00",
-          "deadline": "2023-07-15T06:00:00"
-        },
-        {
-          "taskid": 216,
-          "goalid": "free",
-          "title": "free",
-          "duration": 18,
-          "start": "2023-07-15T06:00:00",
           "deadline": "2023-07-16T00:00:00"
         }
       ]
@@ -2425,7 +1785,7 @@
       "day": "2023-07-16",
       "outputs": [
         {
-          "taskid": 217,
+          "taskid": 137,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -2438,7 +1798,7 @@
       "day": "2023-07-17",
       "outputs": [
         {
-          "taskid": 218,
+          "taskid": 138,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -2451,7 +1811,7 @@
       "day": "2023-07-18",
       "outputs": [
         {
-          "taskid": 219,
+          "taskid": 139,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -2464,7 +1824,7 @@
       "day": "2023-07-19",
       "outputs": [
         {
-          "taskid": 220,
+          "taskid": 140,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -2477,7 +1837,16 @@
   "impossible": [
     {
       "day": "2023-03-01",
-      "outputs": []
+      "outputs": [
+        {
+          "taskid": 141,
+          "goalid": "1",
+          "title": "Rust project",
+          "duration": 40,
+          "start": "2023-03-01T00:00:00",
+          "deadline": "2023-07-20T00:00:00"
+        }
+      ]
     },
     {
       "day": "2023-03-02",

--- a/tests/jsons/issue-284-no-repeat-large-dur-with-impossible/actual_output.json
+++ b/tests/jsons/issue-284-no-repeat-large-dur-with-impossible/actual_output.json
@@ -20,24 +20,8 @@
           "taskid": 1,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2023-03-10T00:00:00",
-          "deadline": "2023-03-10T08:00:00"
-        },
-        {
-          "taskid": 2,
-          "goalid": "1",
-          "title": "learn rust",
-          "duration": 1,
-          "start": "2023-03-10T08:00:00",
-          "deadline": "2023-03-10T09:00:00"
-        },
-        {
-          "taskid": 3,
-          "goalid": "free",
-          "title": "free",
-          "duration": 15,
-          "start": "2023-03-10T09:00:00",
           "deadline": "2023-03-11T00:00:00"
         }
       ]
@@ -46,7 +30,7 @@
       "day": "2023-03-11",
       "outputs": [
         {
-          "taskid": 4,
+          "taskid": 2,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -59,7 +43,7 @@
       "day": "2023-03-12",
       "outputs": [
         {
-          "taskid": 5,
+          "taskid": 3,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -72,27 +56,11 @@
       "day": "2023-03-13",
       "outputs": [
         {
-          "taskid": 6,
+          "taskid": 4,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2023-03-13T00:00:00",
-          "deadline": "2023-03-13T08:00:00"
-        },
-        {
-          "taskid": 7,
-          "goalid": "1",
-          "title": "learn rust",
-          "duration": 1,
-          "start": "2023-03-13T08:00:00",
-          "deadline": "2023-03-13T09:00:00"
-        },
-        {
-          "taskid": 8,
-          "goalid": "free",
-          "title": "free",
-          "duration": 15,
-          "start": "2023-03-13T09:00:00",
           "deadline": "2023-03-14T00:00:00"
         }
       ]
@@ -101,7 +69,7 @@
       "day": "2023-03-14",
       "outputs": [
         {
-          "taskid": 9,
+          "taskid": 5,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -114,7 +82,7 @@
       "day": "2023-03-15",
       "outputs": [
         {
-          "taskid": 10,
+          "taskid": 6,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -127,7 +95,7 @@
       "day": "2023-03-16",
       "outputs": [
         {
-          "taskid": 11,
+          "taskid": 7,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -140,27 +108,11 @@
       "day": "2023-03-17",
       "outputs": [
         {
-          "taskid": 12,
+          "taskid": 8,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2023-03-17T00:00:00",
-          "deadline": "2023-03-17T08:00:00"
-        },
-        {
-          "taskid": 13,
-          "goalid": "1",
-          "title": "learn rust",
-          "duration": 1,
-          "start": "2023-03-17T08:00:00",
-          "deadline": "2023-03-17T09:00:00"
-        },
-        {
-          "taskid": 14,
-          "goalid": "free",
-          "title": "free",
-          "duration": 15,
-          "start": "2023-03-17T09:00:00",
           "deadline": "2023-03-18T00:00:00"
         }
       ]
@@ -169,7 +121,7 @@
       "day": "2023-03-18",
       "outputs": [
         {
-          "taskid": 15,
+          "taskid": 9,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -182,7 +134,7 @@
       "day": "2023-03-19",
       "outputs": [
         {
-          "taskid": 16,
+          "taskid": 10,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -197,10 +149,10 @@
       "day": "2023-03-09",
       "outputs": [
         {
-          "taskid": 17,
+          "taskid": 11,
           "goalid": "1",
           "title": "learn rust",
-          "duration": 7,
+          "duration": 10,
           "start": "2023-03-09T00:00:00",
           "deadline": "2023-03-20T00:00:00"
         }

--- a/tests/jsons/planned-goals-hierarchy/actual_output.json
+++ b/tests/jsons/planned-goals-hierarchy/actual_output.json
@@ -36,24 +36,8 @@
           "taskid": 3,
           "goalid": "free",
           "title": "free",
-          "duration": 6,
+          "duration": 24,
           "start": "2018-01-02T00:00:00",
-          "deadline": "2018-01-02T06:00:00"
-        },
-        {
-          "taskid": 4,
-          "goalid": "1",
-          "title": "work",
-          "duration": 10,
-          "start": "2018-01-02T06:00:00",
-          "deadline": "2018-01-02T16:00:00"
-        },
-        {
-          "taskid": 5,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2018-01-02T16:00:00",
           "deadline": "2018-01-03T00:00:00"
         }
       ]
@@ -62,27 +46,11 @@
       "day": "2018-01-03",
       "outputs": [
         {
-          "taskid": 6,
+          "taskid": 4,
           "goalid": "free",
           "title": "free",
-          "duration": 6,
+          "duration": 24,
           "start": "2018-01-03T00:00:00",
-          "deadline": "2018-01-03T06:00:00"
-        },
-        {
-          "taskid": 7,
-          "goalid": "1",
-          "title": "work",
-          "duration": 10,
-          "start": "2018-01-03T06:00:00",
-          "deadline": "2018-01-03T16:00:00"
-        },
-        {
-          "taskid": 8,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2018-01-03T16:00:00",
           "deadline": "2018-01-04T00:00:00"
         }
       ]
@@ -91,7 +59,7 @@
       "day": "2018-01-04",
       "outputs": [
         {
-          "taskid": 9,
+          "taskid": 5,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -104,7 +72,7 @@
       "day": "2018-01-05",
       "outputs": [
         {
-          "taskid": 10,
+          "taskid": 6,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -117,7 +85,16 @@
   "impossible": [
     {
       "day": "2018-01-01",
-      "outputs": []
+      "outputs": [
+        {
+          "taskid": 7,
+          "goalid": "1",
+          "title": "work",
+          "duration": 30,
+          "start": "2018-01-01T00:00:00",
+          "deadline": "2018-01-06T00:00:00"
+        }
+      ]
     },
     {
       "day": "2018-01-02",

--- a/tests/jsons/realistic-schedule-1/actual_output.json
+++ b/tests/jsons/realistic-schedule-1/actual_output.json
@@ -45,34 +45,26 @@
         },
         {
           "taskid": 5,
-          "goalid": "1",
-          "title": "walk",
-          "duration": 1,
-          "start": "2022-09-01T17:00:00",
-          "deadline": "2022-09-01T18:00:00"
-        },
-        {
-          "taskid": 6,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-09-01T18:00:00",
-          "deadline": "2022-09-01T19:00:00"
-        },
-        {
-          "taskid": 7,
-          "goalid": "2",
-          "title": "read",
-          "duration": 1,
-          "start": "2022-09-01T19:00:00",
-          "deadline": "2022-09-01T20:00:00"
-        },
-        {
-          "taskid": 8,
           "goalid": "free",
           "title": "free",
           "duration": 4,
-          "start": "2022-09-01T20:00:00",
+          "start": "2022-09-01T17:00:00",
+          "deadline": "2022-09-01T21:00:00"
+        },
+        {
+          "taskid": 6,
+          "goalid": "2",
+          "title": "read",
+          "duration": 1,
+          "start": "2022-09-01T21:00:00",
+          "deadline": "2022-09-01T22:00:00"
+        },
+        {
+          "taskid": 7,
+          "goalid": "free",
+          "title": "free",
+          "duration": 2,
+          "start": "2022-09-01T22:00:00",
           "deadline": "2022-09-02T00:00:00"
         }
       ]
@@ -81,7 +73,7 @@
       "day": "2022-09-02",
       "outputs": [
         {
-          "taskid": 9,
+          "taskid": 8,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -89,7 +81,7 @@
           "deadline": "2022-09-02T05:00:00"
         },
         {
-          "taskid": 10,
+          "taskid": 9,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -97,7 +89,7 @@
           "deadline": "2022-09-02T07:00:00"
         },
         {
-          "taskid": 11,
+          "taskid": 10,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -105,7 +97,7 @@
           "deadline": "2022-09-02T09:00:00"
         },
         {
-          "taskid": 12,
+          "taskid": 11,
           "goalid": "5",
           "title": "work",
           "duration": 8,
@@ -113,35 +105,27 @@
           "deadline": "2022-09-02T17:00:00"
         },
         {
-          "taskid": 13,
-          "goalid": "1",
-          "title": "walk",
-          "duration": 1,
+          "taskid": 12,
+          "goalid": "free",
+          "title": "free",
+          "duration": 4,
           "start": "2022-09-02T17:00:00",
-          "deadline": "2022-09-02T18:00:00"
+          "deadline": "2022-09-02T21:00:00"
+        },
+        {
+          "taskid": 13,
+          "goalid": "2",
+          "title": "read",
+          "duration": 1,
+          "start": "2022-09-02T21:00:00",
+          "deadline": "2022-09-02T22:00:00"
         },
         {
           "taskid": 14,
           "goalid": "free",
           "title": "free",
-          "duration": 1,
-          "start": "2022-09-02T18:00:00",
-          "deadline": "2022-09-02T19:00:00"
-        },
-        {
-          "taskid": 15,
-          "goalid": "2",
-          "title": "read",
-          "duration": 1,
-          "start": "2022-09-02T19:00:00",
-          "deadline": "2022-09-02T20:00:00"
-        },
-        {
-          "taskid": 16,
-          "goalid": "free",
-          "title": "free",
-          "duration": 4,
-          "start": "2022-09-02T20:00:00",
+          "duration": 2,
+          "start": "2022-09-02T22:00:00",
           "deadline": "2022-09-03T00:00:00"
         }
       ]
@@ -150,7 +134,7 @@
       "day": "2022-09-03",
       "outputs": [
         {
-          "taskid": 17,
+          "taskid": 15,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -158,7 +142,7 @@
           "deadline": "2022-09-03T05:00:00"
         },
         {
-          "taskid": 18,
+          "taskid": 16,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -166,7 +150,7 @@
           "deadline": "2022-09-03T07:00:00"
         },
         {
-          "taskid": 19,
+          "taskid": 17,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -174,7 +158,7 @@
           "deadline": "2022-09-03T09:00:00"
         },
         {
-          "taskid": 20,
+          "taskid": 18,
           "goalid": "5",
           "title": "work",
           "duration": 8,
@@ -182,35 +166,27 @@
           "deadline": "2022-09-03T17:00:00"
         },
         {
-          "taskid": 21,
-          "goalid": "1",
-          "title": "walk",
-          "duration": 1,
-          "start": "2022-09-03T17:00:00",
-          "deadline": "2022-09-03T18:00:00"
-        },
-        {
-          "taskid": 22,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-09-03T18:00:00",
-          "deadline": "2022-09-03T19:00:00"
-        },
-        {
-          "taskid": 23,
-          "goalid": "2",
-          "title": "read",
-          "duration": 1,
-          "start": "2022-09-03T19:00:00",
-          "deadline": "2022-09-03T20:00:00"
-        },
-        {
-          "taskid": 24,
+          "taskid": 19,
           "goalid": "free",
           "title": "free",
           "duration": 4,
-          "start": "2022-09-03T20:00:00",
+          "start": "2022-09-03T17:00:00",
+          "deadline": "2022-09-03T21:00:00"
+        },
+        {
+          "taskid": 20,
+          "goalid": "2",
+          "title": "read",
+          "duration": 1,
+          "start": "2022-09-03T21:00:00",
+          "deadline": "2022-09-03T22:00:00"
+        },
+        {
+          "taskid": 21,
+          "goalid": "free",
+          "title": "free",
+          "duration": 2,
+          "start": "2022-09-03T22:00:00",
           "deadline": "2022-09-04T00:00:00"
         }
       ]
@@ -219,7 +195,7 @@
       "day": "2022-09-04",
       "outputs": [
         {
-          "taskid": 25,
+          "taskid": 22,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -227,7 +203,7 @@
           "deadline": "2022-09-04T05:00:00"
         },
         {
-          "taskid": 26,
+          "taskid": 23,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -235,7 +211,7 @@
           "deadline": "2022-09-04T07:00:00"
         },
         {
-          "taskid": 27,
+          "taskid": 24,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -243,7 +219,7 @@
           "deadline": "2022-09-04T09:00:00"
         },
         {
-          "taskid": 28,
+          "taskid": 25,
           "goalid": "5",
           "title": "work",
           "duration": 8,
@@ -251,35 +227,27 @@
           "deadline": "2022-09-04T17:00:00"
         },
         {
-          "taskid": 29,
-          "goalid": "1",
-          "title": "walk",
-          "duration": 1,
-          "start": "2022-09-04T17:00:00",
-          "deadline": "2022-09-04T18:00:00"
-        },
-        {
-          "taskid": 30,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-09-04T18:00:00",
-          "deadline": "2022-09-04T19:00:00"
-        },
-        {
-          "taskid": 31,
-          "goalid": "2",
-          "title": "read",
-          "duration": 1,
-          "start": "2022-09-04T19:00:00",
-          "deadline": "2022-09-04T20:00:00"
-        },
-        {
-          "taskid": 32,
+          "taskid": 26,
           "goalid": "free",
           "title": "free",
           "duration": 4,
-          "start": "2022-09-04T20:00:00",
+          "start": "2022-09-04T17:00:00",
+          "deadline": "2022-09-04T21:00:00"
+        },
+        {
+          "taskid": 27,
+          "goalid": "2",
+          "title": "read",
+          "duration": 1,
+          "start": "2022-09-04T21:00:00",
+          "deadline": "2022-09-04T22:00:00"
+        },
+        {
+          "taskid": 28,
+          "goalid": "free",
+          "title": "free",
+          "duration": 2,
+          "start": "2022-09-04T22:00:00",
           "deadline": "2022-09-05T00:00:00"
         }
       ]
@@ -288,7 +256,7 @@
       "day": "2022-09-05",
       "outputs": [
         {
-          "taskid": 33,
+          "taskid": 29,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -296,7 +264,7 @@
           "deadline": "2022-09-05T05:00:00"
         },
         {
-          "taskid": 34,
+          "taskid": 30,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -304,7 +272,7 @@
           "deadline": "2022-09-05T07:00:00"
         },
         {
-          "taskid": 35,
+          "taskid": 31,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -312,7 +280,7 @@
           "deadline": "2022-09-05T09:00:00"
         },
         {
-          "taskid": 36,
+          "taskid": 32,
           "goalid": "5",
           "title": "work",
           "duration": 8,
@@ -320,35 +288,27 @@
           "deadline": "2022-09-05T17:00:00"
         },
         {
-          "taskid": 37,
-          "goalid": "1",
-          "title": "walk",
-          "duration": 1,
-          "start": "2022-09-05T17:00:00",
-          "deadline": "2022-09-05T18:00:00"
-        },
-        {
-          "taskid": 38,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-09-05T18:00:00",
-          "deadline": "2022-09-05T19:00:00"
-        },
-        {
-          "taskid": 39,
-          "goalid": "2",
-          "title": "read",
-          "duration": 1,
-          "start": "2022-09-05T19:00:00",
-          "deadline": "2022-09-05T20:00:00"
-        },
-        {
-          "taskid": 40,
+          "taskid": 33,
           "goalid": "free",
           "title": "free",
           "duration": 4,
-          "start": "2022-09-05T20:00:00",
+          "start": "2022-09-05T17:00:00",
+          "deadline": "2022-09-05T21:00:00"
+        },
+        {
+          "taskid": 34,
+          "goalid": "2",
+          "title": "read",
+          "duration": 1,
+          "start": "2022-09-05T21:00:00",
+          "deadline": "2022-09-05T22:00:00"
+        },
+        {
+          "taskid": 35,
+          "goalid": "free",
+          "title": "free",
+          "duration": 2,
+          "start": "2022-09-05T22:00:00",
           "deadline": "2022-09-06T00:00:00"
         }
       ]
@@ -357,7 +317,7 @@
       "day": "2022-09-06",
       "outputs": [
         {
-          "taskid": 41,
+          "taskid": 36,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -365,7 +325,7 @@
           "deadline": "2022-09-06T05:00:00"
         },
         {
-          "taskid": 42,
+          "taskid": 37,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -373,7 +333,7 @@
           "deadline": "2022-09-06T07:00:00"
         },
         {
-          "taskid": 43,
+          "taskid": 38,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -381,7 +341,7 @@
           "deadline": "2022-09-06T09:00:00"
         },
         {
-          "taskid": 44,
+          "taskid": 39,
           "goalid": "5",
           "title": "work",
           "duration": 8,
@@ -389,35 +349,27 @@
           "deadline": "2022-09-06T17:00:00"
         },
         {
-          "taskid": 45,
-          "goalid": "1",
-          "title": "walk",
-          "duration": 1,
-          "start": "2022-09-06T17:00:00",
-          "deadline": "2022-09-06T18:00:00"
-        },
-        {
-          "taskid": 46,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-09-06T18:00:00",
-          "deadline": "2022-09-06T19:00:00"
-        },
-        {
-          "taskid": 47,
-          "goalid": "2",
-          "title": "read",
-          "duration": 1,
-          "start": "2022-09-06T19:00:00",
-          "deadline": "2022-09-06T20:00:00"
-        },
-        {
-          "taskid": 48,
+          "taskid": 40,
           "goalid": "free",
           "title": "free",
           "duration": 4,
-          "start": "2022-09-06T20:00:00",
+          "start": "2022-09-06T17:00:00",
+          "deadline": "2022-09-06T21:00:00"
+        },
+        {
+          "taskid": 41,
+          "goalid": "2",
+          "title": "read",
+          "duration": 1,
+          "start": "2022-09-06T21:00:00",
+          "deadline": "2022-09-06T22:00:00"
+        },
+        {
+          "taskid": 42,
+          "goalid": "free",
+          "title": "free",
+          "duration": 2,
+          "start": "2022-09-06T22:00:00",
           "deadline": "2022-09-07T00:00:00"
         }
       ]
@@ -426,7 +378,7 @@
       "day": "2022-09-07",
       "outputs": [
         {
-          "taskid": 49,
+          "taskid": 43,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -434,7 +386,7 @@
           "deadline": "2022-09-07T05:00:00"
         },
         {
-          "taskid": 50,
+          "taskid": 44,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -442,7 +394,7 @@
           "deadline": "2022-09-07T07:00:00"
         },
         {
-          "taskid": 51,
+          "taskid": 45,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -450,7 +402,7 @@
           "deadline": "2022-09-07T12:00:00"
         },
         {
-          "taskid": 52,
+          "taskid": 46,
           "goalid": "3",
           "title": "piano practice",
           "duration": 2,
@@ -458,7 +410,7 @@
           "deadline": "2022-09-07T14:00:00"
         },
         {
-          "taskid": 53,
+          "taskid": 47,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -466,7 +418,7 @@
           "deadline": "2022-09-07T17:00:00"
         },
         {
-          "taskid": 54,
+          "taskid": 48,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -474,7 +426,7 @@
           "deadline": "2022-09-07T18:00:00"
         },
         {
-          "taskid": 55,
+          "taskid": 49,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -482,7 +434,7 @@
           "deadline": "2022-09-07T19:00:00"
         },
         {
-          "taskid": 56,
+          "taskid": 50,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -490,7 +442,7 @@
           "deadline": "2022-09-07T20:00:00"
         },
         {
-          "taskid": 57,
+          "taskid": 51,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -503,7 +455,7 @@
       "day": "2022-09-08",
       "outputs": [
         {
-          "taskid": 58,
+          "taskid": 52,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -511,7 +463,7 @@
           "deadline": "2022-09-08T05:00:00"
         },
         {
-          "taskid": 59,
+          "taskid": 53,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -519,7 +471,7 @@
           "deadline": "2022-09-08T07:00:00"
         },
         {
-          "taskid": 60,
+          "taskid": 54,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -527,7 +479,7 @@
           "deadline": "2022-09-08T17:00:00"
         },
         {
-          "taskid": 61,
+          "taskid": 55,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -535,7 +487,7 @@
           "deadline": "2022-09-08T18:00:00"
         },
         {
-          "taskid": 62,
+          "taskid": 56,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -543,7 +495,7 @@
           "deadline": "2022-09-08T19:00:00"
         },
         {
-          "taskid": 63,
+          "taskid": 57,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -551,7 +503,7 @@
           "deadline": "2022-09-08T20:00:00"
         },
         {
-          "taskid": 64,
+          "taskid": 58,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -564,7 +516,7 @@
       "day": "2022-09-09",
       "outputs": [
         {
-          "taskid": 65,
+          "taskid": 59,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -572,7 +524,7 @@
           "deadline": "2022-09-09T05:00:00"
         },
         {
-          "taskid": 66,
+          "taskid": 60,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -580,7 +532,7 @@
           "deadline": "2022-09-09T07:00:00"
         },
         {
-          "taskid": 67,
+          "taskid": 61,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -588,7 +540,7 @@
           "deadline": "2022-09-09T17:00:00"
         },
         {
-          "taskid": 68,
+          "taskid": 62,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -596,7 +548,7 @@
           "deadline": "2022-09-09T18:00:00"
         },
         {
-          "taskid": 69,
+          "taskid": 63,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -604,7 +556,7 @@
           "deadline": "2022-09-09T19:00:00"
         },
         {
-          "taskid": 70,
+          "taskid": 64,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -612,7 +564,7 @@
           "deadline": "2022-09-09T20:00:00"
         },
         {
-          "taskid": 71,
+          "taskid": 65,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -625,7 +577,7 @@
       "day": "2022-09-10",
       "outputs": [
         {
-          "taskid": 72,
+          "taskid": 66,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -633,7 +585,7 @@
           "deadline": "2022-09-10T05:00:00"
         },
         {
-          "taskid": 73,
+          "taskid": 67,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -641,7 +593,7 @@
           "deadline": "2022-09-10T07:00:00"
         },
         {
-          "taskid": 74,
+          "taskid": 68,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -649,7 +601,7 @@
           "deadline": "2022-09-10T12:00:00"
         },
         {
-          "taskid": 75,
+          "taskid": 69,
           "goalid": "7",
           "title": "shopping",
           "duration": 2,
@@ -657,7 +609,7 @@
           "deadline": "2022-09-10T14:00:00"
         },
         {
-          "taskid": 76,
+          "taskid": 70,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -665,7 +617,7 @@
           "deadline": "2022-09-10T17:00:00"
         },
         {
-          "taskid": 77,
+          "taskid": 71,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -673,7 +625,7 @@
           "deadline": "2022-09-10T18:00:00"
         },
         {
-          "taskid": 78,
+          "taskid": 72,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -681,7 +633,7 @@
           "deadline": "2022-09-10T19:00:00"
         },
         {
-          "taskid": 79,
+          "taskid": 73,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -689,7 +641,7 @@
           "deadline": "2022-09-10T20:00:00"
         },
         {
-          "taskid": 80,
+          "taskid": 74,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -702,7 +654,7 @@
       "day": "2022-09-11",
       "outputs": [
         {
-          "taskid": 81,
+          "taskid": 75,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -710,7 +662,7 @@
           "deadline": "2022-09-11T05:00:00"
         },
         {
-          "taskid": 82,
+          "taskid": 76,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -718,7 +670,7 @@
           "deadline": "2022-09-11T07:00:00"
         },
         {
-          "taskid": 83,
+          "taskid": 77,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -726,7 +678,7 @@
           "deadline": "2022-09-11T17:00:00"
         },
         {
-          "taskid": 84,
+          "taskid": 78,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -734,7 +686,7 @@
           "deadline": "2022-09-11T18:00:00"
         },
         {
-          "taskid": 85,
+          "taskid": 79,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -742,7 +694,7 @@
           "deadline": "2022-09-11T19:00:00"
         },
         {
-          "taskid": 86,
+          "taskid": 80,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -750,7 +702,7 @@
           "deadline": "2022-09-11T20:00:00"
         },
         {
-          "taskid": 87,
+          "taskid": 81,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -763,7 +715,7 @@
       "day": "2022-09-12",
       "outputs": [
         {
-          "taskid": 88,
+          "taskid": 82,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -771,7 +723,7 @@
           "deadline": "2022-09-12T05:00:00"
         },
         {
-          "taskid": 89,
+          "taskid": 83,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -779,7 +731,7 @@
           "deadline": "2022-09-12T07:00:00"
         },
         {
-          "taskid": 90,
+          "taskid": 84,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -787,7 +739,7 @@
           "deadline": "2022-09-12T17:00:00"
         },
         {
-          "taskid": 91,
+          "taskid": 85,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -795,7 +747,7 @@
           "deadline": "2022-09-12T18:00:00"
         },
         {
-          "taskid": 92,
+          "taskid": 86,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -803,7 +755,7 @@
           "deadline": "2022-09-12T19:00:00"
         },
         {
-          "taskid": 93,
+          "taskid": 87,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -811,7 +763,7 @@
           "deadline": "2022-09-12T20:00:00"
         },
         {
-          "taskid": 94,
+          "taskid": 88,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -824,7 +776,7 @@
       "day": "2022-09-13",
       "outputs": [
         {
-          "taskid": 95,
+          "taskid": 89,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -832,7 +784,7 @@
           "deadline": "2022-09-13T05:00:00"
         },
         {
-          "taskid": 96,
+          "taskid": 90,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -840,7 +792,7 @@
           "deadline": "2022-09-13T07:00:00"
         },
         {
-          "taskid": 97,
+          "taskid": 91,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -848,7 +800,7 @@
           "deadline": "2022-09-13T17:00:00"
         },
         {
-          "taskid": 98,
+          "taskid": 92,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -856,7 +808,7 @@
           "deadline": "2022-09-13T18:00:00"
         },
         {
-          "taskid": 99,
+          "taskid": 93,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -864,7 +816,7 @@
           "deadline": "2022-09-13T19:00:00"
         },
         {
-          "taskid": 100,
+          "taskid": 94,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -872,7 +824,7 @@
           "deadline": "2022-09-13T20:00:00"
         },
         {
-          "taskid": 101,
+          "taskid": 95,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -885,7 +837,7 @@
       "day": "2022-09-14",
       "outputs": [
         {
-          "taskid": 102,
+          "taskid": 96,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -893,7 +845,7 @@
           "deadline": "2022-09-14T05:00:00"
         },
         {
-          "taskid": 103,
+          "taskid": 97,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -901,7 +853,7 @@
           "deadline": "2022-09-14T07:00:00"
         },
         {
-          "taskid": 104,
+          "taskid": 98,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -909,7 +861,7 @@
           "deadline": "2022-09-14T10:00:00"
         },
         {
-          "taskid": 105,
+          "taskid": 99,
           "goalid": "6",
           "title": "dentist",
           "duration": 1,
@@ -917,7 +869,7 @@
           "deadline": "2022-09-14T11:00:00"
         },
         {
-          "taskid": 106,
+          "taskid": 100,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -925,7 +877,7 @@
           "deadline": "2022-09-14T12:00:00"
         },
         {
-          "taskid": 107,
+          "taskid": 101,
           "goalid": "3",
           "title": "piano practice",
           "duration": 2,
@@ -933,7 +885,7 @@
           "deadline": "2022-09-14T14:00:00"
         },
         {
-          "taskid": 108,
+          "taskid": 102,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -941,7 +893,7 @@
           "deadline": "2022-09-14T17:00:00"
         },
         {
-          "taskid": 109,
+          "taskid": 103,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -949,7 +901,7 @@
           "deadline": "2022-09-14T18:00:00"
         },
         {
-          "taskid": 110,
+          "taskid": 104,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -957,7 +909,7 @@
           "deadline": "2022-09-14T19:00:00"
         },
         {
-          "taskid": 111,
+          "taskid": 105,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -965,7 +917,7 @@
           "deadline": "2022-09-14T20:00:00"
         },
         {
-          "taskid": 112,
+          "taskid": 106,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -978,7 +930,7 @@
       "day": "2022-09-15",
       "outputs": [
         {
-          "taskid": 113,
+          "taskid": 107,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -986,7 +938,7 @@
           "deadline": "2022-09-15T05:00:00"
         },
         {
-          "taskid": 114,
+          "taskid": 108,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -994,7 +946,7 @@
           "deadline": "2022-09-15T07:00:00"
         },
         {
-          "taskid": 115,
+          "taskid": 109,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -1002,7 +954,7 @@
           "deadline": "2022-09-15T17:00:00"
         },
         {
-          "taskid": 116,
+          "taskid": 110,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1010,7 +962,7 @@
           "deadline": "2022-09-15T18:00:00"
         },
         {
-          "taskid": 117,
+          "taskid": 111,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1018,7 +970,7 @@
           "deadline": "2022-09-15T19:00:00"
         },
         {
-          "taskid": 118,
+          "taskid": 112,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1026,7 +978,7 @@
           "deadline": "2022-09-15T20:00:00"
         },
         {
-          "taskid": 119,
+          "taskid": 113,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1039,7 +991,7 @@
       "day": "2022-09-16",
       "outputs": [
         {
-          "taskid": 120,
+          "taskid": 114,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1047,7 +999,7 @@
           "deadline": "2022-09-16T05:00:00"
         },
         {
-          "taskid": 121,
+          "taskid": 115,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1055,7 +1007,7 @@
           "deadline": "2022-09-16T07:00:00"
         },
         {
-          "taskid": 122,
+          "taskid": 116,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -1063,7 +1015,7 @@
           "deadline": "2022-09-16T17:00:00"
         },
         {
-          "taskid": 123,
+          "taskid": 117,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1071,7 +1023,7 @@
           "deadline": "2022-09-16T18:00:00"
         },
         {
-          "taskid": 124,
+          "taskid": 118,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1079,7 +1031,7 @@
           "deadline": "2022-09-16T19:00:00"
         },
         {
-          "taskid": 125,
+          "taskid": 119,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1087,7 +1039,7 @@
           "deadline": "2022-09-16T20:00:00"
         },
         {
-          "taskid": 126,
+          "taskid": 120,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1100,7 +1052,7 @@
       "day": "2022-09-17",
       "outputs": [
         {
-          "taskid": 127,
+          "taskid": 121,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1108,7 +1060,7 @@
           "deadline": "2022-09-17T05:00:00"
         },
         {
-          "taskid": 128,
+          "taskid": 122,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1116,7 +1068,7 @@
           "deadline": "2022-09-17T07:00:00"
         },
         {
-          "taskid": 129,
+          "taskid": 123,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -1124,7 +1076,7 @@
           "deadline": "2022-09-17T17:00:00"
         },
         {
-          "taskid": 130,
+          "taskid": 124,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1132,7 +1084,7 @@
           "deadline": "2022-09-17T18:00:00"
         },
         {
-          "taskid": 131,
+          "taskid": 125,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1140,7 +1092,7 @@
           "deadline": "2022-09-17T19:00:00"
         },
         {
-          "taskid": 132,
+          "taskid": 126,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1148,7 +1100,7 @@
           "deadline": "2022-09-17T20:00:00"
         },
         {
-          "taskid": 133,
+          "taskid": 127,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1161,7 +1113,7 @@
       "day": "2022-09-18",
       "outputs": [
         {
-          "taskid": 134,
+          "taskid": 128,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1169,7 +1121,7 @@
           "deadline": "2022-09-18T05:00:00"
         },
         {
-          "taskid": 135,
+          "taskid": 129,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1177,7 +1129,7 @@
           "deadline": "2022-09-18T07:00:00"
         },
         {
-          "taskid": 136,
+          "taskid": 130,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -1185,7 +1137,7 @@
           "deadline": "2022-09-18T17:00:00"
         },
         {
-          "taskid": 137,
+          "taskid": 131,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1193,7 +1145,7 @@
           "deadline": "2022-09-18T18:00:00"
         },
         {
-          "taskid": 138,
+          "taskid": 132,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1201,7 +1153,7 @@
           "deadline": "2022-09-18T19:00:00"
         },
         {
-          "taskid": 139,
+          "taskid": 133,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1209,7 +1161,7 @@
           "deadline": "2022-09-18T20:00:00"
         },
         {
-          "taskid": 140,
+          "taskid": 134,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1222,7 +1174,7 @@
       "day": "2022-09-19",
       "outputs": [
         {
-          "taskid": 141,
+          "taskid": 135,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1230,7 +1182,7 @@
           "deadline": "2022-09-19T05:00:00"
         },
         {
-          "taskid": 142,
+          "taskid": 136,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1238,7 +1190,7 @@
           "deadline": "2022-09-19T07:00:00"
         },
         {
-          "taskid": 143,
+          "taskid": 137,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -1246,7 +1198,7 @@
           "deadline": "2022-09-19T17:00:00"
         },
         {
-          "taskid": 144,
+          "taskid": 138,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1254,7 +1206,7 @@
           "deadline": "2022-09-19T18:00:00"
         },
         {
-          "taskid": 145,
+          "taskid": 139,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1262,7 +1214,7 @@
           "deadline": "2022-09-19T19:00:00"
         },
         {
-          "taskid": 146,
+          "taskid": 140,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1270,7 +1222,7 @@
           "deadline": "2022-09-19T20:00:00"
         },
         {
-          "taskid": 147,
+          "taskid": 141,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1283,7 +1235,7 @@
       "day": "2022-09-20",
       "outputs": [
         {
-          "taskid": 148,
+          "taskid": 142,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1291,7 +1243,7 @@
           "deadline": "2022-09-20T05:00:00"
         },
         {
-          "taskid": 149,
+          "taskid": 143,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1299,7 +1251,7 @@
           "deadline": "2022-09-20T07:00:00"
         },
         {
-          "taskid": 150,
+          "taskid": 144,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -1307,7 +1259,7 @@
           "deadline": "2022-09-20T17:00:00"
         },
         {
-          "taskid": 151,
+          "taskid": 145,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1315,7 +1267,7 @@
           "deadline": "2022-09-20T18:00:00"
         },
         {
-          "taskid": 152,
+          "taskid": 146,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1323,7 +1275,7 @@
           "deadline": "2022-09-20T19:00:00"
         },
         {
-          "taskid": 153,
+          "taskid": 147,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1331,7 +1283,7 @@
           "deadline": "2022-09-20T20:00:00"
         },
         {
-          "taskid": 154,
+          "taskid": 148,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1344,7 +1296,7 @@
       "day": "2022-09-21",
       "outputs": [
         {
-          "taskid": 155,
+          "taskid": 149,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1352,7 +1304,7 @@
           "deadline": "2022-09-21T05:00:00"
         },
         {
-          "taskid": 156,
+          "taskid": 150,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1360,7 +1312,7 @@
           "deadline": "2022-09-21T07:00:00"
         },
         {
-          "taskid": 157,
+          "taskid": 151,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1368,7 +1320,7 @@
           "deadline": "2022-09-21T12:00:00"
         },
         {
-          "taskid": 158,
+          "taskid": 152,
           "goalid": "3",
           "title": "piano practice",
           "duration": 2,
@@ -1376,7 +1328,7 @@
           "deadline": "2022-09-21T14:00:00"
         },
         {
-          "taskid": 159,
+          "taskid": 153,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -1384,7 +1336,7 @@
           "deadline": "2022-09-21T17:00:00"
         },
         {
-          "taskid": 160,
+          "taskid": 154,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1392,7 +1344,7 @@
           "deadline": "2022-09-21T18:00:00"
         },
         {
-          "taskid": 161,
+          "taskid": 155,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1400,7 +1352,7 @@
           "deadline": "2022-09-21T19:00:00"
         },
         {
-          "taskid": 162,
+          "taskid": 156,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1408,7 +1360,7 @@
           "deadline": "2022-09-21T20:00:00"
         },
         {
-          "taskid": 163,
+          "taskid": 157,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1421,7 +1373,7 @@
       "day": "2022-09-22",
       "outputs": [
         {
-          "taskid": 164,
+          "taskid": 158,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1429,7 +1381,7 @@
           "deadline": "2022-09-22T05:00:00"
         },
         {
-          "taskid": 165,
+          "taskid": 159,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1437,7 +1389,7 @@
           "deadline": "2022-09-22T07:00:00"
         },
         {
-          "taskid": 166,
+          "taskid": 160,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -1445,7 +1397,7 @@
           "deadline": "2022-09-22T17:00:00"
         },
         {
-          "taskid": 167,
+          "taskid": 161,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1453,7 +1405,7 @@
           "deadline": "2022-09-22T18:00:00"
         },
         {
-          "taskid": 168,
+          "taskid": 162,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1461,7 +1413,7 @@
           "deadline": "2022-09-22T19:00:00"
         },
         {
-          "taskid": 169,
+          "taskid": 163,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1469,7 +1421,7 @@
           "deadline": "2022-09-22T20:00:00"
         },
         {
-          "taskid": 170,
+          "taskid": 164,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1482,7 +1434,7 @@
       "day": "2022-09-23",
       "outputs": [
         {
-          "taskid": 171,
+          "taskid": 165,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1490,7 +1442,7 @@
           "deadline": "2022-09-23T05:00:00"
         },
         {
-          "taskid": 172,
+          "taskid": 166,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1498,7 +1450,7 @@
           "deadline": "2022-09-23T07:00:00"
         },
         {
-          "taskid": 173,
+          "taskid": 167,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -1506,7 +1458,7 @@
           "deadline": "2022-09-23T17:00:00"
         },
         {
-          "taskid": 174,
+          "taskid": 168,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1514,7 +1466,7 @@
           "deadline": "2022-09-23T18:00:00"
         },
         {
-          "taskid": 175,
+          "taskid": 169,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1522,7 +1474,7 @@
           "deadline": "2022-09-23T19:00:00"
         },
         {
-          "taskid": 176,
+          "taskid": 170,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1530,7 +1482,7 @@
           "deadline": "2022-09-23T20:00:00"
         },
         {
-          "taskid": 177,
+          "taskid": 171,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1543,7 +1495,7 @@
       "day": "2022-09-24",
       "outputs": [
         {
-          "taskid": 178,
+          "taskid": 172,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1551,7 +1503,7 @@
           "deadline": "2022-09-24T05:00:00"
         },
         {
-          "taskid": 179,
+          "taskid": 173,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1559,7 +1511,7 @@
           "deadline": "2022-09-24T07:00:00"
         },
         {
-          "taskid": 180,
+          "taskid": 174,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -1567,7 +1519,7 @@
           "deadline": "2022-09-24T17:00:00"
         },
         {
-          "taskid": 181,
+          "taskid": 175,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1575,7 +1527,7 @@
           "deadline": "2022-09-24T18:00:00"
         },
         {
-          "taskid": 182,
+          "taskid": 176,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1583,7 +1535,7 @@
           "deadline": "2022-09-24T19:00:00"
         },
         {
-          "taskid": 183,
+          "taskid": 177,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1591,7 +1543,7 @@
           "deadline": "2022-09-24T20:00:00"
         },
         {
-          "taskid": 184,
+          "taskid": 178,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1604,7 +1556,7 @@
       "day": "2022-09-25",
       "outputs": [
         {
-          "taskid": 185,
+          "taskid": 179,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1612,7 +1564,7 @@
           "deadline": "2022-09-25T05:00:00"
         },
         {
-          "taskid": 186,
+          "taskid": 180,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1620,7 +1572,7 @@
           "deadline": "2022-09-25T07:00:00"
         },
         {
-          "taskid": 187,
+          "taskid": 181,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -1628,7 +1580,7 @@
           "deadline": "2022-09-25T17:00:00"
         },
         {
-          "taskid": 188,
+          "taskid": 182,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1636,7 +1588,7 @@
           "deadline": "2022-09-25T18:00:00"
         },
         {
-          "taskid": 189,
+          "taskid": 183,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1644,7 +1596,7 @@
           "deadline": "2022-09-25T19:00:00"
         },
         {
-          "taskid": 190,
+          "taskid": 184,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1652,7 +1604,7 @@
           "deadline": "2022-09-25T20:00:00"
         },
         {
-          "taskid": 191,
+          "taskid": 185,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1665,7 +1617,7 @@
       "day": "2022-09-26",
       "outputs": [
         {
-          "taskid": 192,
+          "taskid": 186,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1673,7 +1625,7 @@
           "deadline": "2022-09-26T05:00:00"
         },
         {
-          "taskid": 193,
+          "taskid": 187,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1681,7 +1633,7 @@
           "deadline": "2022-09-26T07:00:00"
         },
         {
-          "taskid": 194,
+          "taskid": 188,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -1689,7 +1641,7 @@
           "deadline": "2022-09-26T17:00:00"
         },
         {
-          "taskid": 195,
+          "taskid": 189,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1697,7 +1649,7 @@
           "deadline": "2022-09-26T18:00:00"
         },
         {
-          "taskid": 196,
+          "taskid": 190,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1705,7 +1657,7 @@
           "deadline": "2022-09-26T19:00:00"
         },
         {
-          "taskid": 197,
+          "taskid": 191,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1713,7 +1665,7 @@
           "deadline": "2022-09-26T20:00:00"
         },
         {
-          "taskid": 198,
+          "taskid": 192,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1726,7 +1678,7 @@
       "day": "2022-09-27",
       "outputs": [
         {
-          "taskid": 199,
+          "taskid": 193,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1734,7 +1686,7 @@
           "deadline": "2022-09-27T05:00:00"
         },
         {
-          "taskid": 200,
+          "taskid": 194,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1742,7 +1694,7 @@
           "deadline": "2022-09-27T07:00:00"
         },
         {
-          "taskid": 201,
+          "taskid": 195,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -1750,7 +1702,7 @@
           "deadline": "2022-09-27T17:00:00"
         },
         {
-          "taskid": 202,
+          "taskid": 196,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1758,7 +1710,7 @@
           "deadline": "2022-09-27T18:00:00"
         },
         {
-          "taskid": 203,
+          "taskid": 197,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1766,7 +1718,7 @@
           "deadline": "2022-09-27T19:00:00"
         },
         {
-          "taskid": 204,
+          "taskid": 198,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1774,7 +1726,7 @@
           "deadline": "2022-09-27T20:00:00"
         },
         {
-          "taskid": 205,
+          "taskid": 199,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1787,7 +1739,7 @@
       "day": "2022-09-28",
       "outputs": [
         {
-          "taskid": 206,
+          "taskid": 200,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1795,7 +1747,7 @@
           "deadline": "2022-09-28T05:00:00"
         },
         {
-          "taskid": 207,
+          "taskid": 201,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1803,7 +1755,7 @@
           "deadline": "2022-09-28T07:00:00"
         },
         {
-          "taskid": 208,
+          "taskid": 202,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1811,7 +1763,7 @@
           "deadline": "2022-09-28T12:00:00"
         },
         {
-          "taskid": 209,
+          "taskid": 203,
           "goalid": "3",
           "title": "piano practice",
           "duration": 2,
@@ -1819,7 +1771,7 @@
           "deadline": "2022-09-28T14:00:00"
         },
         {
-          "taskid": 210,
+          "taskid": 204,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -1827,7 +1779,7 @@
           "deadline": "2022-09-28T17:00:00"
         },
         {
-          "taskid": 211,
+          "taskid": 205,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1835,7 +1787,7 @@
           "deadline": "2022-09-28T18:00:00"
         },
         {
-          "taskid": 212,
+          "taskid": 206,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1843,7 +1795,7 @@
           "deadline": "2022-09-28T19:00:00"
         },
         {
-          "taskid": 213,
+          "taskid": 207,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1851,7 +1803,7 @@
           "deadline": "2022-09-28T20:00:00"
         },
         {
-          "taskid": 214,
+          "taskid": 208,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1864,7 +1816,7 @@
       "day": "2022-09-29",
       "outputs": [
         {
-          "taskid": 215,
+          "taskid": 209,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1872,7 +1824,7 @@
           "deadline": "2022-09-29T05:00:00"
         },
         {
-          "taskid": 216,
+          "taskid": 210,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1880,7 +1832,7 @@
           "deadline": "2022-09-29T07:00:00"
         },
         {
-          "taskid": 217,
+          "taskid": 211,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -1888,7 +1840,7 @@
           "deadline": "2022-09-29T17:00:00"
         },
         {
-          "taskid": 218,
+          "taskid": 212,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1896,7 +1848,7 @@
           "deadline": "2022-09-29T18:00:00"
         },
         {
-          "taskid": 219,
+          "taskid": 213,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1904,7 +1856,7 @@
           "deadline": "2022-09-29T19:00:00"
         },
         {
-          "taskid": 220,
+          "taskid": 214,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1912,7 +1864,7 @@
           "deadline": "2022-09-29T20:00:00"
         },
         {
-          "taskid": 221,
+          "taskid": 215,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1925,7 +1877,7 @@
       "day": "2022-09-30",
       "outputs": [
         {
-          "taskid": 222,
+          "taskid": 216,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1933,7 +1885,7 @@
           "deadline": "2022-09-30T05:00:00"
         },
         {
-          "taskid": 223,
+          "taskid": 217,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1941,7 +1893,7 @@
           "deadline": "2022-09-30T07:00:00"
         },
         {
-          "taskid": 224,
+          "taskid": 218,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -1949,7 +1901,7 @@
           "deadline": "2022-09-30T17:00:00"
         },
         {
-          "taskid": 225,
+          "taskid": 219,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1957,7 +1909,7 @@
           "deadline": "2022-09-30T18:00:00"
         },
         {
-          "taskid": 226,
+          "taskid": 220,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1965,7 +1917,7 @@
           "deadline": "2022-09-30T19:00:00"
         },
         {
-          "taskid": 227,
+          "taskid": 221,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1973,7 +1925,7 @@
           "deadline": "2022-09-30T20:00:00"
         },
         {
-          "taskid": 228,
+          "taskid": 222,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1986,7 +1938,56 @@
   "impossible": [
     {
       "day": "2022-09-01",
-      "outputs": []
+      "outputs": [
+        {
+          "taskid": 223,
+          "goalid": "1",
+          "title": "walk",
+          "duration": 1,
+          "start": "2022-09-01T00:00:00",
+          "deadline": "2022-10-01T00:00:00"
+        },
+        {
+          "taskid": 224,
+          "goalid": "1",
+          "title": "walk",
+          "duration": 1,
+          "start": "2022-09-01T00:00:00",
+          "deadline": "2022-10-01T00:00:00"
+        },
+        {
+          "taskid": 225,
+          "goalid": "1",
+          "title": "walk",
+          "duration": 1,
+          "start": "2022-09-01T00:00:00",
+          "deadline": "2022-10-01T00:00:00"
+        },
+        {
+          "taskid": 226,
+          "goalid": "1",
+          "title": "walk",
+          "duration": 1,
+          "start": "2022-09-01T00:00:00",
+          "deadline": "2022-10-01T00:00:00"
+        },
+        {
+          "taskid": 227,
+          "goalid": "1",
+          "title": "walk",
+          "duration": 1,
+          "start": "2022-09-01T00:00:00",
+          "deadline": "2022-10-01T00:00:00"
+        },
+        {
+          "taskid": 228,
+          "goalid": "1",
+          "title": "walk",
+          "duration": 1,
+          "start": "2022-09-01T00:00:00",
+          "deadline": "2022-10-01T00:00:00"
+        }
+      ]
     },
     {
       "day": "2022-09-02",

--- a/tests/jsons/realistic-weekend-repetition-1/actual_output.json
+++ b/tests/jsons/realistic-weekend-repetition-1/actual_output.json
@@ -31,36 +31,20 @@
           "taskid": 3,
           "goalid": "1",
           "title": "work",
-          "duration": 2,
+          "duration": 6,
           "start": "2022-09-01T08:00:00",
-          "deadline": "2022-09-01T10:00:00"
-        },
-        {
-          "taskid": 4,
-          "goalid": "4",
-          "title": "church",
-          "duration": 2,
-          "start": "2022-09-01T10:00:00",
-          "deadline": "2022-09-01T12:00:00"
-        },
-        {
-          "taskid": 5,
-          "goalid": "free",
-          "title": "free",
-          "duration": 2,
-          "start": "2022-09-01T12:00:00",
           "deadline": "2022-09-01T14:00:00"
         },
         {
-          "taskid": 6,
-          "goalid": "1",
-          "title": "work",
+          "taskid": 4,
+          "goalid": "free",
+          "title": "free",
           "duration": 3,
           "start": "2022-09-01T14:00:00",
           "deadline": "2022-09-01T17:00:00"
         },
         {
-          "taskid": 7,
+          "taskid": 5,
           "goalid": "3",
           "title": "walk",
           "duration": 1,
@@ -68,7 +52,7 @@
           "deadline": "2022-09-01T18:00:00"
         },
         {
-          "taskid": 8,
+          "taskid": 6,
           "goalid": "free",
           "title": "free",
           "duration": 6,
@@ -81,27 +65,11 @@
       "day": "2022-09-02",
       "outputs": [
         {
-          "taskid": 9,
+          "taskid": 7,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2022-09-02T00:00:00",
-          "deadline": "2022-09-02T08:00:00"
-        },
-        {
-          "taskid": 10,
-          "goalid": "1",
-          "title": "work",
-          "duration": 1,
-          "start": "2022-09-02T08:00:00",
-          "deadline": "2022-09-02T09:00:00"
-        },
-        {
-          "taskid": 11,
-          "goalid": "free",
-          "title": "free",
-          "duration": 15,
-          "start": "2022-09-02T09:00:00",
           "deadline": "2022-09-03T00:00:00"
         }
       ]
@@ -110,7 +78,7 @@
       "day": "2022-09-03",
       "outputs": [
         {
-          "taskid": 12,
+          "taskid": 8,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -118,7 +86,7 @@
           "deadline": "2022-09-03T05:00:00"
         },
         {
-          "taskid": 13,
+          "taskid": 9,
           "goalid": "2",
           "title": "gym",
           "duration": 2,
@@ -126,7 +94,7 @@
           "deadline": "2022-09-03T07:00:00"
         },
         {
-          "taskid": 14,
+          "taskid": 10,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -134,31 +102,23 @@
           "deadline": "2022-09-03T08:00:00"
         },
         {
-          "taskid": 15,
+          "taskid": 11,
           "goalid": "1",
           "title": "work",
-          "duration": 2,
+          "duration": 6,
           "start": "2022-09-03T08:00:00",
-          "deadline": "2022-09-03T10:00:00"
-        },
-        {
-          "taskid": 16,
-          "goalid": "free",
-          "title": "free",
-          "duration": 4,
-          "start": "2022-09-03T10:00:00",
           "deadline": "2022-09-03T14:00:00"
         },
         {
-          "taskid": 17,
-          "goalid": "1",
-          "title": "work",
+          "taskid": 12,
+          "goalid": "free",
+          "title": "free",
           "duration": 3,
           "start": "2022-09-03T14:00:00",
           "deadline": "2022-09-03T17:00:00"
         },
         {
-          "taskid": 18,
+          "taskid": 13,
           "goalid": "3",
           "title": "walk",
           "duration": 1,
@@ -166,7 +126,7 @@
           "deadline": "2022-09-03T18:00:00"
         },
         {
-          "taskid": 19,
+          "taskid": 14,
           "goalid": "free",
           "title": "free",
           "duration": 6,
@@ -179,39 +139,15 @@
       "day": "2022-09-04",
       "outputs": [
         {
-          "taskid": 20,
+          "taskid": 15,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 11,
           "start": "2022-09-04T00:00:00",
-          "deadline": "2022-09-04T08:00:00"
-        },
-        {
-          "taskid": 21,
-          "goalid": "1",
-          "title": "work",
-          "duration": 1,
-          "start": "2022-09-04T08:00:00",
-          "deadline": "2022-09-04T09:00:00"
-        },
-        {
-          "taskid": 22,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-09-04T09:00:00",
-          "deadline": "2022-09-04T10:00:00"
-        },
-        {
-          "taskid": 23,
-          "goalid": "4",
-          "title": "church",
-          "duration": 1,
-          "start": "2022-09-04T10:00:00",
           "deadline": "2022-09-04T11:00:00"
         },
         {
-          "taskid": 24,
+          "taskid": 16,
           "goalid": "5",
           "title": "dentist",
           "duration": 1,
@@ -219,19 +155,19 @@
           "deadline": "2022-09-04T12:00:00"
         },
         {
-          "taskid": 25,
+          "taskid": 17,
           "goalid": "4",
           "title": "church",
-          "duration": 1,
+          "duration": 2,
           "start": "2022-09-04T12:00:00",
-          "deadline": "2022-09-04T13:00:00"
+          "deadline": "2022-09-04T14:00:00"
         },
         {
-          "taskid": 26,
+          "taskid": 18,
           "goalid": "free",
           "title": "free",
-          "duration": 11,
-          "start": "2022-09-04T13:00:00",
+          "duration": 10,
+          "start": "2022-09-04T14:00:00",
           "deadline": "2022-09-05T00:00:00"
         }
       ]
@@ -240,7 +176,7 @@
       "day": "2022-09-05",
       "outputs": [
         {
-          "taskid": 27,
+          "taskid": 19,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -253,7 +189,7 @@
       "day": "2022-09-06",
       "outputs": [
         {
-          "taskid": 28,
+          "taskid": 20,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -266,7 +202,7 @@
       "day": "2022-09-07",
       "outputs": [
         {
-          "taskid": 29,
+          "taskid": 21,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -279,7 +215,7 @@
       "day": "2022-09-08",
       "outputs": [
         {
-          "taskid": 30,
+          "taskid": 22,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -292,7 +228,7 @@
       "day": "2022-09-09",
       "outputs": [
         {
-          "taskid": 31,
+          "taskid": 23,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -305,7 +241,7 @@
       "day": "2022-09-10",
       "outputs": [
         {
-          "taskid": 32,
+          "taskid": 24,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -313,7 +249,7 @@
           "deadline": "2022-09-10T05:00:00"
         },
         {
-          "taskid": 33,
+          "taskid": 25,
           "goalid": "2",
           "title": "gym",
           "duration": 2,
@@ -321,7 +257,7 @@
           "deadline": "2022-09-10T07:00:00"
         },
         {
-          "taskid": 34,
+          "taskid": 26,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -329,31 +265,23 @@
           "deadline": "2022-09-10T08:00:00"
         },
         {
-          "taskid": 35,
+          "taskid": 27,
           "goalid": "1",
           "title": "work",
-          "duration": 2,
+          "duration": 6,
           "start": "2022-09-10T08:00:00",
-          "deadline": "2022-09-10T10:00:00"
-        },
-        {
-          "taskid": 36,
-          "goalid": "free",
-          "title": "free",
-          "duration": 4,
-          "start": "2022-09-10T10:00:00",
           "deadline": "2022-09-10T14:00:00"
         },
         {
-          "taskid": 37,
-          "goalid": "1",
-          "title": "work",
+          "taskid": 28,
+          "goalid": "free",
+          "title": "free",
           "duration": 3,
           "start": "2022-09-10T14:00:00",
           "deadline": "2022-09-10T17:00:00"
         },
         {
-          "taskid": 38,
+          "taskid": 29,
           "goalid": "3",
           "title": "walk",
           "duration": 1,
@@ -361,7 +289,7 @@
           "deadline": "2022-09-10T18:00:00"
         },
         {
-          "taskid": 39,
+          "taskid": 30,
           "goalid": "free",
           "title": "free",
           "duration": 6,
@@ -374,43 +302,11 @@
       "day": "2022-09-11",
       "outputs": [
         {
-          "taskid": 40,
+          "taskid": 31,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2022-09-11T00:00:00",
-          "deadline": "2022-09-11T08:00:00"
-        },
-        {
-          "taskid": 41,
-          "goalid": "1",
-          "title": "work",
-          "duration": 1,
-          "start": "2022-09-11T08:00:00",
-          "deadline": "2022-09-11T09:00:00"
-        },
-        {
-          "taskid": 42,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-09-11T09:00:00",
-          "deadline": "2022-09-11T10:00:00"
-        },
-        {
-          "taskid": 43,
-          "goalid": "4",
-          "title": "church",
-          "duration": 2,
-          "start": "2022-09-11T10:00:00",
-          "deadline": "2022-09-11T12:00:00"
-        },
-        {
-          "taskid": 44,
-          "goalid": "free",
-          "title": "free",
-          "duration": 12,
-          "start": "2022-09-11T12:00:00",
           "deadline": "2022-09-12T00:00:00"
         }
       ]
@@ -419,11 +315,27 @@
       "day": "2022-09-12",
       "outputs": [
         {
-          "taskid": 45,
+          "taskid": 32,
           "goalid": "free",
           "title": "free",
-          "duration": 24,
+          "duration": 10,
           "start": "2022-09-12T00:00:00",
+          "deadline": "2022-09-12T10:00:00"
+        },
+        {
+          "taskid": 33,
+          "goalid": "4",
+          "title": "church",
+          "duration": 2,
+          "start": "2022-09-12T10:00:00",
+          "deadline": "2022-09-12T12:00:00"
+        },
+        {
+          "taskid": 34,
+          "goalid": "free",
+          "title": "free",
+          "duration": 12,
+          "start": "2022-09-12T12:00:00",
           "deadline": "2022-09-13T00:00:00"
         }
       ]
@@ -432,7 +344,7 @@
       "day": "2022-09-13",
       "outputs": [
         {
-          "taskid": 46,
+          "taskid": 35,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -445,7 +357,7 @@
       "day": "2022-09-14",
       "outputs": [
         {
-          "taskid": 47,
+          "taskid": 36,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -458,7 +370,7 @@
       "day": "2022-09-15",
       "outputs": [
         {
-          "taskid": 48,
+          "taskid": 37,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -471,7 +383,7 @@
       "day": "2022-09-16",
       "outputs": [
         {
-          "taskid": 49,
+          "taskid": 38,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -484,7 +396,7 @@
       "day": "2022-09-17",
       "outputs": [
         {
-          "taskid": 50,
+          "taskid": 39,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -492,7 +404,7 @@
           "deadline": "2022-09-17T05:00:00"
         },
         {
-          "taskid": 51,
+          "taskid": 40,
           "goalid": "2",
           "title": "gym",
           "duration": 2,
@@ -500,7 +412,7 @@
           "deadline": "2022-09-17T07:00:00"
         },
         {
-          "taskid": 52,
+          "taskid": 41,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -508,31 +420,23 @@
           "deadline": "2022-09-17T08:00:00"
         },
         {
-          "taskid": 53,
+          "taskid": 42,
           "goalid": "1",
           "title": "work",
-          "duration": 2,
+          "duration": 6,
           "start": "2022-09-17T08:00:00",
-          "deadline": "2022-09-17T10:00:00"
-        },
-        {
-          "taskid": 54,
-          "goalid": "free",
-          "title": "free",
-          "duration": 4,
-          "start": "2022-09-17T10:00:00",
           "deadline": "2022-09-17T14:00:00"
         },
         {
-          "taskid": 55,
-          "goalid": "1",
-          "title": "work",
+          "taskid": 43,
+          "goalid": "free",
+          "title": "free",
           "duration": 3,
           "start": "2022-09-17T14:00:00",
           "deadline": "2022-09-17T17:00:00"
         },
         {
-          "taskid": 56,
+          "taskid": 44,
           "goalid": "3",
           "title": "walk",
           "duration": 1,
@@ -540,7 +444,7 @@
           "deadline": "2022-09-17T18:00:00"
         },
         {
-          "taskid": 57,
+          "taskid": 45,
           "goalid": "free",
           "title": "free",
           "duration": 6,
@@ -553,43 +457,11 @@
       "day": "2022-09-18",
       "outputs": [
         {
-          "taskid": 58,
+          "taskid": 46,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2022-09-18T00:00:00",
-          "deadline": "2022-09-18T08:00:00"
-        },
-        {
-          "taskid": 59,
-          "goalid": "1",
-          "title": "work",
-          "duration": 1,
-          "start": "2022-09-18T08:00:00",
-          "deadline": "2022-09-18T09:00:00"
-        },
-        {
-          "taskid": 60,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-09-18T09:00:00",
-          "deadline": "2022-09-18T10:00:00"
-        },
-        {
-          "taskid": 61,
-          "goalid": "4",
-          "title": "church",
-          "duration": 2,
-          "start": "2022-09-18T10:00:00",
-          "deadline": "2022-09-18T12:00:00"
-        },
-        {
-          "taskid": 62,
-          "goalid": "free",
-          "title": "free",
-          "duration": 12,
-          "start": "2022-09-18T12:00:00",
           "deadline": "2022-09-19T00:00:00"
         }
       ]
@@ -598,11 +470,27 @@
       "day": "2022-09-19",
       "outputs": [
         {
-          "taskid": 63,
+          "taskid": 47,
           "goalid": "free",
           "title": "free",
-          "duration": 24,
+          "duration": 10,
           "start": "2022-09-19T00:00:00",
+          "deadline": "2022-09-19T10:00:00"
+        },
+        {
+          "taskid": 48,
+          "goalid": "4",
+          "title": "church",
+          "duration": 2,
+          "start": "2022-09-19T10:00:00",
+          "deadline": "2022-09-19T12:00:00"
+        },
+        {
+          "taskid": 49,
+          "goalid": "free",
+          "title": "free",
+          "duration": 12,
+          "start": "2022-09-19T12:00:00",
           "deadline": "2022-09-20T00:00:00"
         }
       ]
@@ -611,7 +499,7 @@
       "day": "2022-09-20",
       "outputs": [
         {
-          "taskid": 64,
+          "taskid": 50,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -624,7 +512,7 @@
       "day": "2022-09-21",
       "outputs": [
         {
-          "taskid": 65,
+          "taskid": 51,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -637,7 +525,7 @@
       "day": "2022-09-22",
       "outputs": [
         {
-          "taskid": 66,
+          "taskid": 52,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -650,7 +538,7 @@
       "day": "2022-09-23",
       "outputs": [
         {
-          "taskid": 67,
+          "taskid": 53,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -663,7 +551,7 @@
       "day": "2022-09-24",
       "outputs": [
         {
-          "taskid": 68,
+          "taskid": 54,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -671,7 +559,7 @@
           "deadline": "2022-09-24T05:00:00"
         },
         {
-          "taskid": 69,
+          "taskid": 55,
           "goalid": "2",
           "title": "gym",
           "duration": 2,
@@ -679,7 +567,7 @@
           "deadline": "2022-09-24T07:00:00"
         },
         {
-          "taskid": 70,
+          "taskid": 56,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -687,31 +575,23 @@
           "deadline": "2022-09-24T08:00:00"
         },
         {
-          "taskid": 71,
+          "taskid": 57,
           "goalid": "1",
           "title": "work",
-          "duration": 2,
+          "duration": 6,
           "start": "2022-09-24T08:00:00",
-          "deadline": "2022-09-24T10:00:00"
-        },
-        {
-          "taskid": 72,
-          "goalid": "free",
-          "title": "free",
-          "duration": 4,
-          "start": "2022-09-24T10:00:00",
           "deadline": "2022-09-24T14:00:00"
         },
         {
-          "taskid": 73,
-          "goalid": "1",
-          "title": "work",
+          "taskid": 58,
+          "goalid": "free",
+          "title": "free",
           "duration": 3,
           "start": "2022-09-24T14:00:00",
           "deadline": "2022-09-24T17:00:00"
         },
         {
-          "taskid": 74,
+          "taskid": 59,
           "goalid": "3",
           "title": "walk",
           "duration": 1,
@@ -719,7 +599,7 @@
           "deadline": "2022-09-24T18:00:00"
         },
         {
-          "taskid": 75,
+          "taskid": 60,
           "goalid": "free",
           "title": "free",
           "duration": 6,
@@ -732,43 +612,11 @@
       "day": "2022-09-25",
       "outputs": [
         {
-          "taskid": 76,
+          "taskid": 61,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
+          "duration": 24,
           "start": "2022-09-25T00:00:00",
-          "deadline": "2022-09-25T08:00:00"
-        },
-        {
-          "taskid": 77,
-          "goalid": "1",
-          "title": "work",
-          "duration": 1,
-          "start": "2022-09-25T08:00:00",
-          "deadline": "2022-09-25T09:00:00"
-        },
-        {
-          "taskid": 78,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-09-25T09:00:00",
-          "deadline": "2022-09-25T10:00:00"
-        },
-        {
-          "taskid": 79,
-          "goalid": "4",
-          "title": "church",
-          "duration": 2,
-          "start": "2022-09-25T10:00:00",
-          "deadline": "2022-09-25T12:00:00"
-        },
-        {
-          "taskid": 80,
-          "goalid": "free",
-          "title": "free",
-          "duration": 12,
-          "start": "2022-09-25T12:00:00",
           "deadline": "2022-09-26T00:00:00"
         }
       ]
@@ -777,11 +625,27 @@
       "day": "2022-09-26",
       "outputs": [
         {
-          "taskid": 81,
+          "taskid": 62,
           "goalid": "free",
           "title": "free",
-          "duration": 24,
+          "duration": 10,
           "start": "2022-09-26T00:00:00",
+          "deadline": "2022-09-26T10:00:00"
+        },
+        {
+          "taskid": 63,
+          "goalid": "4",
+          "title": "church",
+          "duration": 2,
+          "start": "2022-09-26T10:00:00",
+          "deadline": "2022-09-26T12:00:00"
+        },
+        {
+          "taskid": 64,
+          "goalid": "free",
+          "title": "free",
+          "duration": 12,
+          "start": "2022-09-26T12:00:00",
           "deadline": "2022-09-27T00:00:00"
         }
       ]
@@ -790,7 +654,7 @@
       "day": "2022-09-27",
       "outputs": [
         {
-          "taskid": 82,
+          "taskid": 65,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -803,7 +667,7 @@
       "day": "2022-09-28",
       "outputs": [
         {
-          "taskid": 83,
+          "taskid": 66,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -816,7 +680,7 @@
       "day": "2022-09-29",
       "outputs": [
         {
-          "taskid": 84,
+          "taskid": 67,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -829,7 +693,7 @@
       "day": "2022-09-30",
       "outputs": [
         {
-          "taskid": 85,
+          "taskid": 68,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -842,7 +706,16 @@
   "impossible": [
     {
       "day": "2022-09-01",
-      "outputs": []
+      "outputs": [
+        {
+          "taskid": 69,
+          "goalid": "4",
+          "title": "church",
+          "duration": 2,
+          "start": "2022-09-01T00:00:00",
+          "deadline": "2022-10-01T00:00:00"
+        }
+      ]
     },
     {
       "day": "2022-09-02",

--- a/tests/jsons/show-sleep/actual_output.json
+++ b/tests/jsons/show-sleep/actual_output.json
@@ -34,18 +34,10 @@
         },
         {
           "taskid": 3,
-          "goalid": "1429f3f4-0315-4e72-a7e4-19b05b38884c",
-          "title": "Project A",
-          "duration": 8,
-          "start": "2023-03-02T08:00:00",
-          "deadline": "2023-03-02T16:00:00"
-        },
-        {
-          "taskid": 4,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
-          "start": "2023-03-02T16:00:00",
+          "duration": 16,
+          "start": "2023-03-02T08:00:00",
           "deadline": "2023-03-03T00:00:00"
         }
       ]
@@ -54,7 +46,7 @@
       "day": "2023-03-03",
       "outputs": [
         {
-          "taskid": 5,
+          "taskid": 4,
           "goalid": "09e198d9-613f-4f17-a23c-4e38d3c5d529",
           "title": "Sleep sleepingcrescent_moon",
           "duration": 8,
@@ -62,19 +54,11 @@
           "deadline": "2023-03-03T08:00:00"
         },
         {
-          "taskid": 6,
-          "goalid": "1429f3f4-0315-4e72-a7e4-19b05b38884c",
-          "title": "Project A",
-          "duration": 8,
-          "start": "2023-03-03T08:00:00",
-          "deadline": "2023-03-03T16:00:00"
-        },
-        {
-          "taskid": 7,
+          "taskid": 5,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
-          "start": "2023-03-03T16:00:00",
+          "duration": 16,
+          "start": "2023-03-03T08:00:00",
           "deadline": "2023-03-04T00:00:00"
         }
       ]
@@ -83,7 +67,7 @@
       "day": "2023-03-04",
       "outputs": [
         {
-          "taskid": 8,
+          "taskid": 6,
           "goalid": "09e198d9-613f-4f17-a23c-4e38d3c5d529",
           "title": "Sleep sleepingcrescent_moon",
           "duration": 8,
@@ -91,27 +75,11 @@
           "deadline": "2023-03-04T08:00:00"
         },
         {
-          "taskid": 9,
-          "goalid": "1429f3f4-0315-4e72-a7e4-19b05b38884c",
-          "title": "Project A",
-          "duration": 4,
-          "start": "2023-03-04T08:00:00",
-          "deadline": "2023-03-04T12:00:00"
-        },
-        {
-          "taskid": 10,
-          "goalid": "d7fddb3d-2c3b-4a50-aadd-739d60a96378",
-          "title": "Work",
-          "duration": 4,
-          "start": "2023-03-04T12:00:00",
-          "deadline": "2023-03-04T16:00:00"
-        },
-        {
-          "taskid": 11,
+          "taskid": 7,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
-          "start": "2023-03-04T16:00:00",
+          "duration": 16,
+          "start": "2023-03-04T08:00:00",
           "deadline": "2023-03-05T00:00:00"
         }
       ]
@@ -120,7 +88,7 @@
       "day": "2023-03-05",
       "outputs": [
         {
-          "taskid": 12,
+          "taskid": 8,
           "goalid": "09e198d9-613f-4f17-a23c-4e38d3c5d529",
           "title": "Sleep sleepingcrescent_moon",
           "duration": 8,
@@ -128,19 +96,11 @@
           "deadline": "2023-03-05T08:00:00"
         },
         {
-          "taskid": 13,
-          "goalid": "d7fddb3d-2c3b-4a50-aadd-739d60a96378",
-          "title": "Work",
-          "duration": 8,
-          "start": "2023-03-05T08:00:00",
-          "deadline": "2023-03-05T16:00:00"
-        },
-        {
-          "taskid": 14,
+          "taskid": 9,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
-          "start": "2023-03-05T16:00:00",
+          "duration": 16,
+          "start": "2023-03-05T08:00:00",
           "deadline": "2023-03-06T00:00:00"
         }
       ]
@@ -149,7 +109,7 @@
       "day": "2023-03-06",
       "outputs": [
         {
-          "taskid": 15,
+          "taskid": 10,
           "goalid": "09e198d9-613f-4f17-a23c-4e38d3c5d529",
           "title": "Sleep sleepingcrescent_moon",
           "duration": 8,
@@ -157,19 +117,11 @@
           "deadline": "2023-03-06T08:00:00"
         },
         {
-          "taskid": 16,
-          "goalid": "d7fddb3d-2c3b-4a50-aadd-739d60a96378",
-          "title": "Work",
-          "duration": 6,
-          "start": "2023-03-06T08:00:00",
-          "deadline": "2023-03-06T14:00:00"
-        },
-        {
-          "taskid": 17,
+          "taskid": 11,
           "goalid": "free",
           "title": "free",
-          "duration": 10,
-          "start": "2023-03-06T14:00:00",
+          "duration": 16,
+          "start": "2023-03-06T08:00:00",
           "deadline": "2023-03-07T00:00:00"
         }
       ]
@@ -178,7 +130,7 @@
       "day": "2023-03-07",
       "outputs": [
         {
-          "taskid": 18,
+          "taskid": 12,
           "goalid": "09e198d9-613f-4f17-a23c-4e38d3c5d529",
           "title": "Sleep sleepingcrescent_moon",
           "duration": 8,
@@ -186,7 +138,7 @@
           "deadline": "2023-03-07T08:00:00"
         },
         {
-          "taskid": 19,
+          "taskid": 13,
           "goalid": "free",
           "title": "free",
           "duration": 16,
@@ -199,7 +151,24 @@
   "impossible": [
     {
       "day": "2023-03-01",
-      "outputs": []
+      "outputs": [
+        {
+          "taskid": 14,
+          "goalid": "1429f3f4-0315-4e72-a7e4-19b05b38884c",
+          "title": "Project A",
+          "duration": 20,
+          "start": "2023-03-01T00:00:00",
+          "deadline": "2023-03-08T00:00:00"
+        },
+        {
+          "taskid": 15,
+          "goalid": "d7fddb3d-2c3b-4a50-aadd-739d60a96378",
+          "title": "Work",
+          "duration": 38,
+          "start": "2023-03-01T00:00:00",
+          "deadline": "2023-03-08T00:00:00"
+        }
+      ]
     },
     {
       "day": "2023-03-02",

--- a/tests/jsons/singleday-manygoals-1/actual_output.json
+++ b/tests/jsons/singleday-manygoals-1/actual_output.json
@@ -93,18 +93,26 @@
         },
         {
           "taskid": 11,
-          "goalid": "6",
-          "title": "read",
+          "goalid": "free",
+          "title": "free",
           "duration": 1,
           "start": "2022-01-01T20:00:00",
           "deadline": "2022-01-01T21:00:00"
         },
         {
           "taskid": 12,
+          "goalid": "6",
+          "title": "read",
+          "duration": 1,
+          "start": "2022-01-01T21:00:00",
+          "deadline": "2022-01-01T22:00:00"
+        },
+        {
+          "taskid": 13,
           "goalid": "free",
           "title": "free",
-          "duration": 3,
-          "start": "2022-01-01T21:00:00",
+          "duration": 2,
+          "start": "2022-01-01T22:00:00",
           "deadline": "2022-01-02T00:00:00"
         }
       ]

--- a/tests/jsons/sleep-1/actual_output.json
+++ b/tests/jsons/sleep-1/actual_output.json
@@ -5,26 +5,10 @@
       "outputs": [
         {
           "taskid": 0,
-          "goalid": "1",
-          "title": "sleep",
-          "duration": 6,
-          "start": "2022-01-01T00:00:00",
-          "deadline": "2022-01-01T06:00:00"
-        },
-        {
-          "taskid": 1,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-01-01T06:00:00",
-          "deadline": "2022-01-01T22:00:00"
-        },
-        {
-          "taskid": 2,
-          "goalid": "1",
-          "title": "sleep",
-          "duration": 2,
-          "start": "2022-01-01T22:00:00",
+          "duration": 24,
+          "start": "2022-01-01T00:00:00",
           "deadline": "2022-01-02T00:00:00"
         }
       ]
@@ -33,27 +17,11 @@
       "day": "2022-01-02",
       "outputs": [
         {
-          "taskid": 3,
-          "goalid": "1",
-          "title": "sleep",
-          "duration": 6,
-          "start": "2022-01-02T00:00:00",
-          "deadline": "2022-01-02T06:00:00"
-        },
-        {
-          "taskid": 4,
+          "taskid": 1,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-01-02T06:00:00",
-          "deadline": "2022-01-02T22:00:00"
-        },
-        {
-          "taskid": 5,
-          "goalid": "1",
-          "title": "sleep",
-          "duration": 2,
-          "start": "2022-01-02T22:00:00",
+          "duration": 24,
+          "start": "2022-01-02T00:00:00",
           "deadline": "2022-01-03T00:00:00"
         }
       ]
@@ -62,27 +30,11 @@
       "day": "2022-01-03",
       "outputs": [
         {
-          "taskid": 6,
-          "goalid": "1",
-          "title": "sleep",
-          "duration": 6,
-          "start": "2022-01-03T00:00:00",
-          "deadline": "2022-01-03T06:00:00"
-        },
-        {
-          "taskid": 7,
+          "taskid": 2,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-01-03T06:00:00",
-          "deadline": "2022-01-03T22:00:00"
-        },
-        {
-          "taskid": 8,
-          "goalid": "1",
-          "title": "sleep",
-          "duration": 2,
-          "start": "2022-01-03T22:00:00",
+          "duration": 24,
+          "start": "2022-01-03T00:00:00",
           "deadline": "2022-01-04T00:00:00"
         }
       ]
@@ -91,27 +43,11 @@
       "day": "2022-01-04",
       "outputs": [
         {
-          "taskid": 9,
-          "goalid": "1",
-          "title": "sleep",
-          "duration": 6,
-          "start": "2022-01-04T00:00:00",
-          "deadline": "2022-01-04T06:00:00"
-        },
-        {
-          "taskid": 10,
+          "taskid": 3,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-01-04T06:00:00",
-          "deadline": "2022-01-04T22:00:00"
-        },
-        {
-          "taskid": 11,
-          "goalid": "1",
-          "title": "sleep",
-          "duration": 2,
-          "start": "2022-01-04T22:00:00",
+          "duration": 24,
+          "start": "2022-01-04T00:00:00",
           "deadline": "2022-01-05T00:00:00"
         }
       ]
@@ -120,27 +56,11 @@
       "day": "2022-01-05",
       "outputs": [
         {
-          "taskid": 12,
-          "goalid": "1",
-          "title": "sleep",
-          "duration": 6,
-          "start": "2022-01-05T00:00:00",
-          "deadline": "2022-01-05T06:00:00"
-        },
-        {
-          "taskid": 13,
+          "taskid": 4,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-01-05T06:00:00",
-          "deadline": "2022-01-05T22:00:00"
-        },
-        {
-          "taskid": 14,
-          "goalid": "1",
-          "title": "sleep",
-          "duration": 2,
-          "start": "2022-01-05T22:00:00",
+          "duration": 24,
+          "start": "2022-01-05T00:00:00",
           "deadline": "2022-01-06T00:00:00"
         }
       ]
@@ -149,27 +69,11 @@
       "day": "2022-01-06",
       "outputs": [
         {
-          "taskid": 15,
-          "goalid": "1",
-          "title": "sleep",
-          "duration": 6,
-          "start": "2022-01-06T00:00:00",
-          "deadline": "2022-01-06T06:00:00"
-        },
-        {
-          "taskid": 16,
+          "taskid": 5,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-01-06T06:00:00",
-          "deadline": "2022-01-06T22:00:00"
-        },
-        {
-          "taskid": 17,
-          "goalid": "1",
-          "title": "sleep",
-          "duration": 2,
-          "start": "2022-01-06T22:00:00",
+          "duration": 24,
+          "start": "2022-01-06T00:00:00",
           "deadline": "2022-01-07T00:00:00"
         }
       ]
@@ -178,27 +82,11 @@
       "day": "2022-01-07",
       "outputs": [
         {
-          "taskid": 18,
-          "goalid": "1",
-          "title": "sleep",
-          "duration": 6,
-          "start": "2022-01-07T00:00:00",
-          "deadline": "2022-01-07T06:00:00"
-        },
-        {
-          "taskid": 19,
+          "taskid": 6,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-01-07T06:00:00",
-          "deadline": "2022-01-07T22:00:00"
-        },
-        {
-          "taskid": 20,
-          "goalid": "1",
-          "title": "sleep",
-          "duration": 2,
-          "start": "2022-01-07T22:00:00",
+          "duration": 24,
+          "start": "2022-01-07T00:00:00",
           "deadline": "2022-01-08T00:00:00"
         }
       ]
@@ -207,27 +95,11 @@
       "day": "2022-01-08",
       "outputs": [
         {
-          "taskid": 21,
-          "goalid": "1",
-          "title": "sleep",
-          "duration": 6,
-          "start": "2022-01-08T00:00:00",
-          "deadline": "2022-01-08T06:00:00"
-        },
-        {
-          "taskid": 22,
+          "taskid": 7,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-01-08T06:00:00",
-          "deadline": "2022-01-08T22:00:00"
-        },
-        {
-          "taskid": 23,
-          "goalid": "1",
-          "title": "sleep",
-          "duration": 2,
-          "start": "2022-01-08T22:00:00",
+          "duration": 24,
+          "start": "2022-01-08T00:00:00",
           "deadline": "2022-01-09T00:00:00"
         }
       ]
@@ -238,10 +110,74 @@
       "day": "2022-01-01",
       "outputs": [
         {
-          "taskid": 24,
+          "taskid": 8,
           "goalid": "1",
           "title": "sleep",
-          "duration": 2,
+          "duration": 8,
+          "start": "2022-01-01T00:00:00",
+          "deadline": "2022-01-09T00:00:00"
+        },
+        {
+          "taskid": 9,
+          "goalid": "1",
+          "title": "sleep",
+          "duration": 8,
+          "start": "2022-01-01T00:00:00",
+          "deadline": "2022-01-09T00:00:00"
+        },
+        {
+          "taskid": 10,
+          "goalid": "1",
+          "title": "sleep",
+          "duration": 8,
+          "start": "2022-01-01T00:00:00",
+          "deadline": "2022-01-09T00:00:00"
+        },
+        {
+          "taskid": 11,
+          "goalid": "1",
+          "title": "sleep",
+          "duration": 8,
+          "start": "2022-01-01T00:00:00",
+          "deadline": "2022-01-09T00:00:00"
+        },
+        {
+          "taskid": 12,
+          "goalid": "1",
+          "title": "sleep",
+          "duration": 8,
+          "start": "2022-01-01T00:00:00",
+          "deadline": "2022-01-09T00:00:00"
+        },
+        {
+          "taskid": 13,
+          "goalid": "1",
+          "title": "sleep",
+          "duration": 8,
+          "start": "2022-01-01T00:00:00",
+          "deadline": "2022-01-09T00:00:00"
+        },
+        {
+          "taskid": 14,
+          "goalid": "1",
+          "title": "sleep",
+          "duration": 8,
+          "start": "2022-01-01T00:00:00",
+          "deadline": "2022-01-09T00:00:00"
+        },
+        {
+          "taskid": 15,
+          "goalid": "1",
+          "title": "sleep",
+          "duration": 8,
+          "start": "2022-01-01T00:00:00",
+          "deadline": "2022-01-09T00:00:00"
+        },
+        {
+          "taskid": 16,
+          "goalid": "1",
+          "title": "sleep",
+          "duration": 8,
           "start": "2022-01-01T00:00:00",
           "deadline": "2022-01-09T00:00:00"
         }

--- a/tests/jsons/slot-reduced-1/actual_output.json
+++ b/tests/jsons/slot-reduced-1/actual_output.json
@@ -7,20 +7,12 @@
           "taskid": 0,
           "goalid": "free",
           "title": "free",
-          "duration": 12,
+          "duration": 16,
           "start": "2022-11-07T00:00:00",
-          "deadline": "2022-11-07T12:00:00"
-        },
-        {
-          "taskid": 1,
-          "goalid": "1",
-          "title": "work",
-          "duration": 4,
-          "start": "2022-11-07T12:00:00",
           "deadline": "2022-11-07T16:00:00"
         },
         {
-          "taskid": 2,
+          "taskid": 1,
           "goalid": "2",
           "title": "cook pasta",
           "duration": 2,
@@ -28,7 +20,7 @@
           "deadline": "2022-11-07T18:00:00"
         },
         {
-          "taskid": 3,
+          "taskid": 2,
           "goalid": "free",
           "title": "free",
           "duration": 6,
@@ -41,31 +33,15 @@
       "day": "2022-11-08",
       "outputs": [
         {
-          "taskid": 4,
+          "taskid": 3,
           "goalid": "free",
           "title": "free",
-          "duration": 12,
+          "duration": 16,
           "start": "2022-11-08T00:00:00",
-          "deadline": "2022-11-08T12:00:00"
-        },
-        {
-          "taskid": 5,
-          "goalid": "1",
-          "title": "work",
-          "duration": 1,
-          "start": "2022-11-08T12:00:00",
-          "deadline": "2022-11-08T13:00:00"
-        },
-        {
-          "taskid": 6,
-          "goalid": "free",
-          "title": "free",
-          "duration": 3,
-          "start": "2022-11-08T13:00:00",
           "deadline": "2022-11-08T16:00:00"
         },
         {
-          "taskid": 7,
+          "taskid": 4,
           "goalid": "3",
           "title": "cook burger",
           "duration": 2,
@@ -73,7 +49,7 @@
           "deadline": "2022-11-08T18:00:00"
         },
         {
-          "taskid": 8,
+          "taskid": 5,
           "goalid": "free",
           "title": "free",
           "duration": 6,
@@ -86,7 +62,7 @@
       "day": "2022-11-09",
       "outputs": [
         {
-          "taskid": 9,
+          "taskid": 6,
           "goalid": "free",
           "title": "free",
           "duration": 16,
@@ -94,7 +70,7 @@
           "deadline": "2022-11-09T16:00:00"
         },
         {
-          "taskid": 10,
+          "taskid": 7,
           "goalid": "4",
           "title": "cook pizza",
           "duration": 2,
@@ -102,7 +78,7 @@
           "deadline": "2022-11-09T18:00:00"
         },
         {
-          "taskid": 11,
+          "taskid": 8,
           "goalid": "free",
           "title": "free",
           "duration": 6,
@@ -115,11 +91,27 @@
       "day": "2022-11-10",
       "outputs": [
         {
-          "taskid": 12,
+          "taskid": 9,
           "goalid": "free",
           "title": "free",
-          "duration": 24,
+          "duration": 12,
           "start": "2022-11-10T00:00:00",
+          "deadline": "2022-11-10T12:00:00"
+        },
+        {
+          "taskid": 10,
+          "goalid": "1",
+          "title": "work",
+          "duration": 5,
+          "start": "2022-11-10T12:00:00",
+          "deadline": "2022-11-10T17:00:00"
+        },
+        {
+          "taskid": 11,
+          "goalid": "free",
+          "title": "free",
+          "duration": 7,
+          "start": "2022-11-10T17:00:00",
           "deadline": "2022-11-11T00:00:00"
         }
       ]
@@ -128,7 +120,7 @@
       "day": "2022-11-11",
       "outputs": [
         {
-          "taskid": 13,
+          "taskid": 12,
           "goalid": "free",
           "title": "free",
           "duration": 24,

--- a/tests/jsons/split-1/actual_output.json
+++ b/tests/jsons/split-1/actual_output.json
@@ -13,42 +13,26 @@
         },
         {
           "taskid": 1,
-          "goalid": "2",
-          "title": "work",
-          "duration": 4,
-          "start": "2022-09-01T08:00:00",
-          "deadline": "2022-09-01T12:00:00"
-        },
-        {
-          "taskid": 2,
           "goalid": "1",
           "title": "dentist",
           "duration": 1,
-          "start": "2022-09-01T12:00:00",
-          "deadline": "2022-09-01T13:00:00"
+          "start": "2022-09-01T08:00:00",
+          "deadline": "2022-09-01T09:00:00"
+        },
+        {
+          "taskid": 2,
+          "goalid": "2",
+          "title": "work",
+          "duration": 8,
+          "start": "2022-09-01T08:00:00",
+          "deadline": "2022-09-01T16:00:00"
         },
         {
           "taskid": 3,
           "goalid": "free",
           "title": "free",
-          "duration": 1,
-          "start": "2022-09-01T13:00:00",
-          "deadline": "2022-09-01T14:00:00"
-        },
-        {
-          "taskid": 4,
-          "goalid": "2",
-          "title": "work",
-          "duration": 4,
-          "start": "2022-09-01T14:00:00",
-          "deadline": "2022-09-01T18:00:00"
-        },
-        {
-          "taskid": 5,
-          "goalid": "free",
-          "title": "free",
-          "duration": 6,
-          "start": "2022-09-01T18:00:00",
+          "duration": 8,
+          "start": "2022-09-01T16:00:00",
           "deadline": "2022-09-02T00:00:00"
         }
       ]

--- a/tests/jsons/split-2/actual_output.json
+++ b/tests/jsons/split-2/actual_output.json
@@ -15,40 +15,16 @@
           "taskid": 1,
           "goalid": "1",
           "title": "work",
-          "duration": 6,
+          "duration": 8,
           "start": "2022-09-01T08:00:00",
-          "deadline": "2022-09-01T14:00:00"
-        },
-        {
-          "taskid": 2,
-          "goalid": "2",
-          "title": "dentist",
-          "duration": 1,
-          "start": "2022-09-01T14:00:00",
-          "deadline": "2022-09-01T15:00:00"
-        },
-        {
-          "taskid": 3,
-          "goalid": "3",
-          "title": "walk",
-          "duration": 1,
-          "start": "2022-09-01T15:00:00",
           "deadline": "2022-09-01T16:00:00"
         },
         {
-          "taskid": 4,
-          "goalid": "1",
-          "title": "work",
-          "duration": 2,
-          "start": "2022-09-01T16:00:00",
-          "deadline": "2022-09-01T18:00:00"
-        },
-        {
-          "taskid": 5,
+          "taskid": 2,
           "goalid": "free",
           "title": "free",
-          "duration": 6,
-          "start": "2022-09-01T18:00:00",
+          "duration": 8,
+          "start": "2022-09-01T16:00:00",
           "deadline": "2022-09-02T00:00:00"
         }
       ]
@@ -57,7 +33,24 @@
   "impossible": [
     {
       "day": "2022-09-01",
-      "outputs": []
+      "outputs": [
+        {
+          "taskid": 3,
+          "goalid": "2",
+          "title": "dentist",
+          "duration": 1,
+          "start": "2022-09-01T00:00:00",
+          "deadline": "2022-09-02T00:00:00"
+        },
+        {
+          "taskid": 4,
+          "goalid": "3",
+          "title": "walk",
+          "duration": 1,
+          "start": "2022-09-01T00:00:00",
+          "deadline": "2022-09-02T00:00:00"
+        }
+      ]
     }
   ]
 }

--- a/tests/jsons/split-3/actual_output.json
+++ b/tests/jsons/split-3/actual_output.json
@@ -15,48 +15,16 @@
           "taskid": 1,
           "goalid": "1",
           "title": "work",
-          "duration": 5,
+          "duration": 8,
           "start": "2022-09-01T08:00:00",
-          "deadline": "2022-09-01T13:00:00"
-        },
-        {
-          "taskid": 2,
-          "goalid": "3",
-          "title": "walk",
-          "duration": 1,
-          "start": "2022-09-01T13:00:00",
-          "deadline": "2022-09-01T14:00:00"
-        },
-        {
-          "taskid": 3,
-          "goalid": "2",
-          "title": "dentist",
-          "duration": 1,
-          "start": "2022-09-01T14:00:00",
-          "deadline": "2022-09-01T15:00:00"
-        },
-        {
-          "taskid": 4,
-          "goalid": "3",
-          "title": "walk",
-          "duration": 1,
-          "start": "2022-09-01T15:00:00",
           "deadline": "2022-09-01T16:00:00"
         },
         {
-          "taskid": 5,
-          "goalid": "1",
-          "title": "work",
-          "duration": 3,
-          "start": "2022-09-01T16:00:00",
-          "deadline": "2022-09-01T19:00:00"
-        },
-        {
-          "taskid": 6,
+          "taskid": 2,
           "goalid": "free",
           "title": "free",
-          "duration": 5,
-          "start": "2022-09-01T19:00:00",
+          "duration": 8,
+          "start": "2022-09-01T16:00:00",
           "deadline": "2022-09-02T00:00:00"
         }
       ]
@@ -65,7 +33,24 @@
   "impossible": [
     {
       "day": "2022-09-01",
-      "outputs": []
+      "outputs": [
+        {
+          "taskid": 3,
+          "goalid": "2",
+          "title": "dentist",
+          "duration": 1,
+          "start": "2022-09-01T00:00:00",
+          "deadline": "2022-09-02T00:00:00"
+        },
+        {
+          "taskid": 4,
+          "goalid": "3",
+          "title": "walk",
+          "duration": 2,
+          "start": "2022-09-01T00:00:00",
+          "deadline": "2022-09-02T00:00:00"
+        }
+      ]
     }
   ]
 }

--- a/tests/jsons/split-4/actual_output.json
+++ b/tests/jsons/split-4/actual_output.json
@@ -15,48 +15,16 @@
           "taskid": 1,
           "goalid": "1",
           "title": "work",
-          "duration": 5,
+          "duration": 8,
           "start": "2022-09-01T08:00:00",
-          "deadline": "2022-09-01T13:00:00"
-        },
-        {
-          "taskid": 2,
-          "goalid": "3",
-          "title": "walk",
-          "duration": 2,
-          "start": "2022-09-01T13:00:00",
-          "deadline": "2022-09-01T15:00:00"
-        },
-        {
-          "taskid": 3,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-09-01T15:00:00",
           "deadline": "2022-09-01T16:00:00"
         },
         {
-          "taskid": 4,
-          "goalid": "2",
-          "title": "shopping",
-          "duration": 1,
-          "start": "2022-09-01T16:00:00",
-          "deadline": "2022-09-01T17:00:00"
-        },
-        {
-          "taskid": 5,
-          "goalid": "1",
-          "title": "work",
-          "duration": 3,
-          "start": "2022-09-01T17:00:00",
-          "deadline": "2022-09-01T20:00:00"
-        },
-        {
-          "taskid": 6,
+          "taskid": 2,
           "goalid": "free",
           "title": "free",
-          "duration": 4,
-          "start": "2022-09-01T20:00:00",
+          "duration": 8,
+          "start": "2022-09-01T16:00:00",
           "deadline": "2022-09-02T00:00:00"
         }
       ]
@@ -65,7 +33,24 @@
   "impossible": [
     {
       "day": "2022-09-01",
-      "outputs": []
+      "outputs": [
+        {
+          "taskid": 3,
+          "goalid": "2",
+          "title": "shopping",
+          "duration": 1,
+          "start": "2022-09-01T00:00:00",
+          "deadline": "2022-09-02T00:00:00"
+        },
+        {
+          "taskid": 4,
+          "goalid": "3",
+          "title": "walk",
+          "duration": 2,
+          "start": "2022-09-01T00:00:00",
+          "deadline": "2022-09-02T00:00:00"
+        }
+      ]
     }
   ]
 }

--- a/tests/jsons/x-per-day-4/actual_output.json
+++ b/tests/jsons/x-per-day-4/actual_output.json
@@ -21,8 +21,8 @@
         },
         {
           "taskid": 2,
-          "goalid": "1",
-          "title": "play chess",
+          "goalid": "free",
+          "title": "free",
           "duration": 2,
           "start": "2022-11-11T08:00:00",
           "deadline": "2022-11-11T10:00:00"
@@ -39,20 +39,12 @@
           "taskid": 4,
           "goalid": "1",
           "title": "play chess",
-          "duration": 1,
+          "duration": 3,
           "start": "2022-11-11T12:00:00",
-          "deadline": "2022-11-11T13:00:00"
-        },
-        {
-          "taskid": 5,
-          "goalid": "free",
-          "title": "free",
-          "duration": 2,
-          "start": "2022-11-11T13:00:00",
           "deadline": "2022-11-11T15:00:00"
         },
         {
-          "taskid": 6,
+          "taskid": 5,
           "goalid": "4",
           "title": "lunch",
           "duration": 1,
@@ -60,7 +52,7 @@
           "deadline": "2022-11-11T16:00:00"
         },
         {
-          "taskid": 7,
+          "taskid": 6,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -68,7 +60,7 @@
           "deadline": "2022-11-11T17:00:00"
         },
         {
-          "taskid": 8,
+          "taskid": 7,
           "goalid": "5",
           "title": "supper",
           "duration": 3,
@@ -76,7 +68,7 @@
           "deadline": "2022-11-11T20:00:00"
         },
         {
-          "taskid": 9,
+          "taskid": 8,
           "goalid": "free",
           "title": "free",
           "duration": 4,


### PR DESCRIPTION
This is Sub PR based on PR: https://github.com/tijlleenders/ZinZen-scheduler/pull/317

--- 

Filter timing need to be enhanced as below case:
- Task title 'sleep' after `filter_timing`, it contains extra hours out of deadline which leads to wrong scheduling. 
    Input is like below:

    ```json
    {
        "startDate": "2023-01-03T00:00:00",
        "endDate": "2023-01-10T00:00:00",
        "goals": {
            "1": {
                "id": "1",
                "title": "sleep",
                "min_duration": 8,
                "filters": {
                    "after_time": 22,
                    "before_time": 8
                }
            },
            ---
            ---
            ---
        }
    }
    ```

    Sleep Task contains below issue as below:
    ```
    Task
        title: sleep 
        slots:
            2023-01-03 00 - 2023-01-03 08
            2023-01-03 22 - 2023-01-04 08
            2023-01-04 22 - 2023-01-05 08
            2023-01-05 22 - 2023-01-06 08
            2023-01-06 22 - 2023-01-07 08
            2023-01-07 22 - 2023-01-08 08
            2023-01-09 22 - 2023-01-10 08 (here the issue, it should be till end of day "2023-01-10 00")
    ```

--- 

Main issue resolved and edge case passed, but found another issue will be resolved on a sub PR.
Issue found in `Task::remove_slot` which will be resolved in a new sub PR.