### PR TITLE
feat: impl `Debug` and `Display` for `Slot` with test cases

### DIFF
--- a/src/models/slot/impls.rs
+++ b/src/models/slot/impls.rs
@@ -2,15 +2,8 @@ use super::Slot;
 use chrono::{Days, NaiveDateTime, Timelike};
 use std::{
     cmp::{max, min},
-    fmt::Display,
     ops::{Add, Sub},
 };
-
-impl Display for Slot {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Slot - start: {} - end: {}", self.start, self.end)
-    }
-}
 
 impl Sub for Slot {
     type Output = Vec<Slot>;

--- a/src/models/slot/mod.rs
+++ b/src/models/slot/mod.rs
@@ -2,14 +2,15 @@ pub mod impls;
 pub mod iterator;
 pub mod utils;
 
-use chrono::NaiveDateTime;
+use chrono::{Datelike, NaiveDateTime, Timelike};
 use serde::Deserialize;
+use std::fmt::{self, Debug, Display};
 
 // TODO 2023-04-26  | Slot rules as below:
 // - A rule that slot.end must not be before slot.start
 // - A suggestion to add rule to create 2 slots if slot.start is after slot.end
 
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Deserialize)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Deserialize)]
 pub struct Slot {
     pub start: NaiveDateTime,
     pub end: NaiveDateTime,
@@ -19,4 +20,82 @@ pub struct Slot {
 pub struct SlotConflict {
     pub slot: Slot,
     pub num_conflicts: usize,
+}
+
+impl Debug for Slot {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let start = self.start;
+        let end = self.end;
+        write!(
+            f,
+            "Slot {{ \n\tstart:\t {:02}-{:02}-{:02} {:02},\n\t end:\t {:02}-{:02}-{:02} {:02}, \n}}",
+            start.year(),
+            start.month(),
+            start.day(),
+            start.hour(),
+            end.year(),
+            end.month(),
+            end.day(),
+            end.hour(),
+        )
+    }
+}
+
+impl Display for Slot {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let start = self.start;
+        let end = self.end;
+        write!(
+            f,
+            "Slot {{ start: {:02}-{:02}-{:02} {:02} - end: {:02}-{:02}-{:02} {:02} }}",
+            start.year(),
+            start.month(),
+            start.day(),
+            start.hour(),
+            end.year(),
+            end.month(),
+            end.day(),
+            end.hour(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Duration;
+
+    use super::Slot;
+
+    #[test]
+    fn diplay_slot() {
+        let slot = Slot::mock(Duration::hours(12), 2023, 6, 1, 9, 0);
+        let debug_output = format!("{}", slot);
+        assert_eq!(
+            debug_output,
+            "Slot { start: 2023-06-01 09 - end: 2023-06-01 21 }"
+        );
+    }
+
+    #[test]
+    fn debug_slot() {
+        let slot = Slot::mock(Duration::hours(12), 2023, 6, 1, 9, 0);
+        let debug_output = format!("{:?}", slot);
+        let expected =
+            format!("Slot {{ \n\tstart:\t 2023-06-01 09,\n\t end:\t 2023-06-01 21, \n}}");
+
+        assert_eq!(debug_output, expected);
+    }
+
+    #[test]
+    fn debug_slot_formatted() {
+        let slot = Slot::mock(Duration::hours(12), 2023, 6, 1, 9, 0);
+        let debug_output = format!("{:?}", slot);
+        let debug_output_fomratted = format!("{:#?}", slot);
+
+        let expected =
+            format!("Slot {{ \n\tstart:\t 2023-06-01 09,\n\t end:\t 2023-06-01 21, \n}}");
+
+        assert_eq!(debug_output, expected);
+        assert_eq!(debug_output_fomratted, expected);
+    }
 }


### PR DESCRIPTION
Implement `Debug` and `Display` traits for `Slot` struct to show Slot as below:

```bash
# print as display
Slot { start: 2023-06-01 09 - end: 2023-06-01 21 }

# print as debug
Slot { 
        start:   2023-06-01 09,
         end:    2023-06-01 21, 
}

```