### PR TITLE
Tijl/-/refactor-2024-03-25

### DIFF
--- a/src/models/activity.rs
+++ b/src/models/activity.rs
@@ -145,6 +145,9 @@ impl Activity {
                     ActivityType::SimpleFiller => self.total_duration,
                 };
                 for offset in 0..offset_size {
+                    if hour_index + offset == self.calendar_overlay.len() {
+                        break;
+                    }
                     match &self.calendar_overlay[hour_index + offset] {
                         None => {
                             // panic!("Does this ever happen?");

--- a/src/services/activity_placer.rs
+++ b/src/services/activity_placer.rs
@@ -27,12 +27,14 @@ pub fn place(calendar: &mut Calendar, mut activities: Vec<Activity>) -> Vec<Acti
                     && activities[act_index_to_schedule].deadline.is_none()
                     && !calendar.is_budget(activities[act_index_to_schedule].goal_id.clone())
                     && activities[act_index_to_schedule].status != Status::BestEffort
+                // Place function should try to place BestEffort Activities
                 {
                     println!(
                         "Postponing placement of {:?} - since no deadline and conflicts > 0...\n",
                         activities[act_index_to_schedule].title
                     );
                     activities[act_index_to_schedule].status = Status::Postponed;
+                    // Don't release the claims of postponed Activities so other tasks try to stay away from their claims.
                     continue;
                 }
                 println!("reserving {:?} hours...", best_size);
@@ -62,15 +64,15 @@ pub fn place(calendar: &mut Calendar, mut activities: Vec<Activity>) -> Vec<Acti
                     continue;
                 } else {
                     activities[act_index_to_schedule].status = Status::Impossible;
+                    let impossible_activity = ImpossibleActivity {
+                        id: activities[act_index_to_schedule].goal_id.clone(),
+                        hours_missing: activities[act_index_to_schedule].duration_left,
+                        period_start_date_time: activities[act_index_to_schedule].start,
+                        period_end_date_time: activities[act_index_to_schedule].deadline,
+                    };
+                    calendar.impossible_activities.push(impossible_activity);
+                    continue;
                 }
-                let impossible_activity = ImpossibleActivity {
-                    id: activities[act_index_to_schedule].goal_id.clone(),
-                    hours_missing: activities[act_index_to_schedule].duration_left,
-                    period_start_date_time: activities[act_index_to_schedule].start,
-                    period_end_date_time: activities[act_index_to_schedule].deadline,
-                };
-                calendar.impossible_activities.push(impossible_activity);
-                continue;
             }
         } else {
             println!("Tried to schedule activity index None");


### PR DESCRIPTION
Resolves passing index bounds in search for an hour without conflicts in `get_best_scheduling_index_length_conflicts` for Activities that have many/only conflicts.