### PR TITLE
fix: app want't able to work and fixed

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,0 +1,22 @@
+extern crate scheduler;
+use scheduler::models::input::Input;
+use std::error::Error;
+use std::fs::File;
+use std::io::BufReader;
+use std::path::Path;
+fn main() {
+    let path = Path::new("./tests/jsons/after-12/input.json");
+    let path2 = Path::new("./tests/jsons/before-7/input.json");
+    let paths = vec![path, path2];
+    for path in paths {
+        let input: Input = get_input_from_json(path).unwrap();
+        let _output = scheduler::run_scheduler(input);
+    }
+}
+
+pub fn get_input_from_json<P: AsRef<Path>>(path: P) -> Result<Input, Box<dyn Error>> {
+    let file = File::open(path)?;
+    let reader = BufReader::new(file);
+    let input = serde_json::from_reader(reader)?;
+    Ok(input)
+}


### PR DESCRIPTION
After review PR https://github.com/tijlleenders/ZinZen-scheduler/pull/329,  I didn't (by mistake) run the app before approve and merge. 

---

Issue was that app couldn't able to be run as below errors:
```bash
# ===========
$ cargo build
error: couldn't read src/bin/main.rs: No such file or directory (os error 2)

error: could not compile `zinzen` due to previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `zinzen` due to previous error

# ==========
$ cargo test
   Compiling zinzen v0.1.1 (/home/moaz/dev/entity/tijl/ZinZen-scheduler)
error: couldn't read src/bin/main.rs: No such file or directory (os error 2)

error: could not compile `zinzen` due to previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `zinzen` due to previous error
```

Issue resolved by restoring file `src/bin/main.rs` as below commands.

### How to restore file removed in previous commits
For your info restoring files from previous commits can be done as below:
```bash
# Get commits which affecting file before
$ git log --oneline -- src/bin/main.rs
a4c5086 Tijlleenders/issue328 (#329)
d5cdde5 Update/docs update (#302)
453caae wip: defining structs and fucntions in the new structure
10c46e5 Fix warnings appears at cargo build & test cmds
909b99f Create benchmark-tests directory.
95ea30a Create bin directory. See readme in src/bin/ for detailed explanation.

# Return file from a specific commit in our case commit  hash`d5cdde5`
git checkout d5cdde5 -- src/bin/main.rs

```