### PR TITLE
Tijl/-/adjust-start-before-cal-start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,9 +426,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.88"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -436,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.88"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
@@ -451,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.88"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.88"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -474,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.88"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ chrono = { version = "0.4.31", features = ["wasmbind", "serde"] }
 lazy_static = "1.4.0"
 
 # simple WASM codegen
-wasm-bindgen = { version = "0.2.84" }
+wasm-bindgen = { version = "0.2.92" }
 # instead of wasm-bindgen::serde-serialize feature that may lead to a cyclic package dependency 
 serde-wasm-bindgen = "0.5.0"
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,6 +1,6 @@
 use chrono::NaiveDateTime;
 use serde::Deserialize;
-use serde_json::{self, Value};
+use serde_json::Value;
 use std::{fs, path::Path};
 extern crate scheduler;
 use scheduler::{models::goal::Goal, run_scheduler};

--- a/src/models/calendar.rs
+++ b/src/models/calendar.rs
@@ -169,7 +169,7 @@ impl Calendar {
                         }
                         current_task.duration = 1;
                         current_task.goalid = activity_goalid.clone();
-                        current_task.title = activity_title.clone();
+                        current_task.title.clone_from(activity_title);
                         current_task.start = self
                             .start_date_time
                             .add(Duration::hours(hour_offset as i64 - 24)); // TODO: Fix magic number offset everywhere in code

--- a/src/models/calendar.rs
+++ b/src/models/calendar.rs
@@ -168,7 +168,7 @@ impl Calendar {
                             task_counter += 1;
                         }
                         current_task.duration = 1;
-                        current_task.goalid = activity_goalid.clone();
+                        current_task.goalid.clone_from(activity_goalid);
                         current_task.title.clone_from(activity_title);
                         current_task.start = self
                             .start_date_time

--- a/src/models/goal.rs
+++ b/src/models/goal.rs
@@ -48,7 +48,7 @@ pub struct BudgetConfig {
 impl Goal {
     pub fn get_adj_start_deadline(&self, calendar: &Calendar) -> (NaiveDateTime, NaiveDateTime) {
         let mut adjusted_goal_start = self.start;
-        if self.start.year() == 1970 {
+        if self.start.year() == 1970 || self.start < calendar.start_date_time {
             adjusted_goal_start = calendar.start_date_time;
         }
         let mut adjusted_goal_deadline = self.deadline;

--- a/tests/jsons/stable/start-before-cal-start/expected.json
+++ b/tests/jsons/stable/start-before-cal-start/expected.json
@@ -1,0 +1,26 @@
+{
+  "scheduled": [
+    {
+      "day": "2022-01-01",
+      "tasks": [
+        {
+          "taskid": 0,
+          "goalid": "1",
+          "title": "do something",
+          "duration": 1,
+          "start": "2022-01-01T00:00:00",
+          "deadline": "2022-01-01T01:00:00"
+        },
+        {
+          "taskid": 1,
+          "goalid": "free",
+          "title": "free",
+          "duration": 23,
+          "start": "2022-01-01T01:00:00",
+          "deadline": "2022-01-02T00:00:00"
+        }
+      ]
+    }
+  ],
+  "impossible": []
+}

--- a/tests/jsons/stable/start-before-cal-start/input.json
+++ b/tests/jsons/stable/start-before-cal-start/input.json
@@ -1,0 +1,13 @@
+  {
+    "startDate": "2022-01-01T00:00:00",
+    "endDate": "2022-01-02T00:00:00",
+    "goals": [
+      {
+        "id": "1",
+        "title": "do something",
+        "minDuration": 1,
+        "start": "2000-01-01T00:00:00",
+        "deadline": "2022-01-01T13:00:00"
+      }
+    ]
+  }

--- a/tests/jsons/stable/start-before-cal-start/observed.json
+++ b/tests/jsons/stable/start-before-cal-start/observed.json
@@ -7,7 +7,7 @@
           "taskid": 0,
           "goalid": "1",
           "title": "do something",
-          "duration": 10,
+          "duration": 1,
           "start": "2022-01-01T00:00:00",
           "deadline": "2022-01-01T01:00:00"
         },

--- a/tests/jsons/stable/start-before-cal-start/observed.json
+++ b/tests/jsons/stable/start-before-cal-start/observed.json
@@ -1,0 +1,26 @@
+{
+  "scheduled": [
+    {
+      "day": "2022-01-01",
+      "tasks": [
+        {
+          "taskid": 0,
+          "goalid": "1",
+          "title": "do something",
+          "duration": 10,
+          "start": "2022-01-01T00:00:00",
+          "deadline": "2022-01-01T01:00:00"
+        },
+        {
+          "taskid": 1,
+          "goalid": "free",
+          "title": "free",
+          "duration": 23,
+          "start": "2022-01-01T01:00:00",
+          "deadline": "2022-01-02T00:00:00"
+        }
+      ]
+    }
+  ],
+  "impossible": []
+}


### PR DESCRIPTION
When a goal starts before the calendar start - an error is thrown.  
This is not OK. The `adjusted_start` should be the calendar start datetime.