### PR TITLE
fix: Task::remove_slot not removing properly based on business need

### DIFF
--- a/src/models/slot/impls.rs
+++ b/src/models/slot/impls.rs
@@ -28,11 +28,8 @@ impl Sub for Slot {
             return result;
         }
         if rhs.start < self.start && rhs.end > self.end {
-            // If rhs completely encompasses self, then swap self and rhs,
-            //and subtract from each other
-            let swap_subtract = rhs - self;
-            result.extend(swap_subtract);
-            return result;
+            // If rhs completely encompasses self, then return empty list
+            return vec![];
         }
 
         if rhs.start > self.start {

--- a/src/models/task/impls.rs
+++ b/src/models/task/impls.rs
@@ -167,18 +167,10 @@ impl Task {
         for slot in &mut self.slots {
             let task_slot = *slot;
             dbg!(&slot_to_remove, &task_slot);
-            // Business rule:
-            // If slot_to_remove > task_slot AND
-            //  task_slot contained in slot_to_remove,
-            // so remove task_slot
-            if slot_to_remove.duration_as_hours() > task_slot.duration_as_hours() {
-                if slot_to_remove.is_contains_slot(&task_slot) {
-                    continue;
-                }
-            }
 
             let subtracted_slot = task_slot - slot_to_remove;
             dbg!(&subtracted_slot);
+
             slots_after_filter.extend(subtracted_slot);
             dbg!(&slots_after_filter);
         }

--- a/src/models/timeline/mod.rs
+++ b/src/models/timeline/mod.rs
@@ -110,8 +110,6 @@ impl Timeline {
         }
     }
 
-    pub fn remove_slots_by_timing() {}
-
     /// Remove list of slots from timeline
     pub fn remove_slots(&mut self, slots_to_remove: Vec<Slot>) {
         dbg!(&self);

--- a/src/services/placer/mod.rs
+++ b/src/services/placer/mod.rs
@@ -169,6 +169,18 @@ fn do_the_scheduling(tasks_to_place: &mut TasksToPlace, chosen_slots: Vec<Slot>)
         template_task.deadline = Some(slot.end);
         tasks_to_place.tasks.push(template_task.clone());
     }
+    /*
+    Todo 2023-06-11: Fix below functionality:
+    Currently:
+    - It loop over all tasks then remove conflicted slots in all chosen_slots; that is why it is removing unconflicted slots like case.
+
+    Correct is:
+    - loop over chosen_slots, then loop over tasks for each chosen_slot, if a chosen_slot not conflicted with all slots in a tasks, break the loop and don't continue check another chosen_slot.
+
+    Example: Case bug_215, when first_task is Sleep and chosen_slot is:
+        Slot: 2023-01-03 22 to 2023-01-04 06
+        task: water, Slot: 2023-01-04 01 to 03
+    */
     for task in tasks_to_place.tasks.iter_mut() {
         for slot in chosen_slots.iter() {
             task.remove_conflicted_slots(slot.to_owned());

--- a/src/services/placer/mod.rs
+++ b/src/services/placer/mod.rs
@@ -171,7 +171,7 @@ fn do_the_scheduling(tasks_to_place: &mut TasksToPlace, chosen_slots: Vec<Slot>)
     }
     for task in tasks_to_place.tasks.iter_mut() {
         for slot in chosen_slots.iter() {
-            task.remove_slot(slot.to_owned());
+            task.remove_conflicted_slots(slot.to_owned());
         }
     }
     //Todo remove chosen_slots from TaskBudgets

--- a/src/services/placer/mod.rs
+++ b/src/services/placer/mod.rs
@@ -139,9 +139,10 @@ fn do_the_scheduling(tasks_to_place: &mut TasksToPlace, chosen_slots: Vec<Slot>)
     - think to initialize `template_task.duration` to remaining_hours
     - create a function to initialize scheduled task to minimize effort and clean code
     - for code `template_task.id`, make it realistic numbering. Idea to create function inside Task to generate a new number which not duplicated with current list of tasks
-    - 2023-06-04  | for code `template_task.id += 1;`, have issue which multiple tasks with the same id
+    - Todo 2023-06-04  | for code `template_task.id += 1;`, have issue which multiple tasks with the same id
     - for code `for slot in chosen_slots.iter()`, just make it function and call it
 
+    Todo 2023-06-11: Need to refactor this function to be testable
     */
 
     let mut remaining_hours = tasks_to_place.tasks[0].duration;
@@ -169,23 +170,12 @@ fn do_the_scheduling(tasks_to_place: &mut TasksToPlace, chosen_slots: Vec<Slot>)
         template_task.deadline = Some(slot.end);
         tasks_to_place.tasks.push(template_task.clone());
     }
-    /*
-    Todo 2023-06-11: Fix below functionality:
-    Currently:
-    - It loop over all tasks then remove conflicted slots in all chosen_slots; that is why it is removing unconflicted slots like case.
 
-    Correct is:
-    - loop over chosen_slots, then loop over tasks for each chosen_slot, if a chosen_slot not conflicted with all slots in a tasks, break the loop and don't continue check another chosen_slot.
-
-    Example: Case bug_215, when first_task is Sleep and chosen_slot is:
-        Slot: 2023-01-03 22 to 2023-01-04 06
-        task: water, Slot: 2023-01-04 01 to 03
-    */
+    let chosen_slot = chosen_slots[0];
     for task in tasks_to_place.tasks.iter_mut() {
-        for slot in chosen_slots.iter() {
-            task.remove_conflicted_slots(slot.to_owned());
-        }
+        task.remove_conflicted_slots(chosen_slot.to_owned());
     }
+
     //Todo remove chosen_slots from TaskBudgets
     if remaining_hours > 0 {
         tasks_to_place.tasks[0].duration = remaining_hours;

--- a/src/tests/slot.rs
+++ b/src/tests/slot.rs
@@ -5,19 +5,10 @@ use chrono::Duration;
 
 use crate::models::slot::Slot;
 
+/// Test if subtracting few hours from full day (or more duration)
+/// - Expexted to return empty list
 #[test]
 fn test_subtract_few_hours_from_fullday() {
-    /*
-    slot_few_hours = Slot {
-        start: 2022-01-02T05:00:00,
-        end: 2022-01-02T15:00:00,
-    }
-    slot_full_day = Slot {
-        start: 2022-01-02T00:00:00,
-        end: 2022-01-03T00:00:00,
-    }
-    */
-
     let year = 2022;
     let month = 1;
     let day = 1;
@@ -25,10 +16,7 @@ fn test_subtract_few_hours_from_fullday() {
     let slot_few_hours = Slot::mock(Duration::hours(10), year, month, day, 5, 0);
     let slot_full_day = Slot::mock(Duration::days(1), year, month, day, 0, 0);
 
-    let expected_result: Vec<Slot> = vec![
-        Slot::mock(Duration::hours(5), year, month, day, 0, 0),
-        Slot::mock(Duration::hours(9), year, month, day, 15, 0),
-    ];
+    let expected_result: Vec<Slot> = vec![];
     dbg!(&expected_result);
 
     let result = slot_few_hours - slot_full_day;

--- a/tests/jsons/basic-2/actual_output.json
+++ b/tests/jsons/basic-2/actual_output.json
@@ -7,20 +7,28 @@
           "taskid": 0,
           "goalid": "free",
           "title": "free",
-          "duration": 10,
+          "duration": 8,
           "start": "2022-01-01T00:00:00",
-          "deadline": "2022-01-01T10:00:00"
+          "deadline": "2022-01-01T08:00:00"
         },
         {
           "taskid": 1,
           "goalid": "2",
           "title": "presentation",
           "duration": 1,
-          "start": "2022-01-01T10:00:00",
-          "deadline": "2022-01-01T11:00:00"
+          "start": "2022-01-01T08:00:00",
+          "deadline": "2022-01-01T09:00:00"
         },
         {
           "taskid": 2,
+          "goalid": "free",
+          "title": "free",
+          "duration": 2,
+          "start": "2022-01-01T09:00:00",
+          "deadline": "2022-01-01T11:00:00"
+        },
+        {
+          "taskid": 3,
           "goalid": "3",
           "title": "swimming_class",
           "duration": 2,
@@ -28,7 +36,7 @@
           "deadline": "2022-01-01T13:00:00"
         },
         {
-          "taskid": 3,
+          "taskid": 4,
           "goalid": "1",
           "title": "group_discussion",
           "duration": 3,
@@ -36,7 +44,7 @@
           "deadline": "2022-01-01T16:00:00"
         },
         {
-          "taskid": 4,
+          "taskid": 5,
           "goalid": "free",
           "title": "free",
           "duration": 8,

--- a/tests/jsons/bug-215/actual_output.json
+++ b/tests/jsons/bug-215/actual_output.json
@@ -92,8 +92,24 @@
           "taskid": 10,
           "goalid": "free",
           "title": "free",
-          "duration": 24,
+          "duration": 1,
           "start": "2023-01-04T00:00:00",
+          "deadline": "2023-01-04T01:00:00"
+        },
+        {
+          "taskid": 11,
+          "goalid": "8",
+          "title": "water the plants indoors",
+          "duration": 1,
+          "start": "2023-01-04T01:00:00",
+          "deadline": "2023-01-04T02:00:00"
+        },
+        {
+          "taskid": 12,
+          "goalid": "free",
+          "title": "free",
+          "duration": 22,
+          "start": "2023-01-04T02:00:00",
           "deadline": "2023-01-05T00:00:00"
         }
       ]
@@ -102,11 +118,27 @@
       "day": "2023-01-05",
       "outputs": [
         {
-          "taskid": 11,
+          "taskid": 13,
           "goalid": "free",
           "title": "free",
-          "duration": 24,
+          "duration": 1,
           "start": "2023-01-05T00:00:00",
+          "deadline": "2023-01-05T01:00:00"
+        },
+        {
+          "taskid": 14,
+          "goalid": "2",
+          "title": "hurdle",
+          "duration": 2,
+          "start": "2023-01-05T01:00:00",
+          "deadline": "2023-01-05T03:00:00"
+        },
+        {
+          "taskid": 15,
+          "goalid": "free",
+          "title": "free",
+          "duration": 21,
+          "start": "2023-01-05T03:00:00",
           "deadline": "2023-01-06T00:00:00"
         }
       ]
@@ -115,7 +147,7 @@
       "day": "2023-01-06",
       "outputs": [
         {
-          "taskid": 12,
+          "taskid": 16,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -128,27 +160,11 @@
       "day": "2023-01-07",
       "outputs": [
         {
-          "taskid": 13,
+          "taskid": 17,
           "goalid": "free",
           "title": "free",
-          "duration": 1,
+          "duration": 24,
           "start": "2023-01-07T00:00:00",
-          "deadline": "2023-01-07T01:00:00"
-        },
-        {
-          "taskid": 14,
-          "goalid": "8",
-          "title": "water the plants indoors",
-          "duration": 1,
-          "start": "2023-01-07T01:00:00",
-          "deadline": "2023-01-07T02:00:00"
-        },
-        {
-          "taskid": 15,
-          "goalid": "free",
-          "title": "free",
-          "duration": 22,
-          "start": "2023-01-07T02:00:00",
           "deadline": "2023-01-08T00:00:00"
         }
       ]
@@ -157,27 +173,11 @@
       "day": "2023-01-08",
       "outputs": [
         {
-          "taskid": 16,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2023-01-08T00:00:00",
-          "deadline": "2023-01-08T01:00:00"
-        },
-        {
-          "taskid": 17,
-          "goalid": "2",
-          "title": "hurdle",
-          "duration": 2,
-          "start": "2023-01-08T01:00:00",
-          "deadline": "2023-01-08T03:00:00"
-        },
-        {
           "taskid": 18,
           "goalid": "free",
           "title": "free",
-          "duration": 21,
-          "start": "2023-01-08T03:00:00",
+          "duration": 24,
+          "start": "2023-01-08T00:00:00",
           "deadline": "2023-01-09T00:00:00"
         }
       ]

--- a/tests/jsons/bug-215/actual_output.json
+++ b/tests/jsons/bug-215/actual_output.json
@@ -5,14 +5,6 @@
       "outputs": [
         {
           "taskid": 0,
-          "goalid": "8",
-          "title": "water the plants indoors",
-          "duration": 1,
-          "start": "2023-01-03T00:00:00",
-          "deadline": "2023-01-03T01:00:00"
-        },
-        {
-          "taskid": 1,
           "goalid": "1",
           "title": "sleep",
           "duration": 8,
@@ -20,15 +12,7 @@
           "deadline": "2023-01-03T08:00:00"
         },
         {
-          "taskid": 2,
-          "goalid": "2",
-          "title": "hurdle",
-          "duration": 2,
-          "start": "2023-01-03T03:00:00",
-          "deadline": "2023-01-03T05:00:00"
-        },
-        {
-          "taskid": 3,
+          "taskid": 1,
           "goalid": "5",
           "title": "breakfast",
           "duration": 1,
@@ -36,7 +20,7 @@
           "deadline": "2023-01-03T09:00:00"
         },
         {
-          "taskid": 4,
+          "taskid": 2,
           "goalid": "4",
           "title": "me time",
           "duration": 1,
@@ -44,7 +28,7 @@
           "deadline": "2023-01-03T10:00:00"
         },
         {
-          "taskid": 5,
+          "taskid": 3,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -52,7 +36,7 @@
           "deadline": "2023-01-03T12:00:00"
         },
         {
-          "taskid": 6,
+          "taskid": 4,
           "goalid": "3",
           "title": "lunch",
           "duration": 1,
@@ -60,7 +44,7 @@
           "deadline": "2023-01-03T13:00:00"
         },
         {
-          "taskid": 7,
+          "taskid": 5,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -68,7 +52,7 @@
           "deadline": "2023-01-03T14:00:00"
         },
         {
-          "taskid": 8,
+          "taskid": 6,
           "goalid": "6",
           "title": "walk",
           "duration": 1,
@@ -76,7 +60,7 @@
           "deadline": "2023-01-03T15:00:00"
         },
         {
-          "taskid": 9,
+          "taskid": 7,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -84,7 +68,7 @@
           "deadline": "2023-01-03T18:00:00"
         },
         {
-          "taskid": 10,
+          "taskid": 8,
           "goalid": "7",
           "title": "dinner",
           "duration": 1,
@@ -92,7 +76,7 @@
           "deadline": "2023-01-03T19:00:00"
         },
         {
-          "taskid": 11,
+          "taskid": 9,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -105,7 +89,7 @@
       "day": "2023-01-04",
       "outputs": [
         {
-          "taskid": 12,
+          "taskid": 10,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -118,7 +102,7 @@
       "day": "2023-01-05",
       "outputs": [
         {
-          "taskid": 13,
+          "taskid": 11,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -131,7 +115,7 @@
       "day": "2023-01-06",
       "outputs": [
         {
-          "taskid": 14,
+          "taskid": 12,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -144,11 +128,27 @@
       "day": "2023-01-07",
       "outputs": [
         {
+          "taskid": 13,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2023-01-07T00:00:00",
+          "deadline": "2023-01-07T01:00:00"
+        },
+        {
+          "taskid": 14,
+          "goalid": "8",
+          "title": "water the plants indoors",
+          "duration": 1,
+          "start": "2023-01-07T01:00:00",
+          "deadline": "2023-01-07T02:00:00"
+        },
+        {
           "taskid": 15,
           "goalid": "free",
           "title": "free",
-          "duration": 24,
-          "start": "2023-01-07T00:00:00",
+          "duration": 22,
+          "start": "2023-01-07T02:00:00",
           "deadline": "2023-01-08T00:00:00"
         }
       ]
@@ -160,8 +160,24 @@
           "taskid": 16,
           "goalid": "free",
           "title": "free",
-          "duration": 24,
+          "duration": 1,
           "start": "2023-01-08T00:00:00",
+          "deadline": "2023-01-08T01:00:00"
+        },
+        {
+          "taskid": 17,
+          "goalid": "2",
+          "title": "hurdle",
+          "duration": 2,
+          "start": "2023-01-08T01:00:00",
+          "deadline": "2023-01-08T03:00:00"
+        },
+        {
+          "taskid": 18,
+          "goalid": "free",
+          "title": "free",
+          "duration": 21,
+          "start": "2023-01-08T03:00:00",
           "deadline": "2023-01-09T00:00:00"
         }
       ]
@@ -170,7 +186,7 @@
       "day": "2023-01-09",
       "outputs": [
         {
-          "taskid": 17,
+          "taskid": 19,
           "goalid": "free",
           "title": "free",
           "duration": 24,

--- a/tests/jsons/bug-215/output.json
+++ b/tests/jsons/bug-215/output.json
@@ -97,7 +97,7 @@
           "deadline": "2023-01-04T01:00:00"
         },
         {
-          "taskid": 15,
+          "taskid": 11,
           "goalid": "8",
           "title": "water the plants indoors",
           "duration": 1,
@@ -105,7 +105,7 @@
           "deadline": "2023-01-04T02:00:00"
         },
         {
-          "taskid": 16,
+          "taskid": 12,
           "goalid": "free",
           "title": "free",
           "duration": 22,
@@ -118,11 +118,27 @@
       "day": "2023-01-05",
       "outputs": [
         {
-          "taskid": 17,
+          "taskid": 13,
           "goalid": "free",
           "title": "free",
-          "duration": 24,
+          "duration": 1,
           "start": "2023-01-05T00:00:00",
+          "deadline": "2023-01-05T01:00:00"
+        },
+        {
+          "taskid": 14,
+          "goalid": "2",
+          "title": "hurdle",
+          "duration": 2,
+          "start": "2023-01-05T01:00:00",
+          "deadline": "2023-01-05T03:00:00"
+        },
+        {
+          "taskid": 15,
+          "goalid": "free",
+          "title": "free",
+          "duration": 21,
+          "start": "2023-01-05T03:00:00",
           "deadline": "2023-01-06T00:00:00"
         }
       ]
@@ -131,7 +147,7 @@
       "day": "2023-01-06",
       "outputs": [
         {
-          "taskid": 18,
+          "taskid": 16,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -144,7 +160,7 @@
       "day": "2023-01-07",
       "outputs": [
         {
-          "taskid": 19,
+          "taskid": 17,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -157,7 +173,7 @@
       "day": "2023-01-08",
       "outputs": [
         {
-          "taskid": 20,
+          "taskid": 18,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -170,7 +186,7 @@
       "day": "2023-01-09",
       "outputs": [
         {
-          "taskid": 21,
+          "taskid": 19,
           "goalid": "free",
           "title": "free",
           "duration": 24,

--- a/tests/jsons/flex-duration-2/actual_output.json
+++ b/tests/jsons/flex-duration-2/actual_output.json
@@ -538,14 +538,6 @@
           "duration": 8,
           "start": "2022-10-01T00:00:00",
           "deadline": "2022-10-15T00:00:00"
-        },
-        {
-          "taskid": 58,
-          "goalid": "3",
-          "title": "sleep",
-          "duration": 8,
-          "start": "2022-10-01T00:00:00",
-          "deadline": "2022-10-15T00:00:00"
         }
       ]
     },

--- a/tests/jsons/flex-repeat-2/actual_output.json
+++ b/tests/jsons/flex-repeat-2/actual_output.json
@@ -1602,9 +1602,9 @@
         },
         {
           "taskid": 180,
-          "goalid": "2",
-          "title": "sleep",
-          "duration": 10,
+          "goalid": "3",
+          "title": "work",
+          "duration": 9,
           "start": "2022-10-01T00:00:00",
           "deadline": "2022-11-01T00:00:00"
         },
@@ -1634,14 +1634,6 @@
         },
         {
           "taskid": 184,
-          "goalid": "3",
-          "title": "work",
-          "duration": 9,
-          "start": "2022-10-01T00:00:00",
-          "deadline": "2022-11-01T00:00:00"
-        },
-        {
-          "taskid": 185,
           "goalid": "3",
           "title": "work",
           "duration": 9,

--- a/tests/jsons/goals-dependency/actual_output.json
+++ b/tests/jsons/goals-dependency/actual_output.json
@@ -44,8 +44,24 @@
           "taskid": 4,
           "goalid": "free",
           "title": "free",
-          "duration": 24,
+          "duration": 8,
           "start": "2018-01-02T00:00:00",
+          "deadline": "2018-01-02T08:00:00"
+        },
+        {
+          "taskid": 5,
+          "goalid": "2",
+          "title": "program a ZinZen app in rust",
+          "duration": 8,
+          "start": "2018-01-02T08:00:00",
+          "deadline": "2018-01-02T16:00:00"
+        },
+        {
+          "taskid": 6,
+          "goalid": "free",
+          "title": "free",
+          "duration": 8,
+          "start": "2018-01-02T16:00:00",
           "deadline": "2018-01-03T00:00:00"
         }
       ]
@@ -54,7 +70,7 @@
       "day": "2018-01-03",
       "outputs": [
         {
-          "taskid": 5,
+          "taskid": 7,
           "goalid": "free",
           "title": "free",
           "duration": 8,
@@ -62,15 +78,15 @@
           "deadline": "2018-01-03T08:00:00"
         },
         {
-          "taskid": 6,
-          "goalid": "2",
-          "title": "program a ZinZen app in rust",
+          "taskid": 8,
+          "goalid": "3",
+          "title": "learn rust programming",
           "duration": 8,
           "start": "2018-01-03T08:00:00",
           "deadline": "2018-01-03T16:00:00"
         },
         {
-          "taskid": 7,
+          "taskid": 9,
           "goalid": "free",
           "title": "free",
           "duration": 8,
@@ -83,7 +99,7 @@
       "day": "2018-01-04",
       "outputs": [
         {
-          "taskid": 8,
+          "taskid": 10,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -96,7 +112,7 @@
       "day": "2018-01-05",
       "outputs": [
         {
-          "taskid": 9,
+          "taskid": 11,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -109,16 +125,7 @@
   "impossible": [
     {
       "day": "2018-01-01",
-      "outputs": [
-        {
-          "taskid": 10,
-          "goalid": "3",
-          "title": "learn rust programming",
-          "duration": 8,
-          "start": "2018-01-01T00:00:00",
-          "deadline": "2018-01-06T00:00:00"
-        }
-      ]
+      "outputs": []
     },
     {
       "day": "2018-01-02",

--- a/tests/jsons/i287-mix-budgets-many-goals/actual_output.json
+++ b/tests/jsons/i287-mix-budgets-many-goals/actual_output.json
@@ -13,26 +13,18 @@
         },
         {
           "taskid": 1,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-01T02:00:00",
-          "deadline": "2022-10-01T03:00:00"
-        },
-        {
-          "taskid": 2,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-01T03:00:00",
-          "deadline": "2022-10-01T08:00:00"
+          "start": "2022-10-01T02:00:00",
+          "deadline": "2022-10-01T07:00:00"
         },
         {
-          "taskid": 3,
+          "taskid": 2,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-01T08:00:00",
+          "duration": 17,
+          "start": "2022-10-01T07:00:00",
           "deadline": "2022-10-02T00:00:00"
         }
       ]
@@ -41,7 +33,7 @@
       "day": "2022-10-02",
       "outputs": [
         {
-          "taskid": 4,
+          "taskid": 3,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -49,27 +41,19 @@
           "deadline": "2022-10-02T02:00:00"
         },
         {
-          "taskid": 5,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-02T02:00:00",
-          "deadline": "2022-10-02T03:00:00"
-        },
-        {
-          "taskid": 6,
+          "taskid": 4,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-02T03:00:00",
-          "deadline": "2022-10-02T08:00:00"
+          "start": "2022-10-02T02:00:00",
+          "deadline": "2022-10-02T07:00:00"
         },
         {
-          "taskid": 7,
+          "taskid": 5,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-02T08:00:00",
+          "duration": 17,
+          "start": "2022-10-02T07:00:00",
           "deadline": "2022-10-03T00:00:00"
         }
       ]
@@ -78,7 +62,7 @@
       "day": "2022-10-03",
       "outputs": [
         {
-          "taskid": 8,
+          "taskid": 6,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -86,27 +70,19 @@
           "deadline": "2022-10-03T02:00:00"
         },
         {
-          "taskid": 9,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-03T02:00:00",
-          "deadline": "2022-10-03T03:00:00"
-        },
-        {
-          "taskid": 10,
+          "taskid": 7,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-03T03:00:00",
-          "deadline": "2022-10-03T08:00:00"
+          "start": "2022-10-03T02:00:00",
+          "deadline": "2022-10-03T07:00:00"
         },
         {
-          "taskid": 11,
+          "taskid": 8,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-03T08:00:00",
+          "duration": 17,
+          "start": "2022-10-03T07:00:00",
           "deadline": "2022-10-04T00:00:00"
         }
       ]
@@ -115,7 +91,7 @@
       "day": "2022-10-04",
       "outputs": [
         {
-          "taskid": 12,
+          "taskid": 9,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -123,27 +99,19 @@
           "deadline": "2022-10-04T02:00:00"
         },
         {
-          "taskid": 13,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-04T02:00:00",
-          "deadline": "2022-10-04T03:00:00"
-        },
-        {
-          "taskid": 14,
+          "taskid": 10,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-04T03:00:00",
-          "deadline": "2022-10-04T08:00:00"
+          "start": "2022-10-04T02:00:00",
+          "deadline": "2022-10-04T07:00:00"
         },
         {
-          "taskid": 15,
+          "taskid": 11,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-04T08:00:00",
+          "duration": 17,
+          "start": "2022-10-04T07:00:00",
           "deadline": "2022-10-05T00:00:00"
         }
       ]
@@ -152,7 +120,7 @@
       "day": "2022-10-05",
       "outputs": [
         {
-          "taskid": 16,
+          "taskid": 12,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -160,27 +128,19 @@
           "deadline": "2022-10-05T02:00:00"
         },
         {
-          "taskid": 17,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-05T02:00:00",
-          "deadline": "2022-10-05T03:00:00"
-        },
-        {
-          "taskid": 18,
+          "taskid": 13,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-05T03:00:00",
-          "deadline": "2022-10-05T08:00:00"
+          "start": "2022-10-05T02:00:00",
+          "deadline": "2022-10-05T07:00:00"
         },
         {
-          "taskid": 19,
+          "taskid": 14,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-05T08:00:00",
+          "duration": 17,
+          "start": "2022-10-05T07:00:00",
           "deadline": "2022-10-06T00:00:00"
         }
       ]
@@ -189,7 +149,7 @@
       "day": "2022-10-06",
       "outputs": [
         {
-          "taskid": 20,
+          "taskid": 15,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -197,27 +157,19 @@
           "deadline": "2022-10-06T02:00:00"
         },
         {
-          "taskid": 21,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-06T02:00:00",
-          "deadline": "2022-10-06T03:00:00"
-        },
-        {
-          "taskid": 22,
+          "taskid": 16,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-06T03:00:00",
-          "deadline": "2022-10-06T08:00:00"
+          "start": "2022-10-06T02:00:00",
+          "deadline": "2022-10-06T07:00:00"
         },
         {
-          "taskid": 23,
+          "taskid": 17,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-06T08:00:00",
+          "duration": 17,
+          "start": "2022-10-06T07:00:00",
           "deadline": "2022-10-07T00:00:00"
         }
       ]
@@ -226,7 +178,7 @@
       "day": "2022-10-07",
       "outputs": [
         {
-          "taskid": 24,
+          "taskid": 18,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -234,27 +186,19 @@
           "deadline": "2022-10-07T02:00:00"
         },
         {
-          "taskid": 25,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-07T02:00:00",
-          "deadline": "2022-10-07T03:00:00"
-        },
-        {
-          "taskid": 26,
+          "taskid": 19,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-07T03:00:00",
-          "deadline": "2022-10-07T08:00:00"
+          "start": "2022-10-07T02:00:00",
+          "deadline": "2022-10-07T07:00:00"
         },
         {
-          "taskid": 27,
+          "taskid": 20,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-07T08:00:00",
+          "duration": 17,
+          "start": "2022-10-07T07:00:00",
           "deadline": "2022-10-08T00:00:00"
         }
       ]
@@ -263,7 +207,7 @@
       "day": "2022-10-08",
       "outputs": [
         {
-          "taskid": 28,
+          "taskid": 21,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -271,27 +215,19 @@
           "deadline": "2022-10-08T02:00:00"
         },
         {
-          "taskid": 29,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-08T02:00:00",
-          "deadline": "2022-10-08T03:00:00"
-        },
-        {
-          "taskid": 30,
+          "taskid": 22,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-08T03:00:00",
-          "deadline": "2022-10-08T08:00:00"
+          "start": "2022-10-08T02:00:00",
+          "deadline": "2022-10-08T07:00:00"
         },
         {
-          "taskid": 31,
+          "taskid": 23,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-08T08:00:00",
+          "duration": 17,
+          "start": "2022-10-08T07:00:00",
           "deadline": "2022-10-09T00:00:00"
         }
       ]
@@ -300,7 +236,7 @@
       "day": "2022-10-09",
       "outputs": [
         {
-          "taskid": 32,
+          "taskid": 24,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -308,27 +244,19 @@
           "deadline": "2022-10-09T02:00:00"
         },
         {
-          "taskid": 33,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-09T02:00:00",
-          "deadline": "2022-10-09T03:00:00"
-        },
-        {
-          "taskid": 34,
+          "taskid": 25,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-09T03:00:00",
-          "deadline": "2022-10-09T08:00:00"
+          "start": "2022-10-09T02:00:00",
+          "deadline": "2022-10-09T07:00:00"
         },
         {
-          "taskid": 35,
+          "taskid": 26,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-09T08:00:00",
+          "duration": 17,
+          "start": "2022-10-09T07:00:00",
           "deadline": "2022-10-10T00:00:00"
         }
       ]
@@ -337,7 +265,7 @@
       "day": "2022-10-10",
       "outputs": [
         {
-          "taskid": 36,
+          "taskid": 27,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -345,27 +273,19 @@
           "deadline": "2022-10-10T02:00:00"
         },
         {
-          "taskid": 37,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-10T02:00:00",
-          "deadline": "2022-10-10T03:00:00"
-        },
-        {
-          "taskid": 38,
+          "taskid": 28,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-10T03:00:00",
-          "deadline": "2022-10-10T08:00:00"
+          "start": "2022-10-10T02:00:00",
+          "deadline": "2022-10-10T07:00:00"
         },
         {
-          "taskid": 39,
+          "taskid": 29,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-10T08:00:00",
+          "duration": 17,
+          "start": "2022-10-10T07:00:00",
           "deadline": "2022-10-11T00:00:00"
         }
       ]
@@ -374,7 +294,7 @@
       "day": "2022-10-11",
       "outputs": [
         {
-          "taskid": 40,
+          "taskid": 30,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -382,27 +302,19 @@
           "deadline": "2022-10-11T02:00:00"
         },
         {
-          "taskid": 41,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-11T02:00:00",
-          "deadline": "2022-10-11T03:00:00"
-        },
-        {
-          "taskid": 42,
+          "taskid": 31,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-11T03:00:00",
-          "deadline": "2022-10-11T08:00:00"
+          "start": "2022-10-11T02:00:00",
+          "deadline": "2022-10-11T07:00:00"
         },
         {
-          "taskid": 43,
+          "taskid": 32,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-11T08:00:00",
+          "duration": 17,
+          "start": "2022-10-11T07:00:00",
           "deadline": "2022-10-12T00:00:00"
         }
       ]
@@ -411,7 +323,7 @@
       "day": "2022-10-12",
       "outputs": [
         {
-          "taskid": 44,
+          "taskid": 33,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -419,27 +331,19 @@
           "deadline": "2022-10-12T02:00:00"
         },
         {
-          "taskid": 45,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-12T02:00:00",
-          "deadline": "2022-10-12T03:00:00"
-        },
-        {
-          "taskid": 46,
+          "taskid": 34,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-12T03:00:00",
-          "deadline": "2022-10-12T08:00:00"
+          "start": "2022-10-12T02:00:00",
+          "deadline": "2022-10-12T07:00:00"
         },
         {
-          "taskid": 47,
+          "taskid": 35,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-12T08:00:00",
+          "duration": 17,
+          "start": "2022-10-12T07:00:00",
           "deadline": "2022-10-13T00:00:00"
         }
       ]
@@ -448,7 +352,7 @@
       "day": "2022-10-13",
       "outputs": [
         {
-          "taskid": 48,
+          "taskid": 36,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -456,27 +360,19 @@
           "deadline": "2022-10-13T02:00:00"
         },
         {
-          "taskid": 49,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-13T02:00:00",
-          "deadline": "2022-10-13T03:00:00"
-        },
-        {
-          "taskid": 50,
+          "taskid": 37,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-13T03:00:00",
-          "deadline": "2022-10-13T08:00:00"
+          "start": "2022-10-13T02:00:00",
+          "deadline": "2022-10-13T07:00:00"
         },
         {
-          "taskid": 51,
+          "taskid": 38,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-13T08:00:00",
+          "duration": 17,
+          "start": "2022-10-13T07:00:00",
           "deadline": "2022-10-14T00:00:00"
         }
       ]
@@ -485,7 +381,7 @@
       "day": "2022-10-14",
       "outputs": [
         {
-          "taskid": 52,
+          "taskid": 39,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -493,27 +389,19 @@
           "deadline": "2022-10-14T02:00:00"
         },
         {
-          "taskid": 53,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-14T02:00:00",
-          "deadline": "2022-10-14T03:00:00"
-        },
-        {
-          "taskid": 54,
+          "taskid": 40,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-14T03:00:00",
-          "deadline": "2022-10-14T08:00:00"
+          "start": "2022-10-14T02:00:00",
+          "deadline": "2022-10-14T07:00:00"
         },
         {
-          "taskid": 55,
+          "taskid": 41,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-14T08:00:00",
+          "duration": 17,
+          "start": "2022-10-14T07:00:00",
           "deadline": "2022-10-15T00:00:00"
         }
       ]
@@ -522,7 +410,7 @@
       "day": "2022-10-15",
       "outputs": [
         {
-          "taskid": 56,
+          "taskid": 42,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -530,27 +418,19 @@
           "deadline": "2022-10-15T02:00:00"
         },
         {
-          "taskid": 57,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-15T02:00:00",
-          "deadline": "2022-10-15T03:00:00"
-        },
-        {
-          "taskid": 58,
+          "taskid": 43,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-15T03:00:00",
-          "deadline": "2022-10-15T08:00:00"
+          "start": "2022-10-15T02:00:00",
+          "deadline": "2022-10-15T07:00:00"
         },
         {
-          "taskid": 59,
+          "taskid": 44,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-15T08:00:00",
+          "duration": 17,
+          "start": "2022-10-15T07:00:00",
           "deadline": "2022-10-16T00:00:00"
         }
       ]
@@ -559,7 +439,7 @@
       "day": "2022-10-16",
       "outputs": [
         {
-          "taskid": 60,
+          "taskid": 45,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -567,27 +447,19 @@
           "deadline": "2022-10-16T02:00:00"
         },
         {
-          "taskid": 61,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-16T02:00:00",
-          "deadline": "2022-10-16T03:00:00"
-        },
-        {
-          "taskid": 62,
+          "taskid": 46,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-16T03:00:00",
-          "deadline": "2022-10-16T08:00:00"
+          "start": "2022-10-16T02:00:00",
+          "deadline": "2022-10-16T07:00:00"
         },
         {
-          "taskid": 63,
+          "taskid": 47,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-16T08:00:00",
+          "duration": 17,
+          "start": "2022-10-16T07:00:00",
           "deadline": "2022-10-17T00:00:00"
         }
       ]
@@ -596,7 +468,7 @@
       "day": "2022-10-17",
       "outputs": [
         {
-          "taskid": 64,
+          "taskid": 48,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -604,27 +476,19 @@
           "deadline": "2022-10-17T02:00:00"
         },
         {
-          "taskid": 65,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-17T02:00:00",
-          "deadline": "2022-10-17T03:00:00"
-        },
-        {
-          "taskid": 66,
+          "taskid": 49,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-17T03:00:00",
-          "deadline": "2022-10-17T08:00:00"
+          "start": "2022-10-17T02:00:00",
+          "deadline": "2022-10-17T07:00:00"
         },
         {
-          "taskid": 67,
+          "taskid": 50,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-17T08:00:00",
+          "duration": 17,
+          "start": "2022-10-17T07:00:00",
           "deadline": "2022-10-18T00:00:00"
         }
       ]
@@ -633,7 +497,7 @@
       "day": "2022-10-18",
       "outputs": [
         {
-          "taskid": 68,
+          "taskid": 51,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -641,27 +505,19 @@
           "deadline": "2022-10-18T02:00:00"
         },
         {
-          "taskid": 69,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-18T02:00:00",
-          "deadline": "2022-10-18T03:00:00"
-        },
-        {
-          "taskid": 70,
+          "taskid": 52,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-18T03:00:00",
-          "deadline": "2022-10-18T08:00:00"
+          "start": "2022-10-18T02:00:00",
+          "deadline": "2022-10-18T07:00:00"
         },
         {
-          "taskid": 71,
+          "taskid": 53,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-18T08:00:00",
+          "duration": 17,
+          "start": "2022-10-18T07:00:00",
           "deadline": "2022-10-19T00:00:00"
         }
       ]
@@ -670,7 +526,7 @@
       "day": "2022-10-19",
       "outputs": [
         {
-          "taskid": 72,
+          "taskid": 54,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -678,27 +534,19 @@
           "deadline": "2022-10-19T02:00:00"
         },
         {
-          "taskid": 73,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-19T02:00:00",
-          "deadline": "2022-10-19T03:00:00"
-        },
-        {
-          "taskid": 74,
+          "taskid": 55,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-19T03:00:00",
-          "deadline": "2022-10-19T08:00:00"
+          "start": "2022-10-19T02:00:00",
+          "deadline": "2022-10-19T07:00:00"
         },
         {
-          "taskid": 75,
+          "taskid": 56,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-19T08:00:00",
+          "duration": 17,
+          "start": "2022-10-19T07:00:00",
           "deadline": "2022-10-20T00:00:00"
         }
       ]
@@ -707,7 +555,7 @@
       "day": "2022-10-20",
       "outputs": [
         {
-          "taskid": 76,
+          "taskid": 57,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -715,27 +563,19 @@
           "deadline": "2022-10-20T02:00:00"
         },
         {
-          "taskid": 77,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-20T02:00:00",
-          "deadline": "2022-10-20T03:00:00"
-        },
-        {
-          "taskid": 78,
+          "taskid": 58,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-20T03:00:00",
-          "deadline": "2022-10-20T08:00:00"
+          "start": "2022-10-20T02:00:00",
+          "deadline": "2022-10-20T07:00:00"
         },
         {
-          "taskid": 79,
+          "taskid": 59,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-20T08:00:00",
+          "duration": 17,
+          "start": "2022-10-20T07:00:00",
           "deadline": "2022-10-21T00:00:00"
         }
       ]
@@ -744,7 +584,7 @@
       "day": "2022-10-21",
       "outputs": [
         {
-          "taskid": 80,
+          "taskid": 60,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -752,27 +592,19 @@
           "deadline": "2022-10-21T02:00:00"
         },
         {
-          "taskid": 81,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-21T02:00:00",
-          "deadline": "2022-10-21T03:00:00"
-        },
-        {
-          "taskid": 82,
+          "taskid": 61,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-21T03:00:00",
-          "deadline": "2022-10-21T08:00:00"
+          "start": "2022-10-21T02:00:00",
+          "deadline": "2022-10-21T07:00:00"
         },
         {
-          "taskid": 83,
+          "taskid": 62,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-21T08:00:00",
+          "duration": 17,
+          "start": "2022-10-21T07:00:00",
           "deadline": "2022-10-22T00:00:00"
         }
       ]
@@ -781,7 +613,7 @@
       "day": "2022-10-22",
       "outputs": [
         {
-          "taskid": 84,
+          "taskid": 63,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -789,27 +621,19 @@
           "deadline": "2022-10-22T02:00:00"
         },
         {
-          "taskid": 85,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-22T02:00:00",
-          "deadline": "2022-10-22T03:00:00"
-        },
-        {
-          "taskid": 86,
+          "taskid": 64,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-22T03:00:00",
-          "deadline": "2022-10-22T08:00:00"
+          "start": "2022-10-22T02:00:00",
+          "deadline": "2022-10-22T07:00:00"
         },
         {
-          "taskid": 87,
+          "taskid": 65,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-22T08:00:00",
+          "duration": 17,
+          "start": "2022-10-22T07:00:00",
           "deadline": "2022-10-23T00:00:00"
         }
       ]
@@ -818,7 +642,7 @@
       "day": "2022-10-23",
       "outputs": [
         {
-          "taskid": 88,
+          "taskid": 66,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -826,27 +650,19 @@
           "deadline": "2022-10-23T02:00:00"
         },
         {
-          "taskid": 89,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-23T02:00:00",
-          "deadline": "2022-10-23T03:00:00"
-        },
-        {
-          "taskid": 90,
+          "taskid": 67,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-23T03:00:00",
-          "deadline": "2022-10-23T08:00:00"
+          "start": "2022-10-23T02:00:00",
+          "deadline": "2022-10-23T07:00:00"
         },
         {
-          "taskid": 91,
+          "taskid": 68,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-23T08:00:00",
+          "duration": 17,
+          "start": "2022-10-23T07:00:00",
           "deadline": "2022-10-24T00:00:00"
         }
       ]
@@ -855,7 +671,7 @@
       "day": "2022-10-24",
       "outputs": [
         {
-          "taskid": 92,
+          "taskid": 69,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -863,27 +679,19 @@
           "deadline": "2022-10-24T02:00:00"
         },
         {
-          "taskid": 93,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-24T02:00:00",
-          "deadline": "2022-10-24T03:00:00"
-        },
-        {
-          "taskid": 94,
+          "taskid": 70,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-24T03:00:00",
-          "deadline": "2022-10-24T08:00:00"
+          "start": "2022-10-24T02:00:00",
+          "deadline": "2022-10-24T07:00:00"
         },
         {
-          "taskid": 95,
+          "taskid": 71,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-24T08:00:00",
+          "duration": 17,
+          "start": "2022-10-24T07:00:00",
           "deadline": "2022-10-25T00:00:00"
         }
       ]
@@ -892,7 +700,7 @@
       "day": "2022-10-25",
       "outputs": [
         {
-          "taskid": 96,
+          "taskid": 72,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -900,27 +708,19 @@
           "deadline": "2022-10-25T02:00:00"
         },
         {
-          "taskid": 97,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-25T02:00:00",
-          "deadline": "2022-10-25T03:00:00"
-        },
-        {
-          "taskid": 98,
+          "taskid": 73,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-25T03:00:00",
-          "deadline": "2022-10-25T08:00:00"
+          "start": "2022-10-25T02:00:00",
+          "deadline": "2022-10-25T07:00:00"
         },
         {
-          "taskid": 99,
+          "taskid": 74,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-25T08:00:00",
+          "duration": 17,
+          "start": "2022-10-25T07:00:00",
           "deadline": "2022-10-26T00:00:00"
         }
       ]
@@ -929,7 +729,7 @@
       "day": "2022-10-26",
       "outputs": [
         {
-          "taskid": 100,
+          "taskid": 75,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -937,27 +737,19 @@
           "deadline": "2022-10-26T02:00:00"
         },
         {
-          "taskid": 101,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-26T02:00:00",
-          "deadline": "2022-10-26T03:00:00"
-        },
-        {
-          "taskid": 102,
+          "taskid": 76,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-26T03:00:00",
-          "deadline": "2022-10-26T08:00:00"
+          "start": "2022-10-26T02:00:00",
+          "deadline": "2022-10-26T07:00:00"
         },
         {
-          "taskid": 103,
+          "taskid": 77,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-26T08:00:00",
+          "duration": 17,
+          "start": "2022-10-26T07:00:00",
           "deadline": "2022-10-27T00:00:00"
         }
       ]
@@ -966,7 +758,7 @@
       "day": "2022-10-27",
       "outputs": [
         {
-          "taskid": 104,
+          "taskid": 78,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -974,27 +766,19 @@
           "deadline": "2022-10-27T02:00:00"
         },
         {
-          "taskid": 105,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-27T02:00:00",
-          "deadline": "2022-10-27T03:00:00"
-        },
-        {
-          "taskid": 106,
+          "taskid": 79,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-27T03:00:00",
-          "deadline": "2022-10-27T08:00:00"
+          "start": "2022-10-27T02:00:00",
+          "deadline": "2022-10-27T07:00:00"
         },
         {
-          "taskid": 107,
+          "taskid": 80,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-27T08:00:00",
+          "duration": 17,
+          "start": "2022-10-27T07:00:00",
           "deadline": "2022-10-28T00:00:00"
         }
       ]
@@ -1003,7 +787,7 @@
       "day": "2022-10-28",
       "outputs": [
         {
-          "taskid": 108,
+          "taskid": 81,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -1011,27 +795,19 @@
           "deadline": "2022-10-28T02:00:00"
         },
         {
-          "taskid": 109,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-28T02:00:00",
-          "deadline": "2022-10-28T03:00:00"
-        },
-        {
-          "taskid": 110,
+          "taskid": 82,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-28T03:00:00",
-          "deadline": "2022-10-28T08:00:00"
+          "start": "2022-10-28T02:00:00",
+          "deadline": "2022-10-28T07:00:00"
         },
         {
-          "taskid": 111,
+          "taskid": 83,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-28T08:00:00",
+          "duration": 17,
+          "start": "2022-10-28T07:00:00",
           "deadline": "2022-10-29T00:00:00"
         }
       ]
@@ -1040,7 +816,7 @@
       "day": "2022-10-29",
       "outputs": [
         {
-          "taskid": 112,
+          "taskid": 84,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -1048,27 +824,19 @@
           "deadline": "2022-10-29T02:00:00"
         },
         {
-          "taskid": 113,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-29T02:00:00",
-          "deadline": "2022-10-29T03:00:00"
-        },
-        {
-          "taskid": 114,
+          "taskid": 85,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-29T03:00:00",
-          "deadline": "2022-10-29T08:00:00"
+          "start": "2022-10-29T02:00:00",
+          "deadline": "2022-10-29T07:00:00"
         },
         {
-          "taskid": 115,
+          "taskid": 86,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-29T08:00:00",
+          "duration": 17,
+          "start": "2022-10-29T07:00:00",
           "deadline": "2022-10-30T00:00:00"
         }
       ]
@@ -1077,7 +845,7 @@
       "day": "2022-10-30",
       "outputs": [
         {
-          "taskid": 116,
+          "taskid": 87,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -1085,27 +853,19 @@
           "deadline": "2022-10-30T02:00:00"
         },
         {
-          "taskid": 117,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-30T02:00:00",
-          "deadline": "2022-10-30T03:00:00"
-        },
-        {
-          "taskid": 118,
+          "taskid": 88,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-30T03:00:00",
-          "deadline": "2022-10-30T08:00:00"
+          "start": "2022-10-30T02:00:00",
+          "deadline": "2022-10-30T07:00:00"
         },
         {
-          "taskid": 119,
+          "taskid": 89,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-30T08:00:00",
+          "duration": 17,
+          "start": "2022-10-30T07:00:00",
           "deadline": "2022-10-31T00:00:00"
         }
       ]
@@ -1114,7 +874,7 @@
       "day": "2022-10-31",
       "outputs": [
         {
-          "taskid": 120,
+          "taskid": 90,
           "goalid": "2",
           "title": "learn rust",
           "duration": 2,
@@ -1122,27 +882,19 @@
           "deadline": "2022-10-31T02:00:00"
         },
         {
-          "taskid": 121,
-          "goalid": "free",
-          "title": "free",
-          "duration": 1,
-          "start": "2022-10-31T02:00:00",
-          "deadline": "2022-10-31T03:00:00"
-        },
-        {
-          "taskid": 122,
+          "taskid": 91,
           "goalid": "1",
           "title": "work",
           "duration": 5,
-          "start": "2022-10-31T03:00:00",
-          "deadline": "2022-10-31T08:00:00"
+          "start": "2022-10-31T02:00:00",
+          "deadline": "2022-10-31T07:00:00"
         },
         {
-          "taskid": 123,
+          "taskid": 92,
           "goalid": "free",
           "title": "free",
-          "duration": 16,
-          "start": "2022-10-31T08:00:00",
+          "duration": 17,
+          "start": "2022-10-31T07:00:00",
           "deadline": "2022-11-01T00:00:00"
         }
       ]

--- a/tests/jsons/impossible-2/actual_output.json
+++ b/tests/jsons/impossible-2/actual_output.json
@@ -21,14 +21,6 @@
         },
         {
           "taskid": 2,
-          "goalid": "2",
-          "title": "gym",
-          "duration": 1,
-          "start": "2022-11-28T09:00:00",
-          "deadline": "2022-11-28T10:00:00"
-        },
-        {
-          "taskid": 3,
           "goalid": "free",
           "title": "free",
           "duration": 6,
@@ -41,7 +33,7 @@
       "day": "2022-11-29",
       "outputs": [
         {
-          "taskid": 4,
+          "taskid": 3,
           "goalid": "free",
           "title": "free",
           "duration": 9,
@@ -49,7 +41,7 @@
           "deadline": "2022-11-29T09:00:00"
         },
         {
-          "taskid": 5,
+          "taskid": 4,
           "goalid": "1",
           "title": "work",
           "duration": 9,
@@ -57,15 +49,7 @@
           "deadline": "2022-11-29T18:00:00"
         },
         {
-          "taskid": 6,
-          "goalid": "2",
-          "title": "gym",
-          "duration": 1,
-          "start": "2022-11-29T09:00:00",
-          "deadline": "2022-11-29T10:00:00"
-        },
-        {
-          "taskid": 7,
+          "taskid": 5,
           "goalid": "free",
           "title": "free",
           "duration": 6,
@@ -78,7 +62,7 @@
       "day": "2022-11-30",
       "outputs": [
         {
-          "taskid": 8,
+          "taskid": 6,
           "goalid": "free",
           "title": "free",
           "duration": 9,
@@ -86,7 +70,7 @@
           "deadline": "2022-11-30T09:00:00"
         },
         {
-          "taskid": 9,
+          "taskid": 7,
           "goalid": "1",
           "title": "work",
           "duration": 9,
@@ -94,15 +78,7 @@
           "deadline": "2022-11-30T18:00:00"
         },
         {
-          "taskid": 10,
-          "goalid": "2",
-          "title": "gym",
-          "duration": 1,
-          "start": "2022-11-30T09:00:00",
-          "deadline": "2022-11-30T10:00:00"
-        },
-        {
-          "taskid": 11,
+          "taskid": 8,
           "goalid": "free",
           "title": "free",
           "duration": 6,
@@ -115,7 +91,7 @@
       "day": "2022-12-01",
       "outputs": [
         {
-          "taskid": 12,
+          "taskid": 9,
           "goalid": "free",
           "title": "free",
           "duration": 9,
@@ -123,7 +99,7 @@
           "deadline": "2022-12-01T09:00:00"
         },
         {
-          "taskid": 13,
+          "taskid": 10,
           "goalid": "1",
           "title": "work",
           "duration": 9,
@@ -131,15 +107,7 @@
           "deadline": "2022-12-01T18:00:00"
         },
         {
-          "taskid": 14,
-          "goalid": "2",
-          "title": "gym",
-          "duration": 1,
-          "start": "2022-12-01T09:00:00",
-          "deadline": "2022-12-01T10:00:00"
-        },
-        {
-          "taskid": 15,
+          "taskid": 11,
           "goalid": "free",
           "title": "free",
           "duration": 6,
@@ -152,7 +120,7 @@
       "day": "2022-12-02",
       "outputs": [
         {
-          "taskid": 16,
+          "taskid": 12,
           "goalid": "free",
           "title": "free",
           "duration": 9,
@@ -160,7 +128,7 @@
           "deadline": "2022-12-02T09:00:00"
         },
         {
-          "taskid": 17,
+          "taskid": 13,
           "goalid": "1",
           "title": "work",
           "duration": 9,
@@ -168,15 +136,7 @@
           "deadline": "2022-12-02T18:00:00"
         },
         {
-          "taskid": 18,
-          "goalid": "2",
-          "title": "gym",
-          "duration": 1,
-          "start": "2022-12-02T09:00:00",
-          "deadline": "2022-12-02T10:00:00"
-        },
-        {
-          "taskid": 19,
+          "taskid": 14,
           "goalid": "free",
           "title": "free",
           "duration": 6,
@@ -189,7 +149,7 @@
       "day": "2022-12-03",
       "outputs": [
         {
-          "taskid": 20,
+          "taskid": 15,
           "goalid": "free",
           "title": "free",
           "duration": 9,
@@ -197,15 +157,7 @@
           "deadline": "2022-12-03T09:00:00"
         },
         {
-          "taskid": 21,
-          "goalid": "2",
-          "title": "gym",
-          "duration": 1,
-          "start": "2022-12-03T09:00:00",
-          "deadline": "2022-12-03T10:00:00"
-        },
-        {
-          "taskid": 22,
+          "taskid": 16,
           "goalid": "1",
           "title": "work",
           "duration": 9,
@@ -213,7 +165,7 @@
           "deadline": "2022-12-03T18:00:00"
         },
         {
-          "taskid": 23,
+          "taskid": 17,
           "goalid": "free",
           "title": "free",
           "duration": 6,
@@ -226,27 +178,11 @@
       "day": "2022-12-04",
       "outputs": [
         {
-          "taskid": 24,
+          "taskid": 18,
           "goalid": "free",
           "title": "free",
-          "duration": 9,
+          "duration": 24,
           "start": "2022-12-04T00:00:00",
-          "deadline": "2022-12-04T09:00:00"
-        },
-        {
-          "taskid": 25,
-          "goalid": "2",
-          "title": "gym",
-          "duration": 1,
-          "start": "2022-12-04T09:00:00",
-          "deadline": "2022-12-04T10:00:00"
-        },
-        {
-          "taskid": 26,
-          "goalid": "free",
-          "title": "free",
-          "duration": 14,
-          "start": "2022-12-04T10:00:00",
           "deadline": "2022-12-05T00:00:00"
         }
       ]
@@ -255,7 +191,64 @@
   "impossible": [
     {
       "day": "2022-11-28",
-      "outputs": []
+      "outputs": [
+        {
+          "taskid": 19,
+          "goalid": "2",
+          "title": "gym",
+          "duration": 1,
+          "start": "2022-11-28T00:00:00",
+          "deadline": "2022-12-05T00:00:00"
+        },
+        {
+          "taskid": 20,
+          "goalid": "2",
+          "title": "gym",
+          "duration": 1,
+          "start": "2022-11-28T00:00:00",
+          "deadline": "2022-12-05T00:00:00"
+        },
+        {
+          "taskid": 21,
+          "goalid": "2",
+          "title": "gym",
+          "duration": 1,
+          "start": "2022-11-28T00:00:00",
+          "deadline": "2022-12-05T00:00:00"
+        },
+        {
+          "taskid": 22,
+          "goalid": "2",
+          "title": "gym",
+          "duration": 1,
+          "start": "2022-11-28T00:00:00",
+          "deadline": "2022-12-05T00:00:00"
+        },
+        {
+          "taskid": 23,
+          "goalid": "2",
+          "title": "gym",
+          "duration": 1,
+          "start": "2022-11-28T00:00:00",
+          "deadline": "2022-12-05T00:00:00"
+        },
+        {
+          "taskid": 24,
+          "goalid": "2",
+          "title": "gym",
+          "duration": 1,
+          "start": "2022-11-28T00:00:00",
+          "deadline": "2022-12-05T00:00:00"
+        },
+        {
+          "taskid": 25,
+          "goalid": "2",
+          "title": "gym",
+          "duration": 1,
+          "start": "2022-11-28T00:00:00",
+          "deadline": "2022-12-05T00:00:00"
+        }
+      ]
     },
     {
       "day": "2022-11-29",

--- a/tests/jsons/impossible-2/actual_output.json
+++ b/tests/jsons/impossible-2/actual_output.json
@@ -181,8 +181,24 @@
           "taskid": 18,
           "goalid": "free",
           "title": "free",
-          "duration": 24,
+          "duration": 10,
           "start": "2022-12-04T00:00:00",
+          "deadline": "2022-12-04T10:00:00"
+        },
+        {
+          "taskid": 19,
+          "goalid": "2",
+          "title": "gym",
+          "duration": 1,
+          "start": "2022-12-04T10:00:00",
+          "deadline": "2022-12-04T11:00:00"
+        },
+        {
+          "taskid": 20,
+          "goalid": "free",
+          "title": "free",
+          "duration": 13,
+          "start": "2022-12-04T11:00:00",
           "deadline": "2022-12-05T00:00:00"
         }
       ]
@@ -192,22 +208,6 @@
     {
       "day": "2022-11-28",
       "outputs": [
-        {
-          "taskid": 19,
-          "goalid": "2",
-          "title": "gym",
-          "duration": 1,
-          "start": "2022-11-28T00:00:00",
-          "deadline": "2022-12-05T00:00:00"
-        },
-        {
-          "taskid": 20,
-          "goalid": "2",
-          "title": "gym",
-          "duration": 1,
-          "start": "2022-11-28T00:00:00",
-          "deadline": "2022-12-05T00:00:00"
-        },
         {
           "taskid": 21,
           "goalid": "2",
@@ -242,6 +242,14 @@
         },
         {
           "taskid": 25,
+          "goalid": "2",
+          "title": "gym",
+          "duration": 1,
+          "start": "2022-11-28T00:00:00",
+          "deadline": "2022-12-05T00:00:00"
+        },
+        {
+          "taskid": 26,
           "goalid": "2",
           "title": "gym",
           "duration": 1,

--- a/tests/jsons/realistic-schedule-1/actual_output.json
+++ b/tests/jsons/realistic-schedule-1/actual_output.json
@@ -45,26 +45,34 @@
         },
         {
           "taskid": 5,
-          "goalid": "free",
-          "title": "free",
-          "duration": 4,
+          "goalid": "1",
+          "title": "walk",
+          "duration": 1,
           "start": "2022-09-01T17:00:00",
-          "deadline": "2022-09-01T21:00:00"
+          "deadline": "2022-09-01T18:00:00"
         },
         {
           "taskid": 6,
-          "goalid": "2",
-          "title": "read",
+          "goalid": "free",
+          "title": "free",
           "duration": 1,
-          "start": "2022-09-01T21:00:00",
-          "deadline": "2022-09-01T22:00:00"
+          "start": "2022-09-01T18:00:00",
+          "deadline": "2022-09-01T19:00:00"
         },
         {
           "taskid": 7,
+          "goalid": "2",
+          "title": "read",
+          "duration": 1,
+          "start": "2022-09-01T19:00:00",
+          "deadline": "2022-09-01T20:00:00"
+        },
+        {
+          "taskid": 8,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
-          "start": "2022-09-01T22:00:00",
+          "duration": 4,
+          "start": "2022-09-01T20:00:00",
           "deadline": "2022-09-02T00:00:00"
         }
       ]
@@ -73,7 +81,7 @@
       "day": "2022-09-02",
       "outputs": [
         {
-          "taskid": 8,
+          "taskid": 9,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -81,7 +89,7 @@
           "deadline": "2022-09-02T05:00:00"
         },
         {
-          "taskid": 9,
+          "taskid": 10,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -89,7 +97,7 @@
           "deadline": "2022-09-02T07:00:00"
         },
         {
-          "taskid": 10,
+          "taskid": 11,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -97,7 +105,7 @@
           "deadline": "2022-09-02T09:00:00"
         },
         {
-          "taskid": 11,
+          "taskid": 12,
           "goalid": "5",
           "title": "work",
           "duration": 8,
@@ -105,27 +113,35 @@
           "deadline": "2022-09-02T17:00:00"
         },
         {
-          "taskid": 12,
-          "goalid": "free",
-          "title": "free",
-          "duration": 4,
-          "start": "2022-09-02T17:00:00",
-          "deadline": "2022-09-02T21:00:00"
-        },
-        {
           "taskid": 13,
-          "goalid": "2",
-          "title": "read",
+          "goalid": "1",
+          "title": "walk",
           "duration": 1,
-          "start": "2022-09-02T21:00:00",
-          "deadline": "2022-09-02T22:00:00"
+          "start": "2022-09-02T17:00:00",
+          "deadline": "2022-09-02T18:00:00"
         },
         {
           "taskid": 14,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
-          "start": "2022-09-02T22:00:00",
+          "duration": 1,
+          "start": "2022-09-02T18:00:00",
+          "deadline": "2022-09-02T19:00:00"
+        },
+        {
+          "taskid": 15,
+          "goalid": "2",
+          "title": "read",
+          "duration": 1,
+          "start": "2022-09-02T19:00:00",
+          "deadline": "2022-09-02T20:00:00"
+        },
+        {
+          "taskid": 16,
+          "goalid": "free",
+          "title": "free",
+          "duration": 4,
+          "start": "2022-09-02T20:00:00",
           "deadline": "2022-09-03T00:00:00"
         }
       ]
@@ -134,7 +150,7 @@
       "day": "2022-09-03",
       "outputs": [
         {
-          "taskid": 15,
+          "taskid": 17,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -142,7 +158,7 @@
           "deadline": "2022-09-03T05:00:00"
         },
         {
-          "taskid": 16,
+          "taskid": 18,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -150,7 +166,7 @@
           "deadline": "2022-09-03T07:00:00"
         },
         {
-          "taskid": 17,
+          "taskid": 19,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -158,7 +174,7 @@
           "deadline": "2022-09-03T09:00:00"
         },
         {
-          "taskid": 18,
+          "taskid": 20,
           "goalid": "5",
           "title": "work",
           "duration": 8,
@@ -166,27 +182,35 @@
           "deadline": "2022-09-03T17:00:00"
         },
         {
-          "taskid": 19,
-          "goalid": "free",
-          "title": "free",
-          "duration": 4,
+          "taskid": 21,
+          "goalid": "1",
+          "title": "walk",
+          "duration": 1,
           "start": "2022-09-03T17:00:00",
-          "deadline": "2022-09-03T21:00:00"
+          "deadline": "2022-09-03T18:00:00"
         },
         {
-          "taskid": 20,
+          "taskid": 22,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-09-03T18:00:00",
+          "deadline": "2022-09-03T19:00:00"
+        },
+        {
+          "taskid": 23,
           "goalid": "2",
           "title": "read",
           "duration": 1,
-          "start": "2022-09-03T21:00:00",
-          "deadline": "2022-09-03T22:00:00"
+          "start": "2022-09-03T19:00:00",
+          "deadline": "2022-09-03T20:00:00"
         },
         {
-          "taskid": 21,
+          "taskid": 24,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
-          "start": "2022-09-03T22:00:00",
+          "duration": 4,
+          "start": "2022-09-03T20:00:00",
           "deadline": "2022-09-04T00:00:00"
         }
       ]
@@ -195,7 +219,7 @@
       "day": "2022-09-04",
       "outputs": [
         {
-          "taskid": 22,
+          "taskid": 25,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -203,7 +227,7 @@
           "deadline": "2022-09-04T05:00:00"
         },
         {
-          "taskid": 23,
+          "taskid": 26,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -211,7 +235,7 @@
           "deadline": "2022-09-04T07:00:00"
         },
         {
-          "taskid": 24,
+          "taskid": 27,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -219,7 +243,7 @@
           "deadline": "2022-09-04T09:00:00"
         },
         {
-          "taskid": 25,
+          "taskid": 28,
           "goalid": "5",
           "title": "work",
           "duration": 8,
@@ -227,27 +251,35 @@
           "deadline": "2022-09-04T17:00:00"
         },
         {
-          "taskid": 26,
-          "goalid": "free",
-          "title": "free",
-          "duration": 4,
+          "taskid": 29,
+          "goalid": "1",
+          "title": "walk",
+          "duration": 1,
           "start": "2022-09-04T17:00:00",
-          "deadline": "2022-09-04T21:00:00"
+          "deadline": "2022-09-04T18:00:00"
         },
         {
-          "taskid": 27,
+          "taskid": 30,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-09-04T18:00:00",
+          "deadline": "2022-09-04T19:00:00"
+        },
+        {
+          "taskid": 31,
           "goalid": "2",
           "title": "read",
           "duration": 1,
-          "start": "2022-09-04T21:00:00",
-          "deadline": "2022-09-04T22:00:00"
+          "start": "2022-09-04T19:00:00",
+          "deadline": "2022-09-04T20:00:00"
         },
         {
-          "taskid": 28,
+          "taskid": 32,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
-          "start": "2022-09-04T22:00:00",
+          "duration": 4,
+          "start": "2022-09-04T20:00:00",
           "deadline": "2022-09-05T00:00:00"
         }
       ]
@@ -256,7 +288,7 @@
       "day": "2022-09-05",
       "outputs": [
         {
-          "taskid": 29,
+          "taskid": 33,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -264,7 +296,7 @@
           "deadline": "2022-09-05T05:00:00"
         },
         {
-          "taskid": 30,
+          "taskid": 34,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -272,7 +304,7 @@
           "deadline": "2022-09-05T07:00:00"
         },
         {
-          "taskid": 31,
+          "taskid": 35,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -280,7 +312,7 @@
           "deadline": "2022-09-05T09:00:00"
         },
         {
-          "taskid": 32,
+          "taskid": 36,
           "goalid": "5",
           "title": "work",
           "duration": 8,
@@ -288,27 +320,35 @@
           "deadline": "2022-09-05T17:00:00"
         },
         {
-          "taskid": 33,
-          "goalid": "free",
-          "title": "free",
-          "duration": 4,
+          "taskid": 37,
+          "goalid": "1",
+          "title": "walk",
+          "duration": 1,
           "start": "2022-09-05T17:00:00",
-          "deadline": "2022-09-05T21:00:00"
+          "deadline": "2022-09-05T18:00:00"
         },
         {
-          "taskid": 34,
+          "taskid": 38,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-09-05T18:00:00",
+          "deadline": "2022-09-05T19:00:00"
+        },
+        {
+          "taskid": 39,
           "goalid": "2",
           "title": "read",
           "duration": 1,
-          "start": "2022-09-05T21:00:00",
-          "deadline": "2022-09-05T22:00:00"
+          "start": "2022-09-05T19:00:00",
+          "deadline": "2022-09-05T20:00:00"
         },
         {
-          "taskid": 35,
+          "taskid": 40,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
-          "start": "2022-09-05T22:00:00",
+          "duration": 4,
+          "start": "2022-09-05T20:00:00",
           "deadline": "2022-09-06T00:00:00"
         }
       ]
@@ -317,7 +357,7 @@
       "day": "2022-09-06",
       "outputs": [
         {
-          "taskid": 36,
+          "taskid": 41,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -325,7 +365,7 @@
           "deadline": "2022-09-06T05:00:00"
         },
         {
-          "taskid": 37,
+          "taskid": 42,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -333,7 +373,7 @@
           "deadline": "2022-09-06T07:00:00"
         },
         {
-          "taskid": 38,
+          "taskid": 43,
           "goalid": "free",
           "title": "free",
           "duration": 2,
@@ -341,7 +381,7 @@
           "deadline": "2022-09-06T09:00:00"
         },
         {
-          "taskid": 39,
+          "taskid": 44,
           "goalid": "5",
           "title": "work",
           "duration": 8,
@@ -349,27 +389,35 @@
           "deadline": "2022-09-06T17:00:00"
         },
         {
-          "taskid": 40,
-          "goalid": "free",
-          "title": "free",
-          "duration": 4,
+          "taskid": 45,
+          "goalid": "1",
+          "title": "walk",
+          "duration": 1,
           "start": "2022-09-06T17:00:00",
-          "deadline": "2022-09-06T21:00:00"
+          "deadline": "2022-09-06T18:00:00"
         },
         {
-          "taskid": 41,
+          "taskid": 46,
+          "goalid": "free",
+          "title": "free",
+          "duration": 1,
+          "start": "2022-09-06T18:00:00",
+          "deadline": "2022-09-06T19:00:00"
+        },
+        {
+          "taskid": 47,
           "goalid": "2",
           "title": "read",
           "duration": 1,
-          "start": "2022-09-06T21:00:00",
-          "deadline": "2022-09-06T22:00:00"
+          "start": "2022-09-06T19:00:00",
+          "deadline": "2022-09-06T20:00:00"
         },
         {
-          "taskid": 42,
+          "taskid": 48,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
-          "start": "2022-09-06T22:00:00",
+          "duration": 4,
+          "start": "2022-09-06T20:00:00",
           "deadline": "2022-09-07T00:00:00"
         }
       ]
@@ -378,7 +426,7 @@
       "day": "2022-09-07",
       "outputs": [
         {
-          "taskid": 43,
+          "taskid": 49,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -386,7 +434,7 @@
           "deadline": "2022-09-07T05:00:00"
         },
         {
-          "taskid": 44,
+          "taskid": 50,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -394,7 +442,7 @@
           "deadline": "2022-09-07T07:00:00"
         },
         {
-          "taskid": 45,
+          "taskid": 51,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -402,7 +450,7 @@
           "deadline": "2022-09-07T12:00:00"
         },
         {
-          "taskid": 46,
+          "taskid": 52,
           "goalid": "3",
           "title": "piano practice",
           "duration": 2,
@@ -410,7 +458,7 @@
           "deadline": "2022-09-07T14:00:00"
         },
         {
-          "taskid": 47,
+          "taskid": 53,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -418,7 +466,7 @@
           "deadline": "2022-09-07T17:00:00"
         },
         {
-          "taskid": 48,
+          "taskid": 54,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -426,7 +474,7 @@
           "deadline": "2022-09-07T18:00:00"
         },
         {
-          "taskid": 49,
+          "taskid": 55,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -434,7 +482,7 @@
           "deadline": "2022-09-07T19:00:00"
         },
         {
-          "taskid": 50,
+          "taskid": 56,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -442,7 +490,7 @@
           "deadline": "2022-09-07T20:00:00"
         },
         {
-          "taskid": 51,
+          "taskid": 57,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -455,7 +503,7 @@
       "day": "2022-09-08",
       "outputs": [
         {
-          "taskid": 52,
+          "taskid": 58,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -463,7 +511,7 @@
           "deadline": "2022-09-08T05:00:00"
         },
         {
-          "taskid": 53,
+          "taskid": 59,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -471,7 +519,7 @@
           "deadline": "2022-09-08T07:00:00"
         },
         {
-          "taskid": 54,
+          "taskid": 60,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -479,7 +527,7 @@
           "deadline": "2022-09-08T17:00:00"
         },
         {
-          "taskid": 55,
+          "taskid": 61,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -487,7 +535,7 @@
           "deadline": "2022-09-08T18:00:00"
         },
         {
-          "taskid": 56,
+          "taskid": 62,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -495,7 +543,7 @@
           "deadline": "2022-09-08T19:00:00"
         },
         {
-          "taskid": 57,
+          "taskid": 63,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -503,7 +551,7 @@
           "deadline": "2022-09-08T20:00:00"
         },
         {
-          "taskid": 58,
+          "taskid": 64,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -516,7 +564,7 @@
       "day": "2022-09-09",
       "outputs": [
         {
-          "taskid": 59,
+          "taskid": 65,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -524,7 +572,7 @@
           "deadline": "2022-09-09T05:00:00"
         },
         {
-          "taskid": 60,
+          "taskid": 66,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -532,7 +580,7 @@
           "deadline": "2022-09-09T07:00:00"
         },
         {
-          "taskid": 61,
+          "taskid": 67,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -540,7 +588,7 @@
           "deadline": "2022-09-09T17:00:00"
         },
         {
-          "taskid": 62,
+          "taskid": 68,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -548,7 +596,7 @@
           "deadline": "2022-09-09T18:00:00"
         },
         {
-          "taskid": 63,
+          "taskid": 69,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -556,7 +604,7 @@
           "deadline": "2022-09-09T19:00:00"
         },
         {
-          "taskid": 64,
+          "taskid": 70,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -564,7 +612,7 @@
           "deadline": "2022-09-09T20:00:00"
         },
         {
-          "taskid": 65,
+          "taskid": 71,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -577,7 +625,7 @@
       "day": "2022-09-10",
       "outputs": [
         {
-          "taskid": 66,
+          "taskid": 72,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -585,7 +633,7 @@
           "deadline": "2022-09-10T05:00:00"
         },
         {
-          "taskid": 67,
+          "taskid": 73,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -593,7 +641,7 @@
           "deadline": "2022-09-10T07:00:00"
         },
         {
-          "taskid": 68,
+          "taskid": 74,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -601,7 +649,7 @@
           "deadline": "2022-09-10T12:00:00"
         },
         {
-          "taskid": 69,
+          "taskid": 75,
           "goalid": "7",
           "title": "shopping",
           "duration": 2,
@@ -609,7 +657,7 @@
           "deadline": "2022-09-10T14:00:00"
         },
         {
-          "taskid": 70,
+          "taskid": 76,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -617,7 +665,7 @@
           "deadline": "2022-09-10T17:00:00"
         },
         {
-          "taskid": 71,
+          "taskid": 77,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -625,7 +673,7 @@
           "deadline": "2022-09-10T18:00:00"
         },
         {
-          "taskid": 72,
+          "taskid": 78,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -633,7 +681,7 @@
           "deadline": "2022-09-10T19:00:00"
         },
         {
-          "taskid": 73,
+          "taskid": 79,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -641,7 +689,7 @@
           "deadline": "2022-09-10T20:00:00"
         },
         {
-          "taskid": 74,
+          "taskid": 80,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -654,7 +702,7 @@
       "day": "2022-09-11",
       "outputs": [
         {
-          "taskid": 75,
+          "taskid": 81,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -662,7 +710,7 @@
           "deadline": "2022-09-11T05:00:00"
         },
         {
-          "taskid": 76,
+          "taskid": 82,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -670,7 +718,7 @@
           "deadline": "2022-09-11T07:00:00"
         },
         {
-          "taskid": 77,
+          "taskid": 83,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -678,7 +726,7 @@
           "deadline": "2022-09-11T17:00:00"
         },
         {
-          "taskid": 78,
+          "taskid": 84,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -686,7 +734,7 @@
           "deadline": "2022-09-11T18:00:00"
         },
         {
-          "taskid": 79,
+          "taskid": 85,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -694,7 +742,7 @@
           "deadline": "2022-09-11T19:00:00"
         },
         {
-          "taskid": 80,
+          "taskid": 86,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -702,7 +750,7 @@
           "deadline": "2022-09-11T20:00:00"
         },
         {
-          "taskid": 81,
+          "taskid": 87,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -715,7 +763,7 @@
       "day": "2022-09-12",
       "outputs": [
         {
-          "taskid": 82,
+          "taskid": 88,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -723,7 +771,7 @@
           "deadline": "2022-09-12T05:00:00"
         },
         {
-          "taskid": 83,
+          "taskid": 89,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -731,7 +779,7 @@
           "deadline": "2022-09-12T07:00:00"
         },
         {
-          "taskid": 84,
+          "taskid": 90,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -739,7 +787,7 @@
           "deadline": "2022-09-12T17:00:00"
         },
         {
-          "taskid": 85,
+          "taskid": 91,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -747,7 +795,7 @@
           "deadline": "2022-09-12T18:00:00"
         },
         {
-          "taskid": 86,
+          "taskid": 92,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -755,7 +803,7 @@
           "deadline": "2022-09-12T19:00:00"
         },
         {
-          "taskid": 87,
+          "taskid": 93,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -763,7 +811,7 @@
           "deadline": "2022-09-12T20:00:00"
         },
         {
-          "taskid": 88,
+          "taskid": 94,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -776,7 +824,7 @@
       "day": "2022-09-13",
       "outputs": [
         {
-          "taskid": 89,
+          "taskid": 95,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -784,7 +832,7 @@
           "deadline": "2022-09-13T05:00:00"
         },
         {
-          "taskid": 90,
+          "taskid": 96,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -792,7 +840,7 @@
           "deadline": "2022-09-13T07:00:00"
         },
         {
-          "taskid": 91,
+          "taskid": 97,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -800,7 +848,7 @@
           "deadline": "2022-09-13T17:00:00"
         },
         {
-          "taskid": 92,
+          "taskid": 98,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -808,7 +856,7 @@
           "deadline": "2022-09-13T18:00:00"
         },
         {
-          "taskid": 93,
+          "taskid": 99,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -816,7 +864,7 @@
           "deadline": "2022-09-13T19:00:00"
         },
         {
-          "taskid": 94,
+          "taskid": 100,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -824,7 +872,7 @@
           "deadline": "2022-09-13T20:00:00"
         },
         {
-          "taskid": 95,
+          "taskid": 101,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -837,7 +885,7 @@
       "day": "2022-09-14",
       "outputs": [
         {
-          "taskid": 96,
+          "taskid": 102,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -845,7 +893,7 @@
           "deadline": "2022-09-14T05:00:00"
         },
         {
-          "taskid": 97,
+          "taskid": 103,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -853,7 +901,7 @@
           "deadline": "2022-09-14T07:00:00"
         },
         {
-          "taskid": 98,
+          "taskid": 104,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -861,7 +909,7 @@
           "deadline": "2022-09-14T10:00:00"
         },
         {
-          "taskid": 99,
+          "taskid": 105,
           "goalid": "6",
           "title": "dentist",
           "duration": 1,
@@ -869,7 +917,7 @@
           "deadline": "2022-09-14T11:00:00"
         },
         {
-          "taskid": 100,
+          "taskid": 106,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -877,7 +925,7 @@
           "deadline": "2022-09-14T12:00:00"
         },
         {
-          "taskid": 101,
+          "taskid": 107,
           "goalid": "3",
           "title": "piano practice",
           "duration": 2,
@@ -885,7 +933,7 @@
           "deadline": "2022-09-14T14:00:00"
         },
         {
-          "taskid": 102,
+          "taskid": 108,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -893,7 +941,7 @@
           "deadline": "2022-09-14T17:00:00"
         },
         {
-          "taskid": 103,
+          "taskid": 109,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -901,7 +949,7 @@
           "deadline": "2022-09-14T18:00:00"
         },
         {
-          "taskid": 104,
+          "taskid": 110,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -909,7 +957,7 @@
           "deadline": "2022-09-14T19:00:00"
         },
         {
-          "taskid": 105,
+          "taskid": 111,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -917,7 +965,7 @@
           "deadline": "2022-09-14T20:00:00"
         },
         {
-          "taskid": 106,
+          "taskid": 112,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -930,7 +978,7 @@
       "day": "2022-09-15",
       "outputs": [
         {
-          "taskid": 107,
+          "taskid": 113,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -938,7 +986,7 @@
           "deadline": "2022-09-15T05:00:00"
         },
         {
-          "taskid": 108,
+          "taskid": 114,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -946,7 +994,7 @@
           "deadline": "2022-09-15T07:00:00"
         },
         {
-          "taskid": 109,
+          "taskid": 115,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -954,7 +1002,7 @@
           "deadline": "2022-09-15T17:00:00"
         },
         {
-          "taskid": 110,
+          "taskid": 116,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -962,7 +1010,7 @@
           "deadline": "2022-09-15T18:00:00"
         },
         {
-          "taskid": 111,
+          "taskid": 117,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -970,7 +1018,7 @@
           "deadline": "2022-09-15T19:00:00"
         },
         {
-          "taskid": 112,
+          "taskid": 118,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -978,7 +1026,7 @@
           "deadline": "2022-09-15T20:00:00"
         },
         {
-          "taskid": 113,
+          "taskid": 119,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -991,7 +1039,7 @@
       "day": "2022-09-16",
       "outputs": [
         {
-          "taskid": 114,
+          "taskid": 120,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -999,7 +1047,7 @@
           "deadline": "2022-09-16T05:00:00"
         },
         {
-          "taskid": 115,
+          "taskid": 121,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1007,7 +1055,7 @@
           "deadline": "2022-09-16T07:00:00"
         },
         {
-          "taskid": 116,
+          "taskid": 122,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -1015,7 +1063,7 @@
           "deadline": "2022-09-16T17:00:00"
         },
         {
-          "taskid": 117,
+          "taskid": 123,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1023,7 +1071,7 @@
           "deadline": "2022-09-16T18:00:00"
         },
         {
-          "taskid": 118,
+          "taskid": 124,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1031,7 +1079,7 @@
           "deadline": "2022-09-16T19:00:00"
         },
         {
-          "taskid": 119,
+          "taskid": 125,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1039,7 +1087,7 @@
           "deadline": "2022-09-16T20:00:00"
         },
         {
-          "taskid": 120,
+          "taskid": 126,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1052,7 +1100,7 @@
       "day": "2022-09-17",
       "outputs": [
         {
-          "taskid": 121,
+          "taskid": 127,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1060,7 +1108,7 @@
           "deadline": "2022-09-17T05:00:00"
         },
         {
-          "taskid": 122,
+          "taskid": 128,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1068,7 +1116,7 @@
           "deadline": "2022-09-17T07:00:00"
         },
         {
-          "taskid": 123,
+          "taskid": 129,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -1076,7 +1124,7 @@
           "deadline": "2022-09-17T17:00:00"
         },
         {
-          "taskid": 124,
+          "taskid": 130,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1084,7 +1132,7 @@
           "deadline": "2022-09-17T18:00:00"
         },
         {
-          "taskid": 125,
+          "taskid": 131,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1092,7 +1140,7 @@
           "deadline": "2022-09-17T19:00:00"
         },
         {
-          "taskid": 126,
+          "taskid": 132,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1100,7 +1148,7 @@
           "deadline": "2022-09-17T20:00:00"
         },
         {
-          "taskid": 127,
+          "taskid": 133,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1113,7 +1161,7 @@
       "day": "2022-09-18",
       "outputs": [
         {
-          "taskid": 128,
+          "taskid": 134,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1121,7 +1169,7 @@
           "deadline": "2022-09-18T05:00:00"
         },
         {
-          "taskid": 129,
+          "taskid": 135,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1129,7 +1177,7 @@
           "deadline": "2022-09-18T07:00:00"
         },
         {
-          "taskid": 130,
+          "taskid": 136,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -1137,7 +1185,7 @@
           "deadline": "2022-09-18T17:00:00"
         },
         {
-          "taskid": 131,
+          "taskid": 137,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1145,7 +1193,7 @@
           "deadline": "2022-09-18T18:00:00"
         },
         {
-          "taskid": 132,
+          "taskid": 138,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1153,7 +1201,7 @@
           "deadline": "2022-09-18T19:00:00"
         },
         {
-          "taskid": 133,
+          "taskid": 139,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1161,7 +1209,7 @@
           "deadline": "2022-09-18T20:00:00"
         },
         {
-          "taskid": 134,
+          "taskid": 140,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1174,7 +1222,7 @@
       "day": "2022-09-19",
       "outputs": [
         {
-          "taskid": 135,
+          "taskid": 141,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1182,7 +1230,7 @@
           "deadline": "2022-09-19T05:00:00"
         },
         {
-          "taskid": 136,
+          "taskid": 142,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1190,7 +1238,7 @@
           "deadline": "2022-09-19T07:00:00"
         },
         {
-          "taskid": 137,
+          "taskid": 143,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -1198,7 +1246,7 @@
           "deadline": "2022-09-19T17:00:00"
         },
         {
-          "taskid": 138,
+          "taskid": 144,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1206,7 +1254,7 @@
           "deadline": "2022-09-19T18:00:00"
         },
         {
-          "taskid": 139,
+          "taskid": 145,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1214,7 +1262,7 @@
           "deadline": "2022-09-19T19:00:00"
         },
         {
-          "taskid": 140,
+          "taskid": 146,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1222,7 +1270,7 @@
           "deadline": "2022-09-19T20:00:00"
         },
         {
-          "taskid": 141,
+          "taskid": 147,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1235,7 +1283,7 @@
       "day": "2022-09-20",
       "outputs": [
         {
-          "taskid": 142,
+          "taskid": 148,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1243,7 +1291,7 @@
           "deadline": "2022-09-20T05:00:00"
         },
         {
-          "taskid": 143,
+          "taskid": 149,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1251,7 +1299,7 @@
           "deadline": "2022-09-20T07:00:00"
         },
         {
-          "taskid": 144,
+          "taskid": 150,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -1259,7 +1307,7 @@
           "deadline": "2022-09-20T17:00:00"
         },
         {
-          "taskid": 145,
+          "taskid": 151,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1267,7 +1315,7 @@
           "deadline": "2022-09-20T18:00:00"
         },
         {
-          "taskid": 146,
+          "taskid": 152,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1275,7 +1323,7 @@
           "deadline": "2022-09-20T19:00:00"
         },
         {
-          "taskid": 147,
+          "taskid": 153,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1283,7 +1331,7 @@
           "deadline": "2022-09-20T20:00:00"
         },
         {
-          "taskid": 148,
+          "taskid": 154,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1296,7 +1344,7 @@
       "day": "2022-09-21",
       "outputs": [
         {
-          "taskid": 149,
+          "taskid": 155,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1304,7 +1352,7 @@
           "deadline": "2022-09-21T05:00:00"
         },
         {
-          "taskid": 150,
+          "taskid": 156,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1312,7 +1360,7 @@
           "deadline": "2022-09-21T07:00:00"
         },
         {
-          "taskid": 151,
+          "taskid": 157,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1320,7 +1368,7 @@
           "deadline": "2022-09-21T12:00:00"
         },
         {
-          "taskid": 152,
+          "taskid": 158,
           "goalid": "3",
           "title": "piano practice",
           "duration": 2,
@@ -1328,7 +1376,7 @@
           "deadline": "2022-09-21T14:00:00"
         },
         {
-          "taskid": 153,
+          "taskid": 159,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -1336,7 +1384,7 @@
           "deadline": "2022-09-21T17:00:00"
         },
         {
-          "taskid": 154,
+          "taskid": 160,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1344,7 +1392,7 @@
           "deadline": "2022-09-21T18:00:00"
         },
         {
-          "taskid": 155,
+          "taskid": 161,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1352,7 +1400,7 @@
           "deadline": "2022-09-21T19:00:00"
         },
         {
-          "taskid": 156,
+          "taskid": 162,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1360,7 +1408,7 @@
           "deadline": "2022-09-21T20:00:00"
         },
         {
-          "taskid": 157,
+          "taskid": 163,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1373,7 +1421,7 @@
       "day": "2022-09-22",
       "outputs": [
         {
-          "taskid": 158,
+          "taskid": 164,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1381,7 +1429,7 @@
           "deadline": "2022-09-22T05:00:00"
         },
         {
-          "taskid": 159,
+          "taskid": 165,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1389,7 +1437,7 @@
           "deadline": "2022-09-22T07:00:00"
         },
         {
-          "taskid": 160,
+          "taskid": 166,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -1397,7 +1445,7 @@
           "deadline": "2022-09-22T17:00:00"
         },
         {
-          "taskid": 161,
+          "taskid": 167,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1405,7 +1453,7 @@
           "deadline": "2022-09-22T18:00:00"
         },
         {
-          "taskid": 162,
+          "taskid": 168,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1413,7 +1461,7 @@
           "deadline": "2022-09-22T19:00:00"
         },
         {
-          "taskid": 163,
+          "taskid": 169,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1421,7 +1469,7 @@
           "deadline": "2022-09-22T20:00:00"
         },
         {
-          "taskid": 164,
+          "taskid": 170,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1434,7 +1482,7 @@
       "day": "2022-09-23",
       "outputs": [
         {
-          "taskid": 165,
+          "taskid": 171,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1442,7 +1490,7 @@
           "deadline": "2022-09-23T05:00:00"
         },
         {
-          "taskid": 166,
+          "taskid": 172,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1450,7 +1498,7 @@
           "deadline": "2022-09-23T07:00:00"
         },
         {
-          "taskid": 167,
+          "taskid": 173,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -1458,7 +1506,7 @@
           "deadline": "2022-09-23T17:00:00"
         },
         {
-          "taskid": 168,
+          "taskid": 174,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1466,7 +1514,7 @@
           "deadline": "2022-09-23T18:00:00"
         },
         {
-          "taskid": 169,
+          "taskid": 175,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1474,7 +1522,7 @@
           "deadline": "2022-09-23T19:00:00"
         },
         {
-          "taskid": 170,
+          "taskid": 176,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1482,7 +1530,7 @@
           "deadline": "2022-09-23T20:00:00"
         },
         {
-          "taskid": 171,
+          "taskid": 177,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1495,7 +1543,7 @@
       "day": "2022-09-24",
       "outputs": [
         {
-          "taskid": 172,
+          "taskid": 178,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1503,7 +1551,7 @@
           "deadline": "2022-09-24T05:00:00"
         },
         {
-          "taskid": 173,
+          "taskid": 179,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1511,7 +1559,7 @@
           "deadline": "2022-09-24T07:00:00"
         },
         {
-          "taskid": 174,
+          "taskid": 180,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -1519,7 +1567,7 @@
           "deadline": "2022-09-24T17:00:00"
         },
         {
-          "taskid": 175,
+          "taskid": 181,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1527,7 +1575,7 @@
           "deadline": "2022-09-24T18:00:00"
         },
         {
-          "taskid": 176,
+          "taskid": 182,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1535,7 +1583,7 @@
           "deadline": "2022-09-24T19:00:00"
         },
         {
-          "taskid": 177,
+          "taskid": 183,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1543,7 +1591,7 @@
           "deadline": "2022-09-24T20:00:00"
         },
         {
-          "taskid": 178,
+          "taskid": 184,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1556,7 +1604,7 @@
       "day": "2022-09-25",
       "outputs": [
         {
-          "taskid": 179,
+          "taskid": 185,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1564,7 +1612,7 @@
           "deadline": "2022-09-25T05:00:00"
         },
         {
-          "taskid": 180,
+          "taskid": 186,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1572,7 +1620,7 @@
           "deadline": "2022-09-25T07:00:00"
         },
         {
-          "taskid": 181,
+          "taskid": 187,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -1580,7 +1628,7 @@
           "deadline": "2022-09-25T17:00:00"
         },
         {
-          "taskid": 182,
+          "taskid": 188,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1588,7 +1636,7 @@
           "deadline": "2022-09-25T18:00:00"
         },
         {
-          "taskid": 183,
+          "taskid": 189,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1596,7 +1644,7 @@
           "deadline": "2022-09-25T19:00:00"
         },
         {
-          "taskid": 184,
+          "taskid": 190,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1604,7 +1652,7 @@
           "deadline": "2022-09-25T20:00:00"
         },
         {
-          "taskid": 185,
+          "taskid": 191,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1617,7 +1665,7 @@
       "day": "2022-09-26",
       "outputs": [
         {
-          "taskid": 186,
+          "taskid": 192,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1625,7 +1673,7 @@
           "deadline": "2022-09-26T05:00:00"
         },
         {
-          "taskid": 187,
+          "taskid": 193,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1633,7 +1681,7 @@
           "deadline": "2022-09-26T07:00:00"
         },
         {
-          "taskid": 188,
+          "taskid": 194,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -1641,7 +1689,7 @@
           "deadline": "2022-09-26T17:00:00"
         },
         {
-          "taskid": 189,
+          "taskid": 195,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1649,7 +1697,7 @@
           "deadline": "2022-09-26T18:00:00"
         },
         {
-          "taskid": 190,
+          "taskid": 196,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1657,7 +1705,7 @@
           "deadline": "2022-09-26T19:00:00"
         },
         {
-          "taskid": 191,
+          "taskid": 197,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1665,7 +1713,7 @@
           "deadline": "2022-09-26T20:00:00"
         },
         {
-          "taskid": 192,
+          "taskid": 198,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1678,7 +1726,7 @@
       "day": "2022-09-27",
       "outputs": [
         {
-          "taskid": 193,
+          "taskid": 199,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1686,7 +1734,7 @@
           "deadline": "2022-09-27T05:00:00"
         },
         {
-          "taskid": 194,
+          "taskid": 200,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1694,7 +1742,7 @@
           "deadline": "2022-09-27T07:00:00"
         },
         {
-          "taskid": 195,
+          "taskid": 201,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -1702,7 +1750,7 @@
           "deadline": "2022-09-27T17:00:00"
         },
         {
-          "taskid": 196,
+          "taskid": 202,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1710,7 +1758,7 @@
           "deadline": "2022-09-27T18:00:00"
         },
         {
-          "taskid": 197,
+          "taskid": 203,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1718,7 +1766,7 @@
           "deadline": "2022-09-27T19:00:00"
         },
         {
-          "taskid": 198,
+          "taskid": 204,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1726,7 +1774,7 @@
           "deadline": "2022-09-27T20:00:00"
         },
         {
-          "taskid": 199,
+          "taskid": 205,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1739,7 +1787,7 @@
       "day": "2022-09-28",
       "outputs": [
         {
-          "taskid": 200,
+          "taskid": 206,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1747,7 +1795,7 @@
           "deadline": "2022-09-28T05:00:00"
         },
         {
-          "taskid": 201,
+          "taskid": 207,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1755,7 +1803,7 @@
           "deadline": "2022-09-28T07:00:00"
         },
         {
-          "taskid": 202,
+          "taskid": 208,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1763,7 +1811,7 @@
           "deadline": "2022-09-28T12:00:00"
         },
         {
-          "taskid": 203,
+          "taskid": 209,
           "goalid": "3",
           "title": "piano practice",
           "duration": 2,
@@ -1771,7 +1819,7 @@
           "deadline": "2022-09-28T14:00:00"
         },
         {
-          "taskid": 204,
+          "taskid": 210,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -1779,7 +1827,7 @@
           "deadline": "2022-09-28T17:00:00"
         },
         {
-          "taskid": 205,
+          "taskid": 211,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1787,7 +1835,7 @@
           "deadline": "2022-09-28T18:00:00"
         },
         {
-          "taskid": 206,
+          "taskid": 212,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1795,7 +1843,7 @@
           "deadline": "2022-09-28T19:00:00"
         },
         {
-          "taskid": 207,
+          "taskid": 213,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1803,7 +1851,7 @@
           "deadline": "2022-09-28T20:00:00"
         },
         {
-          "taskid": 208,
+          "taskid": 214,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1816,7 +1864,7 @@
       "day": "2022-09-29",
       "outputs": [
         {
-          "taskid": 209,
+          "taskid": 215,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1824,7 +1872,7 @@
           "deadline": "2022-09-29T05:00:00"
         },
         {
-          "taskid": 210,
+          "taskid": 216,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1832,7 +1880,7 @@
           "deadline": "2022-09-29T07:00:00"
         },
         {
-          "taskid": 211,
+          "taskid": 217,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -1840,7 +1888,7 @@
           "deadline": "2022-09-29T17:00:00"
         },
         {
-          "taskid": 212,
+          "taskid": 218,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1848,7 +1896,7 @@
           "deadline": "2022-09-29T18:00:00"
         },
         {
-          "taskid": 213,
+          "taskid": 219,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1856,7 +1904,7 @@
           "deadline": "2022-09-29T19:00:00"
         },
         {
-          "taskid": 214,
+          "taskid": 220,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1864,7 +1912,7 @@
           "deadline": "2022-09-29T20:00:00"
         },
         {
-          "taskid": 215,
+          "taskid": 221,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1877,7 +1925,7 @@
       "day": "2022-09-30",
       "outputs": [
         {
-          "taskid": 216,
+          "taskid": 222,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -1885,7 +1933,7 @@
           "deadline": "2022-09-30T05:00:00"
         },
         {
-          "taskid": 217,
+          "taskid": 223,
           "goalid": "4",
           "title": "gym",
           "duration": 2,
@@ -1893,7 +1941,7 @@
           "deadline": "2022-09-30T07:00:00"
         },
         {
-          "taskid": 218,
+          "taskid": 224,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -1901,7 +1949,7 @@
           "deadline": "2022-09-30T17:00:00"
         },
         {
-          "taskid": 219,
+          "taskid": 225,
           "goalid": "1",
           "title": "walk",
           "duration": 1,
@@ -1909,7 +1957,7 @@
           "deadline": "2022-09-30T18:00:00"
         },
         {
-          "taskid": 220,
+          "taskid": 226,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -1917,7 +1965,7 @@
           "deadline": "2022-09-30T19:00:00"
         },
         {
-          "taskid": 221,
+          "taskid": 227,
           "goalid": "2",
           "title": "read",
           "duration": 1,
@@ -1925,7 +1973,7 @@
           "deadline": "2022-09-30T20:00:00"
         },
         {
-          "taskid": 222,
+          "taskid": 228,
           "goalid": "free",
           "title": "free",
           "duration": 4,
@@ -1938,56 +1986,7 @@
   "impossible": [
     {
       "day": "2022-09-01",
-      "outputs": [
-        {
-          "taskid": 223,
-          "goalid": "1",
-          "title": "walk",
-          "duration": 1,
-          "start": "2022-09-01T00:00:00",
-          "deadline": "2022-10-01T00:00:00"
-        },
-        {
-          "taskid": 224,
-          "goalid": "1",
-          "title": "walk",
-          "duration": 1,
-          "start": "2022-09-01T00:00:00",
-          "deadline": "2022-10-01T00:00:00"
-        },
-        {
-          "taskid": 225,
-          "goalid": "1",
-          "title": "walk",
-          "duration": 1,
-          "start": "2022-09-01T00:00:00",
-          "deadline": "2022-10-01T00:00:00"
-        },
-        {
-          "taskid": 226,
-          "goalid": "1",
-          "title": "walk",
-          "duration": 1,
-          "start": "2022-09-01T00:00:00",
-          "deadline": "2022-10-01T00:00:00"
-        },
-        {
-          "taskid": 227,
-          "goalid": "1",
-          "title": "walk",
-          "duration": 1,
-          "start": "2022-09-01T00:00:00",
-          "deadline": "2022-10-01T00:00:00"
-        },
-        {
-          "taskid": 228,
-          "goalid": "1",
-          "title": "walk",
-          "duration": 1,
-          "start": "2022-09-01T00:00:00",
-          "deadline": "2022-10-01T00:00:00"
-        }
-      ]
+      "outputs": []
     },
     {
       "day": "2022-09-02",

--- a/tests/jsons/realistic-weekend-repetition-1/actual_output.json
+++ b/tests/jsons/realistic-weekend-repetition-1/actual_output.json
@@ -68,8 +68,24 @@
           "taskid": 7,
           "goalid": "free",
           "title": "free",
-          "duration": 24,
+          "duration": 10,
           "start": "2022-09-02T00:00:00",
+          "deadline": "2022-09-02T10:00:00"
+        },
+        {
+          "taskid": 8,
+          "goalid": "4",
+          "title": "church",
+          "duration": 2,
+          "start": "2022-09-02T10:00:00",
+          "deadline": "2022-09-02T12:00:00"
+        },
+        {
+          "taskid": 9,
+          "goalid": "free",
+          "title": "free",
+          "duration": 12,
+          "start": "2022-09-02T12:00:00",
           "deadline": "2022-09-03T00:00:00"
         }
       ]
@@ -78,7 +94,7 @@
       "day": "2022-09-03",
       "outputs": [
         {
-          "taskid": 8,
+          "taskid": 10,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -86,7 +102,7 @@
           "deadline": "2022-09-03T05:00:00"
         },
         {
-          "taskid": 9,
+          "taskid": 11,
           "goalid": "2",
           "title": "gym",
           "duration": 2,
@@ -94,7 +110,7 @@
           "deadline": "2022-09-03T07:00:00"
         },
         {
-          "taskid": 10,
+          "taskid": 12,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -102,7 +118,7 @@
           "deadline": "2022-09-03T08:00:00"
         },
         {
-          "taskid": 11,
+          "taskid": 13,
           "goalid": "1",
           "title": "work",
           "duration": 6,
@@ -110,7 +126,7 @@
           "deadline": "2022-09-03T14:00:00"
         },
         {
-          "taskid": 12,
+          "taskid": 14,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -118,7 +134,7 @@
           "deadline": "2022-09-03T17:00:00"
         },
         {
-          "taskid": 13,
+          "taskid": 15,
           "goalid": "3",
           "title": "walk",
           "duration": 1,
@@ -126,7 +142,7 @@
           "deadline": "2022-09-03T18:00:00"
         },
         {
-          "taskid": 14,
+          "taskid": 16,
           "goalid": "free",
           "title": "free",
           "duration": 6,
@@ -139,7 +155,7 @@
       "day": "2022-09-04",
       "outputs": [
         {
-          "taskid": 15,
+          "taskid": 17,
           "goalid": "free",
           "title": "free",
           "duration": 11,
@@ -147,7 +163,7 @@
           "deadline": "2022-09-04T11:00:00"
         },
         {
-          "taskid": 16,
+          "taskid": 18,
           "goalid": "5",
           "title": "dentist",
           "duration": 1,
@@ -155,7 +171,7 @@
           "deadline": "2022-09-04T12:00:00"
         },
         {
-          "taskid": 17,
+          "taskid": 19,
           "goalid": "4",
           "title": "church",
           "duration": 2,
@@ -163,7 +179,7 @@
           "deadline": "2022-09-04T14:00:00"
         },
         {
-          "taskid": 18,
+          "taskid": 20,
           "goalid": "free",
           "title": "free",
           "duration": 10,
@@ -176,7 +192,7 @@
       "day": "2022-09-05",
       "outputs": [
         {
-          "taskid": 19,
+          "taskid": 21,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -189,7 +205,7 @@
       "day": "2022-09-06",
       "outputs": [
         {
-          "taskid": 20,
+          "taskid": 22,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -202,7 +218,7 @@
       "day": "2022-09-07",
       "outputs": [
         {
-          "taskid": 21,
+          "taskid": 23,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -215,7 +231,7 @@
       "day": "2022-09-08",
       "outputs": [
         {
-          "taskid": 22,
+          "taskid": 24,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -228,7 +244,7 @@
       "day": "2022-09-09",
       "outputs": [
         {
-          "taskid": 23,
+          "taskid": 25,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -241,7 +257,7 @@
       "day": "2022-09-10",
       "outputs": [
         {
-          "taskid": 24,
+          "taskid": 26,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -249,7 +265,7 @@
           "deadline": "2022-09-10T05:00:00"
         },
         {
-          "taskid": 25,
+          "taskid": 27,
           "goalid": "2",
           "title": "gym",
           "duration": 2,
@@ -257,7 +273,7 @@
           "deadline": "2022-09-10T07:00:00"
         },
         {
-          "taskid": 26,
+          "taskid": 28,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -265,7 +281,7 @@
           "deadline": "2022-09-10T08:00:00"
         },
         {
-          "taskid": 27,
+          "taskid": 29,
           "goalid": "1",
           "title": "work",
           "duration": 6,
@@ -273,7 +289,7 @@
           "deadline": "2022-09-10T14:00:00"
         },
         {
-          "taskid": 28,
+          "taskid": 30,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -281,7 +297,7 @@
           "deadline": "2022-09-10T17:00:00"
         },
         {
-          "taskid": 29,
+          "taskid": 31,
           "goalid": "3",
           "title": "walk",
           "duration": 1,
@@ -289,7 +305,7 @@
           "deadline": "2022-09-10T18:00:00"
         },
         {
-          "taskid": 30,
+          "taskid": 32,
           "goalid": "free",
           "title": "free",
           "duration": 6,
@@ -302,11 +318,27 @@
       "day": "2022-09-11",
       "outputs": [
         {
-          "taskid": 31,
+          "taskid": 33,
           "goalid": "free",
           "title": "free",
-          "duration": 24,
+          "duration": 10,
           "start": "2022-09-11T00:00:00",
+          "deadline": "2022-09-11T10:00:00"
+        },
+        {
+          "taskid": 34,
+          "goalid": "4",
+          "title": "church",
+          "duration": 2,
+          "start": "2022-09-11T10:00:00",
+          "deadline": "2022-09-11T12:00:00"
+        },
+        {
+          "taskid": 35,
+          "goalid": "free",
+          "title": "free",
+          "duration": 12,
+          "start": "2022-09-11T12:00:00",
           "deadline": "2022-09-12T00:00:00"
         }
       ]
@@ -315,27 +347,11 @@
       "day": "2022-09-12",
       "outputs": [
         {
-          "taskid": 32,
+          "taskid": 36,
           "goalid": "free",
           "title": "free",
-          "duration": 10,
+          "duration": 24,
           "start": "2022-09-12T00:00:00",
-          "deadline": "2022-09-12T10:00:00"
-        },
-        {
-          "taskid": 33,
-          "goalid": "4",
-          "title": "church",
-          "duration": 2,
-          "start": "2022-09-12T10:00:00",
-          "deadline": "2022-09-12T12:00:00"
-        },
-        {
-          "taskid": 34,
-          "goalid": "free",
-          "title": "free",
-          "duration": 12,
-          "start": "2022-09-12T12:00:00",
           "deadline": "2022-09-13T00:00:00"
         }
       ]
@@ -344,7 +360,7 @@
       "day": "2022-09-13",
       "outputs": [
         {
-          "taskid": 35,
+          "taskid": 37,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -357,7 +373,7 @@
       "day": "2022-09-14",
       "outputs": [
         {
-          "taskid": 36,
+          "taskid": 38,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -370,7 +386,7 @@
       "day": "2022-09-15",
       "outputs": [
         {
-          "taskid": 37,
+          "taskid": 39,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -383,7 +399,7 @@
       "day": "2022-09-16",
       "outputs": [
         {
-          "taskid": 38,
+          "taskid": 40,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -396,7 +412,7 @@
       "day": "2022-09-17",
       "outputs": [
         {
-          "taskid": 39,
+          "taskid": 41,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -404,7 +420,7 @@
           "deadline": "2022-09-17T05:00:00"
         },
         {
-          "taskid": 40,
+          "taskid": 42,
           "goalid": "2",
           "title": "gym",
           "duration": 2,
@@ -412,7 +428,7 @@
           "deadline": "2022-09-17T07:00:00"
         },
         {
-          "taskid": 41,
+          "taskid": 43,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -420,7 +436,7 @@
           "deadline": "2022-09-17T08:00:00"
         },
         {
-          "taskid": 42,
+          "taskid": 44,
           "goalid": "1",
           "title": "work",
           "duration": 6,
@@ -428,7 +444,7 @@
           "deadline": "2022-09-17T14:00:00"
         },
         {
-          "taskid": 43,
+          "taskid": 45,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -436,7 +452,7 @@
           "deadline": "2022-09-17T17:00:00"
         },
         {
-          "taskid": 44,
+          "taskid": 46,
           "goalid": "3",
           "title": "walk",
           "duration": 1,
@@ -444,7 +460,7 @@
           "deadline": "2022-09-17T18:00:00"
         },
         {
-          "taskid": 45,
+          "taskid": 47,
           "goalid": "free",
           "title": "free",
           "duration": 6,
@@ -457,11 +473,27 @@
       "day": "2022-09-18",
       "outputs": [
         {
-          "taskid": 46,
+          "taskid": 48,
           "goalid": "free",
           "title": "free",
-          "duration": 24,
+          "duration": 10,
           "start": "2022-09-18T00:00:00",
+          "deadline": "2022-09-18T10:00:00"
+        },
+        {
+          "taskid": 49,
+          "goalid": "4",
+          "title": "church",
+          "duration": 2,
+          "start": "2022-09-18T10:00:00",
+          "deadline": "2022-09-18T12:00:00"
+        },
+        {
+          "taskid": 50,
+          "goalid": "free",
+          "title": "free",
+          "duration": 12,
+          "start": "2022-09-18T12:00:00",
           "deadline": "2022-09-19T00:00:00"
         }
       ]
@@ -470,27 +502,11 @@
       "day": "2022-09-19",
       "outputs": [
         {
-          "taskid": 47,
+          "taskid": 51,
           "goalid": "free",
           "title": "free",
-          "duration": 10,
+          "duration": 24,
           "start": "2022-09-19T00:00:00",
-          "deadline": "2022-09-19T10:00:00"
-        },
-        {
-          "taskid": 48,
-          "goalid": "4",
-          "title": "church",
-          "duration": 2,
-          "start": "2022-09-19T10:00:00",
-          "deadline": "2022-09-19T12:00:00"
-        },
-        {
-          "taskid": 49,
-          "goalid": "free",
-          "title": "free",
-          "duration": 12,
-          "start": "2022-09-19T12:00:00",
           "deadline": "2022-09-20T00:00:00"
         }
       ]
@@ -499,7 +515,7 @@
       "day": "2022-09-20",
       "outputs": [
         {
-          "taskid": 50,
+          "taskid": 52,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -512,7 +528,7 @@
       "day": "2022-09-21",
       "outputs": [
         {
-          "taskid": 51,
+          "taskid": 53,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -525,7 +541,7 @@
       "day": "2022-09-22",
       "outputs": [
         {
-          "taskid": 52,
+          "taskid": 54,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -538,7 +554,7 @@
       "day": "2022-09-23",
       "outputs": [
         {
-          "taskid": 53,
+          "taskid": 55,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -551,7 +567,7 @@
       "day": "2022-09-24",
       "outputs": [
         {
-          "taskid": 54,
+          "taskid": 56,
           "goalid": "free",
           "title": "free",
           "duration": 5,
@@ -559,7 +575,7 @@
           "deadline": "2022-09-24T05:00:00"
         },
         {
-          "taskid": 55,
+          "taskid": 57,
           "goalid": "2",
           "title": "gym",
           "duration": 2,
@@ -567,7 +583,7 @@
           "deadline": "2022-09-24T07:00:00"
         },
         {
-          "taskid": 56,
+          "taskid": 58,
           "goalid": "free",
           "title": "free",
           "duration": 1,
@@ -575,7 +591,7 @@
           "deadline": "2022-09-24T08:00:00"
         },
         {
-          "taskid": 57,
+          "taskid": 59,
           "goalid": "1",
           "title": "work",
           "duration": 6,
@@ -583,7 +599,7 @@
           "deadline": "2022-09-24T14:00:00"
         },
         {
-          "taskid": 58,
+          "taskid": 60,
           "goalid": "free",
           "title": "free",
           "duration": 3,
@@ -591,7 +607,7 @@
           "deadline": "2022-09-24T17:00:00"
         },
         {
-          "taskid": 59,
+          "taskid": 61,
           "goalid": "3",
           "title": "walk",
           "duration": 1,
@@ -599,7 +615,7 @@
           "deadline": "2022-09-24T18:00:00"
         },
         {
-          "taskid": 60,
+          "taskid": 62,
           "goalid": "free",
           "title": "free",
           "duration": 6,
@@ -612,11 +628,27 @@
       "day": "2022-09-25",
       "outputs": [
         {
-          "taskid": 61,
+          "taskid": 63,
           "goalid": "free",
           "title": "free",
-          "duration": 24,
+          "duration": 10,
           "start": "2022-09-25T00:00:00",
+          "deadline": "2022-09-25T10:00:00"
+        },
+        {
+          "taskid": 64,
+          "goalid": "4",
+          "title": "church",
+          "duration": 2,
+          "start": "2022-09-25T10:00:00",
+          "deadline": "2022-09-25T12:00:00"
+        },
+        {
+          "taskid": 65,
+          "goalid": "free",
+          "title": "free",
+          "duration": 12,
+          "start": "2022-09-25T12:00:00",
           "deadline": "2022-09-26T00:00:00"
         }
       ]
@@ -625,27 +657,11 @@
       "day": "2022-09-26",
       "outputs": [
         {
-          "taskid": 62,
+          "taskid": 66,
           "goalid": "free",
           "title": "free",
-          "duration": 10,
+          "duration": 24,
           "start": "2022-09-26T00:00:00",
-          "deadline": "2022-09-26T10:00:00"
-        },
-        {
-          "taskid": 63,
-          "goalid": "4",
-          "title": "church",
-          "duration": 2,
-          "start": "2022-09-26T10:00:00",
-          "deadline": "2022-09-26T12:00:00"
-        },
-        {
-          "taskid": 64,
-          "goalid": "free",
-          "title": "free",
-          "duration": 12,
-          "start": "2022-09-26T12:00:00",
           "deadline": "2022-09-27T00:00:00"
         }
       ]
@@ -654,7 +670,7 @@
       "day": "2022-09-27",
       "outputs": [
         {
-          "taskid": 65,
+          "taskid": 67,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -667,7 +683,7 @@
       "day": "2022-09-28",
       "outputs": [
         {
-          "taskid": 66,
+          "taskid": 68,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -680,7 +696,7 @@
       "day": "2022-09-29",
       "outputs": [
         {
-          "taskid": 67,
+          "taskid": 69,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -693,7 +709,7 @@
       "day": "2022-09-30",
       "outputs": [
         {
-          "taskid": 68,
+          "taskid": 70,
           "goalid": "free",
           "title": "free",
           "duration": 24,
@@ -706,16 +722,7 @@
   "impossible": [
     {
       "day": "2022-09-01",
-      "outputs": [
-        {
-          "taskid": 69,
-          "goalid": "4",
-          "title": "church",
-          "duration": 2,
-          "start": "2022-09-01T00:00:00",
-          "deadline": "2022-10-01T00:00:00"
-        }
-      ]
+      "outputs": []
     },
     {
       "day": "2022-09-02",

--- a/tests/jsons/singleday-manygoals-1/actual_output.json
+++ b/tests/jsons/singleday-manygoals-1/actual_output.json
@@ -93,26 +93,18 @@
         },
         {
           "taskid": 11,
-          "goalid": "free",
-          "title": "free",
+          "goalid": "6",
+          "title": "read",
           "duration": 1,
           "start": "2022-01-01T20:00:00",
           "deadline": "2022-01-01T21:00:00"
         },
         {
           "taskid": 12,
-          "goalid": "6",
-          "title": "read",
-          "duration": 1,
-          "start": "2022-01-01T21:00:00",
-          "deadline": "2022-01-01T22:00:00"
-        },
-        {
-          "taskid": 13,
           "goalid": "free",
           "title": "free",
-          "duration": 2,
-          "start": "2022-01-01T22:00:00",
+          "duration": 3,
+          "start": "2022-01-01T21:00:00",
           "deadline": "2022-01-02T00:00:00"
         }
       ]

--- a/tests/jsons/sleep-1/actual_output.json
+++ b/tests/jsons/sleep-1/actual_output.json
@@ -172,14 +172,6 @@
           "duration": 8,
           "start": "2022-01-01T00:00:00",
           "deadline": "2022-01-09T00:00:00"
-        },
-        {
-          "taskid": 16,
-          "goalid": "1",
-          "title": "sleep",
-          "duration": 8,
-          "start": "2022-01-01T00:00:00",
-          "deadline": "2022-01-09T00:00:00"
         }
       ]
     },

--- a/tests/jsons/split-1/actual_output.json
+++ b/tests/jsons/split-1/actual_output.json
@@ -13,14 +13,6 @@
         },
         {
           "taskid": 1,
-          "goalid": "1",
-          "title": "dentist",
-          "duration": 1,
-          "start": "2022-09-01T08:00:00",
-          "deadline": "2022-09-01T09:00:00"
-        },
-        {
-          "taskid": 2,
           "goalid": "2",
           "title": "work",
           "duration": 8,
@@ -28,7 +20,7 @@
           "deadline": "2022-09-01T16:00:00"
         },
         {
-          "taskid": 3,
+          "taskid": 2,
           "goalid": "free",
           "title": "free",
           "duration": 8,
@@ -41,7 +33,16 @@
   "impossible": [
     {
       "day": "2022-09-01",
-      "outputs": []
+      "outputs": [
+        {
+          "taskid": 3,
+          "goalid": "1",
+          "title": "dentist",
+          "duration": 1,
+          "start": "2022-09-01T00:00:00",
+          "deadline": "2022-09-02T00:00:00"
+        }
+      ]
     }
   ]
 }

--- a/tests/jsons/split-4/actual_output.json
+++ b/tests/jsons/split-4/actual_output.json
@@ -21,10 +21,18 @@
         },
         {
           "taskid": 2,
+          "goalid": "2",
+          "title": "shopping",
+          "duration": 1,
+          "start": "2022-09-01T16:00:00",
+          "deadline": "2022-09-01T17:00:00"
+        },
+        {
+          "taskid": 3,
           "goalid": "free",
           "title": "free",
-          "duration": 8,
-          "start": "2022-09-01T16:00:00",
+          "duration": 7,
+          "start": "2022-09-01T17:00:00",
           "deadline": "2022-09-02T00:00:00"
         }
       ]
@@ -34,14 +42,6 @@
     {
       "day": "2022-09-01",
       "outputs": [
-        {
-          "taskid": 3,
-          "goalid": "2",
-          "title": "shopping",
-          "duration": 1,
-          "start": "2022-09-01T00:00:00",
-          "deadline": "2022-09-02T00:00:00"
-        },
         {
           "taskid": 4,
           "goalid": "3",


### PR DESCRIPTION
This is a Sub-PR for PR https://github.com/tijlleenders/ZinZen-scheduler/pull/317

---

Found this issue while resolving https://github.com/tijlleenders/ZinZen-scheduler/pull/319 which  `Task::remove_slot`  is removing slots properly but not for current context.
Check below sample:
```
// "chosen_slot" to be removed from all tasks:
Slot: 2023-01-03 00 to 08 (8 hours)

// "Task.slot" which has less duration than chosen_slot but not removed
Task.slot: 2023-01-03 01 to 03 (2 hour)

// Current design doesn't remove intersected timing but subtract difference, which causing wrong scheduling as below result.
Task.Slot1: 2023-01-03 00 to 01 (1 hour) [<< that causing wrong scheduling]
Task.Slot2: 2023-01-03 03 to 08 (5 hour) [<< giving more time to the task which out of budget]

// Correct respond should be as below:
Task.Slot 2023-01-03 01 to 03 [REMOVED, so task shouldn't have this] 
```

So business rule for this functionality as below:
- If `slot_to_remove` > `task_slot` AND `task_slot` contained in `slot_to_remove`, so remove `task_slot`
[NOTE: this business rule avoided after below sub-PR done]
---

After discussion, found that `Slot` `Sub` trait impl, should be fixed so previous business rule will not used.
- [x] Sub-PR resolved this PR https://github.com/tijlleenders/ZinZen-scheduler/pull/322