### PR TITLE
remove confusing deserialize from output structs

### DIFF
--- a/build_templates/tests_mod.rs
+++ b/build_templates/tests_mod.rs
@@ -27,11 +27,8 @@ mod TEST_MODULE_NAME {
         let actual_output_path = Path::new(&actual_output_path_str[..]);
 
         let input: Input = input_output::get_input_from_json(input_path).unwrap();
-        let desired_output: String =
-            input_output::get_output_string_from_json(output_path).unwrap();
+        let desired_output: String = input_output::get_output_string_from_json(output_path);
 
-        // ONLY do this if expected is malformatted ... check that contents don't change!
-        // input_output::write_to_file(output_path, &desired_output).unwrap();
         let output = scheduler::run_scheduler(input.start_date, input.end_date, &input.goals);
 
         let actual_output = serde_json::to_string_pretty(&output).unwrap();

--- a/src/models/task.rs
+++ b/src/models/task.rs
@@ -1,16 +1,16 @@
 ///Tasks are only used for outputting
 use chrono::{NaiveDate, NaiveDateTime};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use super::calendar::ImpossibleActivity;
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Serialize, Debug)]
 pub struct FinalTasks {
     pub scheduled: Vec<DayTasks>,
     pub impossible: Vec<ImpossibleActivity>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Task {
     pub taskid: usize,
@@ -21,7 +21,7 @@ pub struct Task {
     pub deadline: NaiveDateTime,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone)]
 pub struct DayTasks {
     pub day: NaiveDate,
     pub tasks: Vec<Task>,

--- a/src/technical/input_output.rs
+++ b/src/technical/input_output.rs
@@ -1,8 +1,8 @@
 use crate::models::goal::Goal;
-use crate::models::task::FinalTasks;
 use chrono::NaiveDateTime;
 use serde::Deserialize;
 use std::error::Error;
+use std::fs;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::BufReader;
@@ -23,12 +23,9 @@ pub fn get_input_from_json<P: AsRef<Path>>(path: P) -> Result<Input, Box<dyn Err
     Ok(input)
 }
 
-pub fn get_output_string_from_json<P: AsRef<Path>>(path: P) -> Result<String, serde_json::Error> {
+pub fn get_output_string_from_json<P: AsRef<Path>>(path: P) -> String {
     println!("get_output_string_from_json\n");
-    let file = File::open(path).expect("Error reading file");
-    let reader = BufReader::new(file);
-    let output: FinalTasks = serde_json::from_reader(reader)?;
-    serde_json::to_string_pretty(&output)
+    fs::read_to_string(path).unwrap()
 }
 
 pub fn write_to_file<P: AsRef<Path>>(path: P, output: &str) -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
Resolves #430 (the part where we ask for removing the confusing deserialize from output structs)

If there is any format difference between `observed.json` and `expected.json` please read https://github.com/tijlleenders/ZinZen-scheduler/issues/430#issuecomment-1906862134