### PR TITLE
test should panic! on illegal `not_on` datetime bounds

### DIFF
--- a/tests/jsons/stable/not-on-panic/expected.json
+++ b/tests/jsons/stable/not-on-panic/expected.json
@@ -1,0 +1,34 @@
+{
+  "scheduled": [
+    {
+      "day": "2022-01-01",
+      "tasks": [
+        {
+          "taskid": 0,
+          "goalid": "free",
+          "title": "free",
+          "duration": 11,
+          "start": "2022-01-01T00:00:00",
+          "deadline": "2022-01-01T11:00:00"
+        },
+        {
+          "taskid": 1,
+          "goalid": "1",
+          "title": "shopping",
+          "duration": 1,
+          "start": "2022-01-01T11:00:00",
+          "deadline": "2022-01-01T12:00:00"
+        },
+        {
+          "taskid": 2,
+          "goalid": "free",
+          "title": "free",
+          "duration": 12,
+          "start": "2022-01-01T12:00:00",
+          "deadline": "2022-01-02T00:00:00"
+        }
+      ]
+    }
+  ],
+  "impossible": []
+}

--- a/tests/jsons/stable/not-on-panic/input.json
+++ b/tests/jsons/stable/not-on-panic/input.json
@@ -1,0 +1,23 @@
+{
+  "startDate": "2024-07-20T00:00:00",
+  "endDate": "2024-07-27T00:00:00",
+  "goals": [
+    {
+      "id": "da66aeab-4d6d-46d7-8117-4240895e7044",
+      "title": "A Goal for which Tasks were postponed",
+      "createdAt": 1711689651172,
+      "minDuration": 1,
+      "notOn": [
+        {
+          "start": "2024-05-28T09:00:00",
+          "end": "2024-05-29T09:00:00"
+        },
+        {
+          "start": "2024-05-29T09:00:00",
+          "end": "2024-05-30T09:00:00"
+        }
+      ]
+    }
+  ],
+  "tasksCompletedToday": []
+}

--- a/tests/jsons/stable/not-on-panic/observed.json
+++ b/tests/jsons/stable/not-on-panic/observed.json
@@ -1,0 +1,34 @@
+{
+  "scheduled": [
+    {
+      "day": "2022-01-01",
+      "tasks": [
+        {
+          "taskid": 0,
+          "goalid": "free",
+          "title": "free",
+          "duration": 11,
+          "start": "2022-01-01T00:00:00",
+          "deadline": "2022-01-01T11:00:00"
+        },
+        {
+          "taskid": 1,
+          "goalid": "1",
+          "title": "shopping",
+          "duration": 1,
+          "start": "2022-01-01T11:00:00",
+          "deadline": "2022-01-01T12:00:00"
+        },
+        {
+          "taskid": 2,
+          "goalid": "free",
+          "title": "free",
+          "duration": 12,
+          "start": "2022-01-01T12:00:00",
+          "deadline": "2022-01-02T00:00:00"
+        }
+      ]
+    }
+  ],
+  "impossible": []
+}


### PR DESCRIPTION
The frontend shouldn't send any not_on block that starts (and possibly ends) before the starting date of the requested Calendar, as noted in https://github.com/tijlleenders/ZinZen/issues/1959  

When this specific case is detected, as specified in the `input.json` we should expect the Scheduler to panic with a helpful message 'not_on block is out of Calendar bounds', ideally with the offending Goal id, title and the not_on dates, as well as the Calendar dates.

This PR is to implement and test just that - to that we get a good error message when the front-end fails to send the required input. This is not for the scheduler to fix - as we want to avoid irrelevant not_on info piling up in the storage frontend.

The `expected.json` and `observed.json` can be removed - they are not relevant to this test case, but we might need a different structure for tests that pass when a panic is generated...