### PR TITLE
Tijl/-/add-filler-goal2

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,13 +99,22 @@ pub fn run_scheduler(
         activity_generator::generate_simple_goal_activities(&calendar, goals);
     dbg!(&simple_goal_activities);
 
+    let simple_filler_activities =
+        activity_generator::generate_simple_filler_goal_activities(&calendar, goals);
+    dbg!(&simple_filler_activities);
+
     //generate and place budget goal activities
     let budget_goal_activities: Vec<Activity> =
         activity_generator::generate_budget_goal_activities(&calendar, goals);
     dbg!(&budget_goal_activities);
     dbg!(&calendar);
 
-    let activities: Vec<Activity> = [simple_goal_activities, budget_goal_activities].concat();
+    let activities: Vec<Activity> = [
+        simple_goal_activities,
+        simple_filler_activities,
+        budget_goal_activities,
+    ]
+    .concat();
     activity_placer::place(&mut calendar, activities);
 
     calendar.log_impossible_min_day_budgets();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,8 +105,8 @@ pub fn run_scheduler(
     dbg!(&budget_goal_activities);
     dbg!(&calendar);
 
-    activity_placer::place(&mut calendar, simple_goal_activities);
-    activity_placer::place(&mut calendar, budget_goal_activities);
+    let activities: Vec<Activity> = [simple_goal_activities, budget_goal_activities].concat();
+    activity_placer::place(&mut calendar, activities);
 
     calendar.log_impossible_min_day_budgets();
 

--- a/src/models/activity.rs
+++ b/src/models/activity.rs
@@ -181,11 +181,14 @@ impl Activity {
     pub(crate) fn get_activities_from_simple_goal(
         goal: &Goal,
         calendar: &Calendar,
+        parent_goal: Option<Goal>,
     ) -> Vec<Activity> {
         if goal.children.is_some() || goal.filters.as_ref().is_some() {
             return vec![];
         }
-        let (adjusted_goal_start, adjusted_goal_deadline) = goal.get_adj_start_deadline(calendar);
+
+        let (adjusted_goal_start, adjusted_goal_deadline) =
+            goal.get_adj_start_deadline(calendar, parent_goal);
         let mut activities: Vec<Activity> = Vec::with_capacity(1);
 
         if let Some(activity_total_duration) = goal.min_duration {
@@ -237,7 +240,8 @@ impl Activity {
                 return vec![];
             }
         }
-        let (adjusted_goal_start, adjusted_goal_deadline) = goal.get_adj_start_deadline(calendar);
+        let (adjusted_goal_start, adjusted_goal_deadline) =
+            goal.get_adj_start_deadline(calendar, None);
         let mut activities: Vec<Activity> = Vec::with_capacity(1);
 
         for day in 0..(adjusted_goal_deadline - adjusted_goal_start).num_days() as u64 {
@@ -476,11 +480,13 @@ impl Activity {
     pub(crate) fn get_filler_activities_from_simple_goal(
         goal: &Goal,
         calendar: &Calendar,
+        parent_goal: Option<Goal>,
     ) -> Vec<Activity> {
         if goal.children.is_none() || goal.filters.as_ref().is_some() {
             return vec![];
         }
-        let (adjusted_goal_start, adjusted_goal_deadline) = goal.get_adj_start_deadline(calendar);
+        let (adjusted_goal_start, adjusted_goal_deadline) =
+            goal.get_adj_start_deadline(calendar, parent_goal);
         let mut activities: Vec<Activity> = Vec::with_capacity(1);
 
         if let Some(activity_total_duration) = goal.min_duration {

--- a/src/models/goal.rs
+++ b/src/models/goal.rs
@@ -46,15 +46,32 @@ pub struct BudgetConfig {
 }
 
 impl Goal {
-    pub fn get_adj_start_deadline(&self, calendar: &Calendar) -> (NaiveDateTime, NaiveDateTime) {
+    pub fn get_adj_start_deadline(
+        &self,
+        calendar: &Calendar,
+        parent_goal: Option<Goal>,
+    ) -> (NaiveDateTime, NaiveDateTime) {
         let mut adjusted_goal_start = self.start;
-        if self.start.year() == 1970 || self.start < calendar.start_date_time {
+        if self.start.year() == 1970 {
             adjusted_goal_start = calendar.start_date_time;
         }
         let mut adjusted_goal_deadline = self.deadline;
         if self.deadline.year() == 1970 {
             adjusted_goal_deadline = calendar.end_date_time;
         }
+
+        // Make sure child goal not fall outside of parent goal start and deadline
+        if let Some(parent_goal) = parent_goal {
+            // means this is a child goal
+            if adjusted_goal_start < parent_goal.start {
+                adjusted_goal_start = parent_goal.start;
+            }
+            if adjusted_goal_deadline > parent_goal.deadline && parent_goal.deadline.year() != 1970
+            {
+                adjusted_goal_deadline = parent_goal.deadline;
+            }
+        }
+
         if self.filters.is_none() {
             return (adjusted_goal_start, adjusted_goal_deadline);
         }
@@ -77,5 +94,18 @@ impl Goal {
             ));
         }
         (adjusted_goal_start, adjusted_goal_deadline)
+    }
+
+    /// Get parent goal of this goal based in provided list of goals
+    pub fn get_parent_goal(&self, goals: &[Goal]) -> Option<Goal> {
+        let parent_goal = goals.iter().find(|goal| {
+            if let Some(childs) = &goal.children {
+                childs.contains(&self.id)
+            } else {
+                false
+            }
+        });
+
+        parent_goal.cloned()
     }
 }

--- a/src/models/goal.rs
+++ b/src/models/goal.rs
@@ -52,7 +52,7 @@ impl Goal {
         parent_goal: Option<Goal>,
     ) -> (NaiveDateTime, NaiveDateTime) {
         let mut adjusted_goal_start = self.start;
-        if self.start.year() == 1970 {
+        if self.start.year() == 1970 || self.start < calendar.start_date_time {
             adjusted_goal_start = calendar.start_date_time;
         }
         let mut adjusted_goal_deadline = self.deadline;

--- a/src/services/activity_generator.rs
+++ b/src/services/activity_generator.rs
@@ -3,7 +3,9 @@ use crate::models::{activity::Activity, budget::TimeBudgetType, calendar::Calend
 pub fn generate_simple_goal_activities(calendar: &Calendar, goals: &[Goal]) -> Vec<Activity> {
     goals
         .iter()
-        .flat_map(|goal| Activity::get_activities_from_simple_goal(goal, calendar))
+        .flat_map(|goal| {
+            Activity::get_activities_from_simple_goal(goal, calendar, goal.get_parent_goal(goals))
+        })
         .collect::<Vec<_>>()
 }
 
@@ -13,7 +15,13 @@ pub fn generate_simple_filler_goal_activities(
 ) -> Vec<Activity> {
     let mut activities = goals
         .iter()
-        .flat_map(|goal| Activity::get_filler_activities_from_simple_goal(goal, calendar))
+        .flat_map(|goal| {
+            Activity::get_filler_activities_from_simple_goal(
+                goal,
+                calendar,
+                goal.get_parent_goal(goals),
+            )
+        })
         .collect::<Vec<_>>();
     for activity in &mut activities {
         if let Some(goal) = goals.iter().find(|g| g.id == activity.goal_id) {

--- a/src/services/activity_generator.rs
+++ b/src/services/activity_generator.rs
@@ -7,6 +7,31 @@ pub fn generate_simple_goal_activities(calendar: &Calendar, goals: &[Goal]) -> V
         .collect::<Vec<_>>()
 }
 
+pub fn generate_simple_filler_goal_activities(
+    calendar: &Calendar,
+    goals: &[Goal],
+) -> Vec<Activity> {
+    let mut activities = goals
+        .iter()
+        .flat_map(|goal| Activity::get_filler_activities_from_simple_goal(goal, calendar))
+        .collect::<Vec<_>>();
+    for activity in &mut activities {
+        if let Some(goal) = goals.iter().find(|g| g.id == activity.goal_id) {
+            let children: Vec<&Goal> = goals
+                .iter()
+                .filter(|child| goal.children.clone().unwrap().contains(&child.id))
+                .collect();
+            for c in children {
+                activity.min_block_size -= c.min_duration.unwrap();
+                activity.max_block_size -= c.min_duration.unwrap();
+                activity.total_duration -= c.min_duration.unwrap();
+                activity.duration_left -= c.min_duration.unwrap();
+            }
+        }
+    }
+    activities
+}
+
 pub fn generate_budget_goal_activities(calendar: &Calendar, goals: &[Goal]) -> Vec<Activity> {
     goals
         .iter()

--- a/tests/jsons/stable/budget-and-goal-one-day/expected.json
+++ b/tests/jsons/stable/budget-and-goal-one-day/expected.json
@@ -29,18 +29,26 @@
         },
         {
           "taskid": 3,
-          "goalid": "2",
-          "title": "work",
-          "duration": 4,
+          "goalid": "free",
+          "title": "free",
+          "duration": 2,
           "start": "2022-09-01T13:00:00",
-          "deadline": "2022-09-01T17:00:00"
+          "deadline": "2022-09-01T15:00:00"
         },
         {
           "taskid": 4,
+          "goalid": "2",
+          "title": "work",
+          "duration": 4,
+          "start": "2022-09-01T15:00:00",
+          "deadline": "2022-09-01T19:00:00"
+        },
+        {
+          "taskid": 5,
           "goalid": "free",
           "title": "free",
-          "duration": 7,
-          "start": "2022-09-01T17:00:00",
+          "duration": 5,
+          "start": "2022-09-01T19:00:00",
           "deadline": "2022-09-02T00:00:00"
         }
       ]

--- a/tests/jsons/stable/budget-and-goal-one-day/observed.json
+++ b/tests/jsons/stable/budget-and-goal-one-day/observed.json
@@ -29,18 +29,26 @@
         },
         {
           "taskid": 3,
-          "goalid": "2",
-          "title": "work",
-          "duration": 4,
+          "goalid": "free",
+          "title": "free",
+          "duration": 2,
           "start": "2022-09-01T13:00:00",
-          "deadline": "2022-09-01T17:00:00"
+          "deadline": "2022-09-01T15:00:00"
         },
         {
           "taskid": 4,
+          "goalid": "2",
+          "title": "work",
+          "duration": 4,
+          "start": "2022-09-01T15:00:00",
+          "deadline": "2022-09-01T19:00:00"
+        },
+        {
+          "taskid": 5,
           "goalid": "free",
           "title": "free",
-          "duration": 7,
-          "start": "2022-09-01T17:00:00",
+          "duration": 5,
+          "start": "2022-09-01T19:00:00",
           "deadline": "2022-09-02T00:00:00"
         }
       ]

--- a/tests/jsons/stable/default-budgets/input.json
+++ b/tests/jsons/stable/default-budgets/input.json
@@ -7,11 +7,12 @@
       "title": "Daily habits 🔁",
       "createdAt": "2024-01-08T10:59:47.134Z",
       "children": [
-        "breakfast",
-        "lunch",
-        "dinner",
-        "meTime",
-        "walk"
+        "40842a7d-c282-406f-9cdf-3d1fbd8e4f61",
+        "18be6978-ffac-46db-8b70-d321c311428a",
+        "103b2eff-6ba5-47b5-ad4f-81d8e8ef5998",
+        "445f787b-d742-4441-9744-e81c286aa3c8",
+        "77e1f762-3a4f-44a3-8f24-1560641a3548",
+        "49b05463-56a0-4af5-9034-83822abf24f6"
       ]
     },
     {

--- a/tests/jsons/stable/filler-goal/expected.json
+++ b/tests/jsons/stable/filler-goal/expected.json
@@ -1,0 +1,50 @@
+{
+  "scheduled": [
+    {
+      "day": "2022-01-01",
+      "tasks": [
+        {
+          "taskid": 0,
+          "goalid": "free",
+          "title": "free",
+          "duration": 10,
+          "start": "2022-01-01T00:00:00",
+          "deadline": "2022-01-01T10:00:00"
+        },
+        {
+          "taskid": 1,
+          "goalid": "2",
+          "title": "Buy stuff",
+          "duration": 1,
+          "start": "2022-01-01T10:00:00",
+          "deadline": "2022-01-01T11:00:00"
+        },
+        {
+          "taskid": 2,
+          "goalid": "3",
+          "title": "Invite friends",
+          "duration": 1,
+          "start": "2022-01-01T11:00:00",
+          "deadline": "2022-01-01T12:00:00"
+        },
+        {
+          "taskid": 3,
+          "goalid": "1",
+          "title": "Plan a party",
+          "duration": 2,
+          "start": "2022-01-01T12:00:00",
+          "deadline": "2022-01-01T14:00:00"
+        },
+        {
+          "taskid": 4,
+          "goalid": "free",
+          "title": "free",
+          "duration": 10,
+          "start": "2022-01-01T14:00:00",
+          "deadline": "2022-01-02T00:00:00"
+        }
+      ]
+    }
+  ],
+  "impossible": []
+}

--- a/tests/jsons/stable/filler-goal/input.json
+++ b/tests/jsons/stable/filler-goal/input.json
@@ -1,0 +1,27 @@
+  {
+    "startDate": "2022-01-01T00:00:00",
+    "endDate": "2022-01-02T00:00:00",
+    "goals": [
+      {
+        "id": "1",
+        "title": "Plan a party",
+        "minDuration": 4,
+        "start": "2022-01-01T10:00:00",
+        "deadline": "2022-01-01T18:00:00",
+        "children": [
+          "2",
+          "3"
+        ]
+      },
+      {
+        "id": "2",
+        "title": "Buy stuff",
+        "minDuration": 1
+      },
+      {
+        "id": "3",
+        "title": "Invite friends",
+        "minDuration": 1
+      }
+    ]
+  }

--- a/tests/jsons/stable/filler-goal/observed.json
+++ b/tests/jsons/stable/filler-goal/observed.json
@@ -5,42 +5,42 @@
       "tasks": [
         {
           "taskid": 0,
-          "goalid": "2",
-          "title": "Buy stuff",
-          "duration": 1,
+          "goalid": "free",
+          "title": "free",
+          "duration": 10,
           "start": "2022-01-01T00:00:00",
-          "deadline": "2022-01-01T01:00:00"
+          "deadline": "2022-01-01T10:00:00"
         },
         {
           "taskid": 1,
-          "goalid": "3",
-          "title": "Invite friends",
+          "goalid": "2",
+          "title": "Buy stuff",
           "duration": 1,
-          "start": "2022-01-01T01:00:00",
-          "deadline": "2022-01-01T02:00:00"
+          "start": "2022-01-01T10:00:00",
+          "deadline": "2022-01-01T11:00:00"
         },
         {
           "taskid": 2,
-          "goalid": "free",
-          "title": "free",
-          "duration": 8,
-          "start": "2022-01-01T02:00:00",
-          "deadline": "2022-01-01T10:00:00"
+          "goalid": "3",
+          "title": "Invite friends",
+          "duration": 1,
+          "start": "2022-01-01T11:00:00",
+          "deadline": "2022-01-01T12:00:00"
         },
         {
           "taskid": 3,
           "goalid": "1",
           "title": "Plan a party",
           "duration": 2,
-          "start": "2022-01-01T10:00:00",
-          "deadline": "2022-01-01T12:00:00"
+          "start": "2022-01-01T12:00:00",
+          "deadline": "2022-01-01T14:00:00"
         },
         {
           "taskid": 4,
           "goalid": "free",
           "title": "free",
-          "duration": 12,
-          "start": "2022-01-01T12:00:00",
+          "duration": 10,
+          "start": "2022-01-01T14:00:00",
           "deadline": "2022-01-02T00:00:00"
         }
       ]

--- a/tests/jsons/stable/filler-goal/observed.json
+++ b/tests/jsons/stable/filler-goal/observed.json
@@ -1,0 +1,50 @@
+{
+  "scheduled": [
+    {
+      "day": "2022-01-01",
+      "tasks": [
+        {
+          "taskid": 0,
+          "goalid": "free",
+          "title": "free",
+          "duration": 10,
+          "start": "2022-01-01T00:00:00",
+          "deadline": "2022-01-01T10:00:00"
+        },
+        {
+          "taskid": 1,
+          "goalid": "2",
+          "title": "Buy stuff",
+          "duration": 1,
+          "start": "2022-01-01T10:00:00",
+          "deadline": "2022-01-01T11:00:00"
+        },
+        {
+          "taskid": 2,
+          "goalid": "3",
+          "title": "Invite friends",
+          "duration": 1,
+          "start": "2022-01-01T11:00:00",
+          "deadline": "2022-01-01T12:00:00"
+        },
+        {
+          "taskid": 3,
+          "goalid": "1",
+          "title": "Plan a party",
+          "duration": 2,
+          "start": "2022-01-01T12:00:00",
+          "deadline": "2022-01-01T14:00:00"
+        },
+        {
+          "taskid": 4,
+          "goalid": "free",
+          "title": "free",
+          "duration": 10,
+          "start": "2022-01-01T14:00:00",
+          "deadline": "2022-01-02T00:00:00"
+        }
+      ]
+    }
+  ],
+  "impossible": []
+}

--- a/tests/jsons/stable/filler-goal/observed.json
+++ b/tests/jsons/stable/filler-goal/observed.json
@@ -5,42 +5,42 @@
       "tasks": [
         {
           "taskid": 0,
-          "goalid": "free",
-          "title": "free",
-          "duration": 10,
-          "start": "2022-01-01T00:00:00",
-          "deadline": "2022-01-01T10:00:00"
-        },
-        {
-          "taskid": 1,
           "goalid": "2",
           "title": "Buy stuff",
           "duration": 1,
-          "start": "2022-01-01T10:00:00",
-          "deadline": "2022-01-01T11:00:00"
+          "start": "2022-01-01T00:00:00",
+          "deadline": "2022-01-01T01:00:00"
         },
         {
-          "taskid": 2,
+          "taskid": 1,
           "goalid": "3",
           "title": "Invite friends",
           "duration": 1,
-          "start": "2022-01-01T11:00:00",
-          "deadline": "2022-01-01T12:00:00"
+          "start": "2022-01-01T01:00:00",
+          "deadline": "2022-01-01T02:00:00"
+        },
+        {
+          "taskid": 2,
+          "goalid": "free",
+          "title": "free",
+          "duration": 8,
+          "start": "2022-01-01T02:00:00",
+          "deadline": "2022-01-01T10:00:00"
         },
         {
           "taskid": 3,
           "goalid": "1",
           "title": "Plan a party",
           "duration": 2,
-          "start": "2022-01-01T12:00:00",
-          "deadline": "2022-01-01T14:00:00"
+          "start": "2022-01-01T10:00:00",
+          "deadline": "2022-01-01T12:00:00"
         },
         {
           "taskid": 4,
           "goalid": "free",
           "title": "free",
-          "duration": 10,
-          "start": "2022-01-01T14:00:00",
+          "duration": 12,
+          "start": "2022-01-01T12:00:00",
           "deadline": "2022-01-02T00:00:00"
         }
       ]


### PR DESCRIPTION
Resolves the add-filler test case in a better way than previous PR #434

All Activities are now place at the same time - so they can 'see' each other. Also, simple filler Activities get their own generate method - which makes it a lot easier to reason about than when 'mixing it in' with regular simple Activity generation and then adjusting it afterwards.

I did use a few code snippets from that PR for adjusting the start/finish to conform to the parent goal.