### PR TITLE
test: developed a script to show summary of cargo test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,11 @@ path = "src/lib.rs"
 name = "scheduler-bin"
 path = "src/bin/flamegraph-bin.rs"
 
+[[bin]]
+name = "test-summary"
+path = "scripts/test_summary.rs"
+
+
 [profile.release]
 lto = true
 # Tell `rustc` to optimize for small code size.
@@ -41,7 +46,7 @@ console_error_panic_hook = "0.1.7"
 
 # display logs
 log = "0.4.19"
-env_logger="0.10.0"
+env_logger = "0.10.0"
 
 # soft assertions without panic
 soft = "0.1.1"

--- a/scripts/test
+++ b/scripts/test
@@ -24,6 +24,11 @@ if [[ "${PARAM}" == "--help" || "${PARAM}" == "-h" ]]; then
     echo "  and saves the output to a log file in the _logs directory."
     echo ""
     exit 0
+elif [[ "${PARAM}" == "summary" ]]; then
+    # Update FILE_NAME and LOG_FILE 
+    FILE_NAME="summary_${CURRENTDATE}.log"
+    LOG_FILE="${LOG_BASE}/${FILE_NAME}"
+    cargo run --bin test-summary --manifest-path "$ZIN_BASE" >> "$LOG_FILE"
 elif [[ "${PARAM}" == "" ]]; then
     # Update FILE_NAME and LOG_FILE to avoid PARAM inside it
     FILE_NAME="test_${CURRENTDATE}.log"

--- a/scripts/test_summary.rs
+++ b/scripts/test_summary.rs
@@ -1,0 +1,43 @@
+use std::process::Command;
+
+fn main() {
+    let mut command = Command::new("cargo");
+    command.args(["test"]);
+
+    let test_output = command.output().expect("failed to execute process");
+    let test_output_string = String::from_utf8_lossy(&test_output.stdout);
+
+    let final_output: String;
+
+    match test_output_string.rfind("failures:") {
+        Some(fails_index) => {
+            let filtered_string = &test_output_string[fails_index..test_output_string.len()];
+            final_output = sort_tests(filtered_string);
+        }
+        None => {
+            let final_index = test_output_string.rfind("test result:").unwrap();
+            final_output = format!(
+                "{}",
+                &test_output_string[final_index..test_output_string.len()]
+            );
+        }
+    }
+    println!("{}", final_output);
+}
+
+fn sort_tests(failed_tests: &str) -> String {
+    let start_index = failed_tests.find("failures:").unwrap() + "failures:".len();
+    let header = failed_tests.lines().next().unwrap().clone().trim();
+
+    let end_index = failed_tests.find("test result:").unwrap();
+    let footer = &failed_tests[end_index..failed_tests.len()].trim();
+
+    let result = format!(
+        "{}\n{}\n{}",
+        header,
+        &failed_tests[start_index..end_index],
+        footer
+    );
+
+    result
+}


### PR DESCRIPTION
Developed a script to show summary of cargo test in brief which we using to compare variances of failed tests cases.
- It running `cargo test` by Rust code which make command faster and avoid any output causing delay.
- In case there are failure cases, it sorts them, so we can compare with previous tests just by opening the log file.
- Old command `./scripts/test` can be used.
- Initial test between old command `./scripts/test` and new command `./scripts/test summary` is around a minute as below output feedback, but after adding some functions to the new script it is the same time, but with a feature of summarized data.

Old command to run tests with complete output:
```shell
❯ time ./scripts/test 
   Compiling zinzen v0.1.1 (/home/moaz/dev/entity/tijl/ZinZen-scheduler)
    Finished test [unoptimized + debuginfo] target(s) in 4.17s
     Running unittests src/lib.rs (target/debug/deps/scheduler-fef0136fcda33c72)
     Running unittests src/bin/flamegraph-bin.rs (target/debug/deps/scheduler_bin-fe7e9f612de3579f)
     Running tests/rust_tests.rs (target/debug/deps/rust_tests-e6c3ee9fa4fcce89)
error: test failed, to rerun pass `--test rust_tests`
   Doc-tests scheduler
error: 1 target failed:
    `--test rust_tests`

real	9m48.163s
user	16m23.878s
sys	0m5.636s
```

New command without any output or filtering:
```shell
❯ time cargo run --bin tester
   Compiling zinzen v0.1.1 (/home/moaz/dev/entity/tijl/ZinZen-scheduler)
    Finished dev [unoptimized + debuginfo] target(s) in 2.25s
     Running `target/debug/tester`

=======
=======


real	8m31.571s
user	15m7.376s
sys	0m4.973s
```
New command after finalized which have filter for output and sorting:
```shell
❯ time ./scripts/test summary
   Compiling zinzen v0.1.1 (/home/moaz/dev/entity/tijl/ZinZen-scheduler)
    Finished dev [unoptimized + debuginfo] target(s) in 2.19s
     Running `target/debug/test-summary`


real	8m8.459s
user	14m33.324s
sys	0m3.982s
```

- Script used by calling `./scripts/test summary`,
- Output will be saved to files starting with formatting `summary_<DATE_TIME>.log` like `summary_2023-07-13--19-27.log`
- Below is output of the script in the file
```shell
failures:

    e2e::children_with_over_duration
    e2e::demo_2_with_filler_with_budget
    e2e::different_repetition_goals
    e2e::every_6_hours
    e2e::every_6_hours_2
    e2e::flex_duration_2
    e2e::goals_dependency
    e2e::goals_hierarchy
    e2e::i293_postpone_2
    e2e::i309
    e2e::impossible_2
    e2e::issue_276_weekdays_filter_on_budget
    e2e::issue_284_filter_days_of_week_with_impossible
    e2e::issue_284_no_repeat_large_dur_with_impossible
    e2e::planned_goals_hierarchy
    e2e::show_sleep
    e2e::slot_reduced_1


test result: FAILED. 49 passed; 17 failed; 0 ignored; 0 measured; 0 filtered out; finished in 482.87s

```